### PR TITLE
Add GPU info to engine stats and test Polychora initialization

### DIFF
--- a/tests/polychora-initialization.test.js
+++ b/tests/polychora-initialization.test.js
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('Polychora system initializes with 4D canvas setup', async ({ page }) => {
+  await page.goto('/index-fixed.html');
+
+  const result = await page.evaluate(async () => {
+    const module = await import('/systems/polychora/PolychoraSystem.js');
+    const system = new module.PolychoraSystem();
+    const initSuccess = await system.initialize();
+    const info = system.getInfo();
+    return { initSuccess, info };
+  });
+
+  expect(result.initSuccess).toBe(true);
+  expect(result.info.isInitialized).toBe(true);
+  expect(result.info.fourDimensional).toBe(true);
+  expect(result.info.polytopes).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- report GPU vendor, renderer, and memory details in unified engine performance stats
- add Playwright test validating Polychora system initialization with 4D canvases

## Testing
- `npx playwright test tests/polychora-initialization.test.js --project=chromium` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b601f8c74c8329855b89ae82cf9825