### PR TITLE
Add Lattice Pulse WebGL rhythm game PWA

### DIFF
--- a/assets/icons/lattice-pulse-icon.svg
+++ b/assets/icons/lattice-pulse-icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4e2cff" />
+      <stop offset="100%" stop-color="#0cf2ff" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="#050018" />
+  <g stroke="url(#grad)" stroke-width="18" fill="none" stroke-linecap="round">
+    <path d="M128 256c48-96 208-96 256 0" />
+    <path d="M96 320c64-144 256-144 320 0" opacity="0.55" />
+    <path d="M160 192c32-48 160-48 192 0" opacity="0.75" />
+    <circle cx="256" cy="256" r="46" fill="url(#grad)" />
+    <circle cx="256" cy="256" r="110" opacity="0.6" />
+  </g>
+</svg>

--- a/js/lattice-pulse.js
+++ b/js/lattice-pulse.js
@@ -1,0 +1,55 @@
+import { LatticePulseGame } from '../src/game/LatticePulseGame.js';
+
+const registerServiceWorker = () => {
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+            navigator.serviceWorker.register('./sw-lattice-pulse.js').catch(err => {
+                console.warn('Service worker registration failed', err);
+            });
+        });
+    }
+};
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('visualizer');
+    const hudElement = document.getElementById('hud');
+    if (!container || !hudElement) {
+        throw new Error('Missing required DOM nodes for Lattice Pulse');
+    }
+
+    const game = new LatticePulseGame({ container, hudElement });
+    window.latticePulseGame = game;
+    await game.start();
+
+    const modeBtn = document.getElementById('modeButton');
+    const geometryBtn = document.getElementById('geometryButton');
+    const levelBtn = document.getElementById('nextLevelButton');
+
+    modeBtn?.addEventListener('click', () => {
+        game.modeController.cycleMode();
+        const mode = game.modeController.activeMode;
+        game.hud.setMode(mode);
+        game.hud.showToast(`${mode.toUpperCase()} MODE`);
+    });
+
+    geometryBtn?.addEventListener('click', () => {
+        const nextIndex = game.geometryController.cycleGeometry();
+        game.modeController.setGeometry(nextIndex);
+        const name = game.geometryController.getGeometryName(nextIndex);
+        game.hud.setGeometry(name);
+        game.hud.showToast(name);
+    });
+
+    levelBtn?.addEventListener('click', () => {
+        game.nextLevel();
+        game.hud.showToast('Level Advance');
+    });
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            game.audioService?.pause?.();
+        }
+    });
+
+    registerServiceWorker();
+});

--- a/lattice-pulse.html
+++ b/lattice-pulse.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Lattice Pulse · VIB34D</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
+  <meta name="theme-color" content="#050018" />
+  <meta name="description" content="Lattice Pulse turns the VIB34D visualizer into a beat-matched mobile web game." />
+  <link rel="manifest" href="./lattice-pulse.webmanifest" />
+  <link rel="stylesheet" href="./styles/lattice-pulse.css" />
+  <link rel="apple-touch-icon" href="./assets/icons/lattice-pulse-icon.svg" />
+</head>
+<body>
+  <div id="app">
+    <div id="visualizer" class="visualizer" aria-hidden="true"></div>
+    <div id="hud" class="hud" aria-live="polite">
+      <div class="hud-row">
+        <div class="hud-card">
+          <div class="hud-label">Score</div>
+          <div class="hud-value" data-hud="score">0</div>
+        </div>
+        <div class="hud-card">
+          <div class="hud-label">Combo</div>
+          <div class="hud-value" data-hud="combo">—</div>
+          <div class="hud-meter" data-hud="pulse"></div>
+        </div>
+        <div class="hud-card">
+          <div class="hud-label">Mode</div>
+          <div class="hud-value hud-small" data-hud="mode">FACETED</div>
+          <div class="hud-label">Geometry</div>
+          <div class="hud-value hud-small" data-hud="geometry">TORUS</div>
+        </div>
+        <div class="hud-card">
+          <div class="hud-label">Level</div>
+          <div class="hud-value hud-small" data-hud="level">—</div>
+          <div class="hud-label">Tempo</div>
+          <div class="hud-value hud-small" data-hud="bpm">120 BPM</div>
+        </div>
+        <div class="hud-card">
+          <div class="hud-label">Performance</div>
+          <div class="hud-value hud-small" data-hud="fps">60 FPS</div>
+          <div class="hud-meter" data-hud="shield"></div>
+        </div>
+      </div>
+    </div>
+    <div class="toast" data-hud="toast">Ready</div>
+    <div class="controls" aria-label="Game controls">
+      <button id="modeButton" class="control-button">Switch Mode</button>
+      <button id="geometryButton" class="control-button">Shift Geometry</button>
+      <button id="nextLevelButton" class="control-button">Next Level</button>
+    </div>
+  </div>
+  <script type="module" src="./js/lattice-pulse.js"></script>
+</body>
+</html>

--- a/lattice-pulse.webmanifest
+++ b/lattice-pulse.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Lattice Pulse",
+  "short_name": "Pulse",
+  "start_url": "./lattice-pulse.html",
+  "display": "standalone",
+  "background_color": "#050018",
+  "theme_color": "#050018",
+  "description": "Beat-driven lattice runner built on the VIB34D visualizer stack.",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "./assets/icons/lattice-pulse-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/game/GameLoop.js
+++ b/src/game/GameLoop.js
@@ -1,0 +1,49 @@
+const STEP = 1 / 60;
+
+export class GameLoop {
+    constructor({ update, render, fixedStep = STEP }) {
+        this.update = update;
+        this.render = render;
+        this.fixedStep = fixedStep;
+        this.accumulator = 0;
+        this.lastTime = 0;
+        this.running = false;
+        this.rafId = null;
+        this.frame = this.frame.bind(this);
+    }
+
+    start() {
+        if (this.running) return;
+        this.running = true;
+        this.accumulator = 0;
+        this.lastTime = performance.now();
+        this.rafId = requestAnimationFrame(this.frame);
+    }
+
+    stop() {
+        this.running = false;
+        if (this.rafId) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+        }
+    }
+
+    frame(now) {
+        if (!this.running) return;
+
+        const delta = (now - this.lastTime) / 1000;
+        this.lastTime = now;
+        this.accumulator += delta;
+
+        while (this.accumulator >= this.fixedStep) {
+            this.update(this.fixedStep);
+            this.accumulator -= this.fixedStep;
+        }
+
+        if (this.render) {
+            this.render();
+        }
+
+        this.rafId = requestAnimationFrame(this.frame);
+    }
+}

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -1,0 +1,201 @@
+import { GameLoop } from './GameLoop.js';
+import { AudioService } from './audio/AudioService.js';
+import { ModeController } from './modes/ModeController.js';
+import { GeometryController } from './geometry/GeometryController.js';
+import { SpawnSystem } from './spawn/SpawnSystem.js';
+import { CollisionSystem } from './collision/CollisionSystem.js';
+import { InputMapping } from './input/InputMapping.js';
+import { EffectsManager } from './effects/EffectsManager.js';
+import { PerformanceController } from './performance/PerformanceController.js';
+import { LevelManager } from './state/LevelManager.js';
+import { DEFAULT_LEVELS } from './state/defaultLevels.js';
+import { HudController } from './ui/HudController.js';
+
+export class LatticePulseGame {
+    constructor({ container, hudElement }) {
+        this.container = container;
+        this.hud = new HudController(hudElement);
+        this.audioService = new AudioService();
+        this.geometryController = new GeometryController();
+        this.modeController = new ModeController({ container, geometryController: this.geometryController });
+        this.spawnSystem = new SpawnSystem({ geometryController: this.geometryController, audioService: this.audioService });
+        this.collisionSystem = new CollisionSystem({ gridResolution: 48 });
+        this.effectsManager = new EffectsManager({ modeController: this.modeController });
+        this.performanceController = new PerformanceController({ modeController: this.modeController });
+        this.levelManager = new LevelManager();
+        this.levelManager.setLevels(DEFAULT_LEVELS);
+        this.score = 0;
+        this.combo = 0;
+        this.health = 1.0;
+        this.slowMoTimer = 0;
+        this.timeScale = 1.0;
+        this.currentLevel = null;
+        this.lastPulseCaptureIds = new Set();
+        this.inputMapping = new InputMapping({
+            element: container,
+            onParameterDelta: deltas => this.modeController.applyParameterDelta(deltas),
+            onPulse: pulse => this.handlePulse(pulse),
+            onLongPress: () => this.handleLongPress()
+        });
+        this.gameLoop = new GameLoop({
+            update: dt => this.update(dt),
+            render: () => this.render()
+        });
+        this.setupSpawnEvents();
+        window.audioEnabled = true;
+        window.interactivityEnabled = true;
+        window.audioReactive = { bass: 0, mid: 0, high: 0, energy: 0 };
+    }
+
+    async start() {
+        this.modeController.initialize();
+        await this.audioService.init();
+        this.spawnSystem.initialize();
+        this.currentLevel = this.levelManager.getCurrentLevel();
+        this.applyLevel(this.currentLevel);
+        this.hud.setLevel(this.currentLevel?.name || '');
+        this.hud.setMode(this.currentLevel?.system || 'faceted');
+        this.hud.setGeometry(this.geometryController.getGeometryName());
+        this.gameLoop.start();
+    }
+
+    nextLevel() {
+        if (this.currentLevel) {
+            this.levelManager.recordScore(this.currentLevel.id, this.score);
+        }
+        this.currentLevel = this.levelManager.advanceLevel();
+        this.applyLevel(this.currentLevel);
+        this.hud.setLevel(this.currentLevel?.name || '');
+        this.hud.setMode(this.currentLevel?.system || 'faceted');
+        this.hud.setGeometry(this.geometryController.getGeometryName());
+    }
+
+    applyLevel(level) {
+        if (!level) return;
+        this.geometryController.setSeed(level.seed || 1);
+        this.spawnSystem.configure({ difficulty: level.difficulty?.speed || 1, spawn: level.spawn });
+        this.levelManager.applyLevelSettings(level, {
+            modeController: this.modeController,
+            geometryController: this.geometryController,
+            audioService: this.audioService
+        });
+        this.hud.setBpm(level.bpm || 120);
+        this.hud.setMode(level.system || 'faceted');
+        this.hud.setGeometry(this.geometryController.getGeometryName());
+        this.hud.setLevel(level.name || '');
+        this.resetRun();
+    }
+
+    setupSpawnEvents() {
+        this.spawnSystem.on('resolve', target => {
+            const gain = 120 + Math.round(target.age * 40);
+            this.combo = Math.min(this.combo + 1, 99);
+            const multiplier = 1 + this.combo * 0.1;
+            const delta = Math.round(gain * multiplier);
+            this.score += delta;
+            this.effectsManager.trigger(this.combo > 5 ? 'combo' : 'pulse');
+            if (target.type === 'orb') {
+                this.effectsManager.trigger('perfect');
+            }
+            this.hud.setScore(this.score);
+            this.hud.setCombo(this.combo);
+        });
+
+        this.spawnSystem.on('miss', () => {
+            this.combo = 0;
+            this.health = Math.max(0, this.health - 0.1);
+            this.effectsManager.trigger('miss');
+            this.hud.setCombo(this.combo);
+            this.hud.setShieldMeter(this.health);
+            if (this.health <= 0) {
+                if (this.currentLevel) {
+                    this.levelManager.recordScore(this.currentLevel.id, this.score);
+                }
+                this.hud.showToast('Grid Collapsed — Retry!');
+                this.resetRun();
+            }
+        });
+    }
+
+    resetRun() {
+        this.score = 0;
+        this.combo = 0;
+        this.health = 1.0;
+        this.spawnSystem.activeTargets = [];
+        this.lastPulseCaptureIds.clear();
+        this.hud.setScore(this.score);
+        this.hud.setCombo(this.combo);
+        this.hud.setShieldMeter(this.health);
+    }
+
+    handlePulse(pulse) {
+        this.lastPulseCaptureIds.clear();
+        this.effectsManager.trigger('pulse');
+        this.hud.setPulseMeter(1);
+    }
+
+    handleLongPress() {
+        this.slowMoTimer = 1.5;
+        this.timeScale = 0.75;
+        this.hud.showToast('Phase Drift');
+    }
+
+    update(dt) {
+        const scaledDt = dt * this.timeScale;
+        this.audioService.update(scaledDt);
+        const bands = this.audioService.getBandLevels();
+        window.audioReactive = {
+            bass: bands.bass,
+            mid: bands.mid,
+            high: bands.high,
+            energy: bands.energy
+        };
+
+        this.spawnSystem.update(scaledDt);
+        const targets = this.spawnSystem.getTargets();
+        this.collisionSystem.rebuild(targets);
+        this.resolveCollisions();
+
+        this.effectsManager.update(scaledDt);
+        this.inputMapping.update(scaledDt);
+        this.performanceController.update();
+
+        if (this.slowMoTimer > 0) {
+            this.slowMoTimer -= dt;
+            if (this.slowMoTimer <= 0) {
+                this.timeScale = 1.0;
+            }
+        }
+
+        const pulseState = this.inputMapping.getPulseState();
+        if (pulseState.active) {
+            this.hud.setPulseMeter(pulseState.radius);
+        } else {
+            this.hud.setPulseMeter(0);
+        }
+
+        this.hud.setFps(this.performanceController.getAverageFps());
+    }
+
+    resolveCollisions() {
+        const pulseState = this.inputMapping.getPulseState();
+        if (!pulseState.active) return;
+        const hits = this.collisionSystem.queryCircle({
+            x: pulseState.x,
+            y: pulseState.y,
+            radius: pulseState.radius
+        });
+        hits.forEach(target => {
+            if (this.lastPulseCaptureIds.has(target.id)) return;
+            const resolved = this.spawnSystem.resolveTarget(target.id);
+            if (resolved) {
+                this.lastPulseCaptureIds.add(target.id);
+            }
+        });
+    }
+
+    render() {
+        this.modeController.render(this.inputMapping.getInteraction());
+        this.performanceController.recordFrame();
+    }
+}

--- a/src/game/audio/AudioService.js
+++ b/src/game/audio/AudioService.js
@@ -1,0 +1,218 @@
+const DEFAULT_BPM = 120;
+
+export class AudioService {
+    constructor() {
+        this.context = null;
+        this.analyser = null;
+        this.source = null;
+        this.trackBuffer = null;
+        this.isPlaying = false;
+        this.startTime = 0;
+        this.pauseTime = 0;
+        this.fftSize = 2048;
+        this.frequencyData = null;
+        this.timeDomainData = null;
+        this.listeners = { beat: new Set(), analyser: new Set() };
+        this.lastBeatTime = 0;
+        this.bpm = DEFAULT_BPM;
+        this.metronomePhase = 0;
+        this.beatThreshold = 1.4;
+        this.energyHistory = [];
+        this.historySize = 43; // ~0.7 seconds at 60fps
+        this.metronomeEnabled = true;
+    }
+
+    async init() {
+        if (this.context) return;
+        this.context = new (window.AudioContext || window.webkitAudioContext)();
+        this.analyser = this.context.createAnalyser();
+        this.analyser.fftSize = this.fftSize;
+        this.analyser.smoothingTimeConstant = 0.8;
+        this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        this.gainNode = this.context.createGain();
+        this.gainNode.gain.value = 0.8;
+        this.analyser.connect(this.gainNode);
+        this.gainNode.connect(this.context.destination);
+    }
+
+    async loadTrack(url) {
+        await this.init();
+        this.stop();
+        const response = await fetch(url);
+        const arrayBuffer = await response.arrayBuffer();
+        this.trackBuffer = await this.context.decodeAudioData(arrayBuffer);
+        this.resetState();
+    }
+
+    useBuffer(buffer) {
+        this.trackBuffer = buffer;
+        this.resetState();
+    }
+
+    resetState() {
+        this.isPlaying = false;
+        this.startTime = 0;
+        this.pauseTime = 0;
+        this.metronomePhase = 0;
+        this.lastBeatTime = 0;
+        this.energyHistory = [];
+    }
+
+    play() {
+        if (!this.trackBuffer || !this.context) {
+            return;
+        }
+
+        if (this.isPlaying) return;
+
+        this.source = this.context.createBufferSource();
+        this.source.buffer = this.trackBuffer;
+        this.source.connect(this.analyser);
+        const offset = this.pauseTime || 0;
+        this.source.start(0, offset);
+        this.startTime = this.context.currentTime - offset;
+        this.isPlaying = true;
+        this.source.onended = () => {
+            this.isPlaying = false;
+            this.pauseTime = 0;
+        };
+    }
+
+    pause() {
+        if (!this.isPlaying) return;
+        this.pauseTime = this.context.currentTime - this.startTime;
+        this.stopSource();
+    }
+
+    stop() {
+        if (!this.context) return;
+        this.pauseTime = 0;
+        this.stopSource();
+        this.isPlaying = false;
+    }
+
+    stopSource() {
+        if (this.source) {
+            try {
+                this.source.stop(0);
+            } catch (e) {
+                console.warn('Audio stop error:', e);
+            }
+            this.source.disconnect();
+            this.source = null;
+        }
+    }
+
+    setVolume(value) {
+        if (this.gainNode) {
+            this.gainNode.gain.value = value;
+        }
+    }
+
+    setBpm(bpm) {
+        this.bpm = bpm || DEFAULT_BPM;
+    }
+
+    enableMetronome(enabled) {
+        this.metronomeEnabled = enabled;
+    }
+
+    onBeat(callback) {
+        this.listeners.beat.add(callback);
+        return () => this.listeners.beat.delete(callback);
+    }
+
+    onAnalyser(callback) {
+        this.listeners.analyser.add(callback);
+        return () => this.listeners.analyser.delete(callback);
+    }
+
+    update(dt) {
+        if (!this.analyser) return;
+
+        this.analyser.getFloatFrequencyData(this.frequencyData);
+        this.analyser.getFloatTimeDomainData(this.timeDomainData);
+
+        const energy = this.computeEnergy(this.frequencyData);
+        this.energyHistory.push(energy);
+        if (this.energyHistory.length > this.historySize) {
+            this.energyHistory.shift();
+        }
+
+        const meanEnergy = this.energyHistory.reduce((a, b) => a + b, 0) / (this.energyHistory.length || 1);
+        const threshold = meanEnergy * this.beatThreshold;
+
+        const currentTime = this.context ? this.context.currentTime : 0;
+        const timeSinceLastBeat = currentTime - this.lastBeatTime;
+        const beatInterval = 60 / this.bpm;
+
+        const beatDetected = energy > threshold && timeSinceLastBeat > beatInterval * 0.5;
+
+        if (beatDetected) {
+            this.lastBeatTime = currentTime;
+            this.emitBeat({ energy, time: currentTime, source: 'audio' });
+        } else if (this.metronomeEnabled && timeSinceLastBeat > beatInterval) {
+            this.lastBeatTime = currentTime;
+            this.emitBeat({ energy: meanEnergy, time: currentTime, source: 'metronome' });
+        }
+
+        this.listeners.analyser.forEach(cb => cb({
+            frequencyData: this.frequencyData,
+            timeDomainData: this.timeDomainData,
+            energy,
+            meanEnergy
+        }));
+    }
+
+    computeEnergy(frequencyData) {
+        let sum = 0;
+        const len = frequencyData.length;
+        for (let i = 0; i < len; i++) {
+            const value = frequencyData[i];
+            if (value !== -Infinity) {
+                sum += Math.pow(10, value / 20);
+            }
+        }
+        return sum / len;
+    }
+
+    emitBeat(event) {
+        this.listeners.beat.forEach(cb => cb(event));
+    }
+
+    getBandLevels() {
+        if (!this.frequencyData) {
+            return { bass: 0, mid: 0, high: 0, energy: 0 };
+        }
+
+        const bassEnd = Math.floor(this.frequencyData.length * 0.08);
+        const midEnd = Math.floor(this.frequencyData.length * 0.4);
+
+        let bass = 0;
+        let mid = 0;
+        let high = 0;
+
+        for (let i = 0; i < this.frequencyData.length; i++) {
+            const value = this.frequencyData[i];
+            if (value === -Infinity) continue;
+            const amplitude = Math.pow(10, value / 20);
+            if (i < bassEnd) {
+                bass += amplitude;
+            } else if (i < midEnd) {
+                mid += amplitude;
+            } else {
+                high += amplitude;
+            }
+        }
+
+        return {
+            bass: bass / bassEnd || 0,
+            mid: mid / (midEnd - bassEnd || 1),
+            high: high / (this.frequencyData.length - midEnd || 1),
+            energy: this.energyHistory.length
+                ? this.energyHistory[this.energyHistory.length - 1]
+                : 0
+        };
+    }
+}

--- a/src/game/collision/CollisionSystem.js
+++ b/src/game/collision/CollisionSystem.js
@@ -1,0 +1,93 @@
+export class CollisionSystem {
+    constructor({ gridResolution = 32 }) {
+        this.gridResolution = gridResolution;
+        this.grid = new Map();
+        this.bounds = { minX: 0, maxX: 1, minY: 0, maxY: 1 };
+    }
+
+    rebuild(targets) {
+        this.grid.clear();
+        targets.forEach(target => {
+            const cells = this.getCellsForTarget(target);
+            cells.forEach(key => {
+                if (!this.grid.has(key)) {
+                    this.grid.set(key, []);
+                }
+                this.grid.get(key).push(target);
+            });
+        });
+    }
+
+    getCellsForTarget(target) {
+        const half = target.radius || 0.05;
+        const minX = Math.max(this.bounds.minX, target.x - half);
+        const maxX = Math.min(this.bounds.maxX, target.x + half);
+        const minY = Math.max(this.bounds.minY, target.y - half);
+        const maxY = Math.min(this.bounds.maxY, target.y + half);
+
+        const startX = Math.floor(minX * this.gridResolution);
+        const endX = Math.floor(maxX * this.gridResolution);
+        const startY = Math.floor(minY * this.gridResolution);
+        const endY = Math.floor(maxY * this.gridResolution);
+
+        const cells = [];
+        for (let gx = startX; gx <= endX; gx++) {
+            for (let gy = startY; gy <= endY; gy++) {
+                cells.push(`${gx},${gy}`);
+            }
+        }
+        return cells;
+    }
+
+    queryCircle({ x, y, radius }) {
+        const cellX = Math.floor(x * this.gridResolution);
+        const cellY = Math.floor(y * this.gridResolution);
+        const results = new Set();
+
+        for (let gx = cellX - 1; gx <= cellX + 1; gx++) {
+            for (let gy = cellY - 1; gy <= cellY + 1; gy++) {
+                const key = `${gx},${gy}`;
+                const bucket = this.grid.get(key);
+                if (!bucket) continue;
+                bucket.forEach(target => {
+                    if (this.circleOverlap(target, { x, y, radius })) {
+                        results.add(target);
+                    }
+                });
+            }
+        }
+
+        return Array.from(results);
+    }
+
+    circleOverlap(target, pulse) {
+        if (!target) return false;
+        if (target.type === 'belt') {
+            return this.capsuleOverlap(target, pulse);
+        }
+        if (target.type === 'wave') {
+            return this.waveOverlap(target, pulse);
+        }
+        const dx = target.x - pulse.x;
+        const dy = target.y - pulse.y;
+        const distanceSq = dx * dx + dy * dy;
+        const radius = (target.radius || 0.05) + pulse.radius;
+        return distanceSq <= radius * radius;
+    }
+
+    capsuleOverlap(target, pulse) {
+        const x = Math.max(Math.min(pulse.x, target.x + 0.05), target.x - 0.05);
+        const dy = pulse.y - target.y;
+        const dx = pulse.x - x;
+        const distanceSq = dx * dx + dy * dy;
+        const radius = (target.radius || 0.05) + pulse.radius * 0.8;
+        return distanceSq <= radius * radius;
+    }
+
+    waveOverlap(target, pulse) {
+        const dx = pulse.x - target.x;
+        const dy = pulse.y - target.y;
+        const radius = (target.radius || 0.04) + pulse.radius * 0.9;
+        return dx * dx + dy * dy <= radius * radius;
+    }
+}

--- a/src/game/effects/EffectsManager.js
+++ b/src/game/effects/EffectsManager.js
@@ -1,0 +1,58 @@
+export class EffectsManager {
+    constructor({ modeController }) {
+        this.modeController = modeController;
+        this.levels = {
+            intensity: 0,
+            hue: 0,
+            saturation: 0
+        };
+        this.decayRates = {
+            intensity: 1.4,
+            hue: 60,
+            saturation: 1.0
+        };
+    }
+
+    trigger(event) {
+        switch (event) {
+            case 'pulse':
+                this.levels.intensity += 0.25;
+                this.modeController.applyParameterDelta({ intensity: 0.2 });
+                break;
+            case 'combo':
+                this.levels.hue += 15;
+                this.modeController.applyParameterDelta({ hue: 15 });
+                break;
+            case 'perfect':
+                this.levels.intensity += 0.35;
+                this.levels.saturation += 0.2;
+                this.modeController.applyParameterDelta({ intensity: 0.25, saturation: 0.1 });
+                break;
+            case 'miss':
+                this.modeController.applyParameterDelta({ saturation: -0.2, intensity: -0.15 });
+                break;
+            default:
+                break;
+        }
+    }
+
+    update(dt) {
+        const decayAdjustments = {};
+        Object.entries(this.levels).forEach(([key, value]) => {
+            if (value <= 0) return;
+            const decay = Math.min(value, this.decayRates[key] * dt);
+            this.levels[key] = Math.max(0, value - decay);
+            if (decay > 0) {
+                if (key === 'hue') {
+                    decayAdjustments.hue = (decayAdjustments.hue || 0) - decay;
+                } else {
+                    decayAdjustments[key] = (decayAdjustments[key] || 0) - decay;
+                }
+            }
+        });
+
+        if (Object.keys(decayAdjustments).length) {
+            this.modeController.applyParameterDelta(decayAdjustments);
+        }
+    }
+}

--- a/src/game/geometry/GeometryController.js
+++ b/src/game/geometry/GeometryController.js
@@ -1,0 +1,285 @@
+import { SeededRandom } from '../utils/SeededRandom.js';
+
+const GEOMETRY_NAMES = [
+    'TETRAHEDRON',
+    'HYPERCUBE',
+    'SPHERE',
+    'TORUS',
+    'KLEIN BOTTLE',
+    'FRACTAL',
+    'WAVE',
+    'CRYSTAL'
+];
+
+const HOLOGRAPHIC_VARIANT_GROUPS = {
+    0: [0, 1, 2, 3],       // Tetrahedron variants
+    1: [4, 5, 6, 7],       // Hypercube
+    2: [8, 9, 10, 11],     // Sphere
+    3: [12, 13, 14, 15],   // Torus
+    4: [16, 17, 18, 19],   // Klein Bottle
+    5: [20, 21, 22],       // Fractal
+    6: [23, 24, 25],       // Wave
+    7: [26, 27, 28, 29]    // Crystal
+};
+
+const GEOMETRY_SPAWN_PROFILES = {
+    0: { pattern: 'vertexPulse', density: 0.7 },
+    1: { pattern: 'hypercubeBelts', density: 1.0 },
+    2: { pattern: 'orbitalShells', density: 0.9 },
+    3: { pattern: 'torusLane', density: 1.1 },
+    4: { pattern: 'kleinInversion', density: 0.8 },
+    5: { pattern: 'fractalChain', density: 1.2 },
+    6: { pattern: 'waveLane', density: 1.0 },
+    7: { pattern: 'crystalShards', density: 0.95 }
+};
+
+export class GeometryController {
+    constructor() {
+        this.geometryIndex = 0;
+        this.variantLevel = 0;
+        this.mode = 'faceted';
+        this.random = new SeededRandom(1);
+    }
+
+    setSeed(seed) {
+        this.random.setSeed(seed);
+    }
+
+    setGeometry(index) {
+        this.geometryIndex = Math.max(0, Math.min(GEOMETRY_NAMES.length - 1, index));
+    }
+
+    setVariantLevel(level) {
+        this.variantLevel = level;
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+    }
+
+    getGeometryName(index = this.geometryIndex) {
+        return GEOMETRY_NAMES[index] || GEOMETRY_NAMES[0];
+    }
+
+    cycleGeometry(direction = 1) {
+        const newIndex = (this.geometryIndex + direction + GEOMETRY_NAMES.length) % GEOMETRY_NAMES.length;
+        this.geometryIndex = newIndex;
+        this.variantLevel = 0;
+        return this.geometryIndex;
+    }
+
+    getVariantForMode(mode = this.mode, geometryIndex = this.geometryIndex, variantLevel = this.variantLevel) {
+        if (mode === 'holographic') {
+            const group = HOLOGRAPHIC_VARIANT_GROUPS[geometryIndex] || [0];
+            const index = group[variantLevel % group.length];
+            return index;
+        }
+
+        // Faceted & Quantum use 0-7 geometry index directly with fractional variant control
+        return geometryIndex;
+    }
+
+    getSpawnProfile(geometryIndex = this.geometryIndex) {
+        return GEOMETRY_SPAWN_PROFILES[geometryIndex] || GEOMETRY_SPAWN_PROFILES[0];
+    }
+
+    generateSpawn(beatIndex, difficulty = 1.0, overrides = {}) {
+        const geometryIndex = this.geometryIndex;
+        const profile = this.getSpawnProfile(geometryIndex);
+        const rng = this.random;
+        const pattern = overrides.pattern || profile.pattern;
+        const baseDensity = (overrides.density ?? profile.density) * difficulty;
+
+        switch (pattern) {
+            case 'vertexPulse':
+                return this.generateVertexPulse(geometryIndex, beatIndex, baseDensity, rng);
+            case 'hypercubeBelts':
+                return this.generateHypercubeBelts(geometryIndex, beatIndex, baseDensity, rng);
+            case 'orbitalShells':
+                return this.generateOrbitalShells(geometryIndex, beatIndex, baseDensity, rng);
+            case 'torusLane':
+                return this.generateTorusLane(geometryIndex, beatIndex, baseDensity, rng);
+            case 'kleinInversion':
+                return this.generateKleinInversion(geometryIndex, beatIndex, baseDensity, rng);
+            case 'fractalChain':
+                return this.generateFractalChain(geometryIndex, beatIndex, baseDensity, rng);
+            case 'waveLane':
+                return this.generateWaveLane(geometryIndex, beatIndex, baseDensity, rng);
+            case 'crystalShards':
+                return this.generateCrystalShards(geometryIndex, beatIndex, baseDensity, rng);
+            case 'torusLane':
+                return this.generateTorusLane(geometryIndex, beatIndex, baseDensity, rng);
+            case 'orbital':
+                return this.generateOrbitalShells(geometryIndex, beatIndex, baseDensity, rng);
+            case 'belt':
+                return this.generateHypercubeBelts(geometryIndex, beatIndex, baseDensity, rng);
+            case 'shard':
+                return this.generateCrystalShards(geometryIndex, beatIndex, baseDensity, rng);
+            default:
+                return [];
+        }
+    }
+
+    generateVertexPulse(geometryIndex, beatIndex, density, rng) {
+        const vertices = [
+            { x: 0.3, y: 0.25 },
+            { x: 0.7, y: 0.25 },
+            { x: 0.5, y: 0.72 },
+            { x: 0.5, y: 0.45 }
+        ];
+
+        const count = Math.max(1, Math.round(2 * density));
+        const result = [];
+        for (let i = 0; i < count; i++) {
+            const base = vertices[(beatIndex + i) % vertices.length];
+            result.push({
+                type: 'node',
+                x: base.x + rng.range(-0.05, 0.05),
+                y: base.y + rng.range(-0.05, 0.05),
+                radius: 0.06,
+                lifespan: 1.6,
+                speed: 0.3,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateHypercubeBelts(geometryIndex, beatIndex, density, rng) {
+        const lanes = [0.2, 0.35, 0.65, 0.8];
+        const result = [];
+        const count = Math.max(1, Math.round(3 * density));
+        for (let i = 0; i < count; i++) {
+            const lane = lanes[(beatIndex + i) % lanes.length];
+            result.push({
+                type: 'belt',
+                x: lane,
+                y: rng.range(0.15, 0.85),
+                radius: 0.05,
+                lifespan: 1.8,
+                speed: 0.45,
+                direction: (i % 2 === 0) ? 1 : -1,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateOrbitalShells(geometryIndex, beatIndex, density, rng) {
+        const rings = [0.18, 0.35, 0.55, 0.75];
+        const result = [];
+        const count = Math.max(1, Math.round(3 * density));
+        for (let i = 0; i < count; i++) {
+            const radius = rings[(beatIndex + i) % rings.length];
+            const angle = rng.range(0, Math.PI * 2);
+            result.push({
+                type: 'orb',
+                x: 0.5 + Math.cos(angle) * radius * 0.5,
+                y: 0.5 + Math.sin(angle) * radius * 0.5,
+                radius: 0.05,
+                lifespan: 2.0,
+                speed: 0.35,
+                orbitRadius: radius,
+                orbitSpeed: rng.range(0.4, 0.8),
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateTorusLane(geometryIndex, beatIndex, density, rng) {
+        const lanes = [0.3, 0.5, 0.7];
+        const result = [];
+        const count = Math.max(1, Math.round(4 * density));
+        for (let i = 0; i < count; i++) {
+            const lane = lanes[(beatIndex + i) % lanes.length];
+            result.push({
+                type: 'ring',
+                x: rng.range(0.15, 0.85),
+                y: lane,
+                radius: 0.07,
+                lifespan: 1.5,
+                speed: 0.5,
+                direction: (i + beatIndex) % 2 === 0 ? 1 : -1,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateKleinInversion(geometryIndex, beatIndex, density, rng) {
+        const result = [];
+        const count = Math.max(1, Math.round(3 * density));
+        for (let i = 0; i < count; i++) {
+            const phase = ((beatIndex + i) % 6) / 6;
+            result.push({
+                type: 'arc',
+                x: 0.5 + Math.sin(phase * Math.PI * 2) * 0.3,
+                y: 0.5 + Math.cos(phase * Math.PI * 2) * 0.2,
+                radius: 0.05,
+                lifespan: 1.7,
+                speed: 0.38,
+                rotationSpeed: (phase < 0.5 ? 1 : -1) * 0.6,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateFractalChain(geometryIndex, beatIndex, density, rng) {
+        const result = [];
+        const segments = 4 + Math.floor(density * 3);
+        for (let i = 0; i < segments; i++) {
+            const offset = i / segments;
+            result.push({
+                type: 'chain',
+                x: 0.2 + offset * 0.6 + rng.range(-0.03, 0.03),
+                y: 0.25 + Math.sin((beatIndex * 0.5 + offset * Math.PI * 2)) * 0.2,
+                radius: 0.045,
+                lifespan: 2.2,
+                speed: 0.4,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateWaveLane(geometryIndex, beatIndex, density, rng) {
+        const result = [];
+        const lanes = 3 + Math.floor(density * 2);
+        for (let i = 0; i < lanes; i++) {
+            const phase = (beatIndex + i) * 0.6;
+            result.push({
+                type: 'wave',
+                x: 0.1,
+                y: 0.2 + i * (0.6 / (lanes - 1)),
+                radius: 0.04,
+                lifespan: 2.0,
+                speed: 0.6,
+                waveAmplitude: 0.15,
+                waveFrequency: 2.2,
+                wavePhase: phase,
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+
+    generateCrystalShards(geometryIndex, beatIndex, density, rng) {
+        const result = [];
+        const shards = Math.max(3, Math.round(5 * density));
+        for (let i = 0; i < shards; i++) {
+            result.push({
+                type: 'shard',
+                x: rng.range(0.25, 0.75),
+                y: rng.range(0.2, 0.8),
+                radius: 0.05,
+                lifespan: 1.6,
+                speed: 0.55,
+                direction: rng.range(-1, 1),
+                metadata: { geometryIndex }
+            });
+        }
+        return result;
+    }
+}

--- a/src/game/input/InputMapping.js
+++ b/src/game/input/InputMapping.js
@@ -1,0 +1,193 @@
+const LONG_PRESS_THRESHOLD = 0.5; // seconds
+const PULSE_WINDOW = 0.15; // seconds
+const ROT_SENSITIVITY = 1.2;
+const DIMENSION_SENSITIVITY = 0.8;
+
+export class InputMapping {
+    constructor({ element, onParameterDelta, onPulse, onLongPress }) {
+        this.element = element;
+        this.onParameterDelta = onParameterDelta;
+        this.onPulse = onPulse;
+        this.onLongPress = onLongPress;
+        this.pointerStates = new Map();
+        this.primaryPointerId = null;
+        this.interaction = { x: 0.5, y: 0.5, intensity: 0 };
+        this.pulseState = { active: false, radius: 0, timer: 0 };
+        this.longPressTimer = 0;
+        this.longPressActive = false;
+        this.tilt = { beta: 0, gamma: 0 };
+        this.lastUpdate = performance.now();
+        this.pinchDistance = null;
+        this.init();
+    }
+
+    init() {
+        this.element.addEventListener('pointerdown', this.handlePointerDown.bind(this));
+        this.element.addEventListener('pointermove', this.handlePointerMove.bind(this));
+        this.element.addEventListener('pointerup', this.handlePointerUp.bind(this));
+        this.element.addEventListener('pointercancel', this.handlePointerUp.bind(this));
+        this.element.addEventListener('pointerleave', this.handlePointerUp.bind(this));
+
+        window.addEventListener('deviceorientation', event => {
+            this.tilt.beta = event.beta || 0;
+            this.tilt.gamma = event.gamma || 0;
+        });
+    }
+
+    handlePointerDown(event) {
+        this.element.setPointerCapture(event.pointerId);
+        const rect = this.element.getBoundingClientRect();
+        const normalized = this.normalize(event.clientX, event.clientY, rect);
+        const state = {
+            id: event.pointerId,
+            startX: normalized.x,
+            startY: normalized.y,
+            x: normalized.x,
+            y: normalized.y,
+            startTime: performance.now(),
+            lastTime: performance.now(),
+            lastX: normalized.x,
+            lastY: normalized.y,
+            velocityX: 0,
+            velocityY: 0
+        };
+        this.pointerStates.set(event.pointerId, state);
+        if (this.primaryPointerId === null) {
+            this.primaryPointerId = event.pointerId;
+            this.interaction.x = normalized.x;
+            this.interaction.y = normalized.y;
+            this.longPressTimer = 0;
+            this.longPressActive = false;
+        }
+    }
+
+    handlePointerMove(event) {
+        const state = this.pointerStates.get(event.pointerId);
+        if (!state) return;
+
+        const rect = this.element.getBoundingClientRect();
+        const normalized = this.normalize(event.clientX, event.clientY, rect);
+        const now = performance.now();
+        const dt = (now - state.lastTime) / 1000;
+        if (dt <= 0) return;
+
+        const deltaX = normalized.x - state.x;
+        const deltaY = normalized.y - state.y;
+        state.velocityX = deltaX / dt;
+        state.velocityY = deltaY / dt;
+        state.lastX = normalized.x;
+        state.lastY = normalized.y;
+        state.lastTime = now;
+        state.x = normalized.x;
+        state.y = normalized.y;
+
+        if (event.pointerId === this.primaryPointerId) {
+            this.interaction.x = normalized.x;
+            this.interaction.y = normalized.y;
+            this.interaction.intensity = Math.min(1, Math.hypot(state.velocityX, state.velocityY));
+            this.emitRotation(deltaX, deltaY);
+        } else {
+            this.handlePinch();
+        }
+    }
+
+    handlePointerUp(event) {
+        const state = this.pointerStates.get(event.pointerId);
+        if (!state) return;
+
+        this.pointerStates.delete(event.pointerId);
+        this.element.releasePointerCapture(event.pointerId);
+
+        if (event.pointerId === this.primaryPointerId) {
+            const duration = (performance.now() - state.startTime) / 1000;
+            const distance = Math.hypot(state.lastX - state.startX, state.lastY - state.startY);
+            if (duration < 0.3 && distance < 0.03) {
+                this.triggerPulse(state.lastX, state.lastY);
+            }
+            this.primaryPointerId = null;
+            this.interaction.intensity = 0;
+            this.longPressTimer = 0;
+            this.longPressActive = false;
+        }
+
+        if (this.pointerStates.size === 1) {
+            this.primaryPointerId = Array.from(this.pointerStates.keys())[0];
+            this.pinchDistance = null;
+        }
+        if (this.pointerStates.size < 2) {
+            this.pinchDistance = null;
+        }
+    }
+
+    handlePinch() {
+        if (this.pointerStates.size < 2) return;
+        const pointers = Array.from(this.pointerStates.values());
+        const [a, b] = pointers;
+        const currentDistance = Math.hypot(a.x - b.x, a.y - b.y);
+        if (this.pinchDistance === null) {
+            this.pinchDistance = currentDistance;
+            return;
+        }
+        const delta = (currentDistance - this.pinchDistance) * DIMENSION_SENSITIVITY;
+        this.pinchDistance = currentDistance;
+        this.onParameterDelta?.({ dimension: delta });
+    }
+
+    emitRotation(deltaX, deltaY) {
+        this.onParameterDelta?.({
+            rot4dXW: deltaX * ROT_SENSITIVITY,
+            rot4dYW: deltaY * ROT_SENSITIVITY
+        });
+    }
+
+    triggerPulse(x, y) {
+        this.pulseState = { active: true, radius: 0.15, timer: PULSE_WINDOW, x, y };
+        this.onPulse?.({ x, y, radius: 0.15, duration: PULSE_WINDOW });
+    }
+
+    normalize(x, y, rect) {
+        return {
+            x: (x - rect.left) / rect.width,
+            y: (y - rect.top) / rect.height
+        };
+    }
+
+    update(dt) {
+        const now = performance.now();
+        const elapsed = (now - this.lastUpdate) / 1000;
+        this.lastUpdate = now;
+
+        if (this.primaryPointerId !== null) {
+            this.longPressTimer += elapsed;
+            if (!this.longPressActive && this.longPressTimer > LONG_PRESS_THRESHOLD) {
+                this.longPressActive = true;
+                this.onLongPress?.();
+            }
+        }
+
+        if (this.pulseState.active) {
+            this.pulseState.timer -= dt;
+            this.pulseState.radius *= 0.92;
+            if (this.pulseState.timer <= 0) {
+                this.pulseState.active = false;
+            }
+        }
+
+        if (Math.abs(this.tilt.beta) > 1 || Math.abs(this.tilt.gamma) > 1) {
+            const tiltX = this.tilt.gamma / 90;
+            const tiltY = this.tilt.beta / 90;
+            this.onParameterDelta?.({
+                rot4dZW: tiltX * 0.3,
+                chaos: Math.abs(tiltY) * 0.05
+            });
+        }
+    }
+
+    getInteraction() {
+        return this.interaction;
+    }
+
+    getPulseState() {
+        return this.pulseState;
+    }
+}

--- a/src/game/modes/ModeController.js
+++ b/src/game/modes/ModeController.js
@@ -1,0 +1,109 @@
+import { ParameterManager } from '../../core/Parameters.js';
+import { ModeRenderer } from './ModeRenderer.js';
+
+const MODE_NAMES = ['faceted', 'quantum', 'holographic'];
+
+export class ModeController {
+    constructor({ container, geometryController }) {
+        this.container = container;
+        this.geometryController = geometryController;
+        this.parameterManager = new ParameterManager();
+        this.modeRenderers = new Map();
+        this.activeMode = 'faceted';
+        this.initialized = false;
+    }
+
+    initialize() {
+        if (this.initialized) return;
+
+        MODE_NAMES.forEach(modeName => {
+            const renderer = new ModeRenderer({
+                name: modeName,
+                container: this.container,
+                parameterManager: this.parameterManager,
+                variantResolver: variantLevel =>
+                    this.geometryController.getVariantForMode(modeName, this.geometryController.geometryIndex, variantLevel)
+            });
+
+            renderer.setActive(modeName === this.activeMode);
+            this.modeRenderers.set(modeName, renderer);
+        });
+
+        this.initialized = true;
+    }
+
+    setMode(modeName) {
+        if (!MODE_NAMES.includes(modeName) || modeName === this.activeMode) return;
+
+        const previousRenderer = this.modeRenderers.get(this.activeMode);
+        if (previousRenderer) previousRenderer.setActive(false);
+
+        this.activeMode = modeName;
+        this.geometryController.setMode(modeName);
+
+        const renderer = this.modeRenderers.get(modeName);
+        if (renderer) {
+            renderer.setActive(true);
+            renderer.updateParameters(this.parameterManager.getAllParameters());
+        }
+    }
+
+    cycleMode(direction = 1) {
+        const index = MODE_NAMES.indexOf(this.activeMode);
+        const nextIndex = (index + direction + MODE_NAMES.length) % MODE_NAMES.length;
+        this.setMode(MODE_NAMES[nextIndex]);
+    }
+
+    setGeometry(index) {
+        this.geometryController.setGeometry(index);
+        this.updateVariant();
+    }
+
+    updateVariant(level = 0) {
+        const renderer = this.modeRenderers.get(this.activeMode);
+        if (renderer) {
+            const variant = this.geometryController.getVariantForMode(
+                this.activeMode,
+                this.geometryController.geometryIndex,
+                level
+            );
+            renderer.setVariant(variant);
+        }
+    }
+
+    updateParameters(params) {
+        this.parameterManager.setParameters(params);
+        const renderer = this.modeRenderers.get(this.activeMode);
+        if (renderer) {
+            renderer.updateParameters(this.parameterManager.getAllParameters());
+        }
+    }
+
+    applyParameterDelta(deltas) {
+        const current = this.parameterManager.getAllParameters();
+        const next = { ...current };
+        Object.entries(deltas).forEach(([key, delta]) => {
+            if (typeof current[key] === 'number' && !Number.isNaN(delta)) {
+                next[key] = current[key] + delta;
+            }
+        });
+        this.parameterManager.setParameters(next);
+        const renderer = this.modeRenderers.get(this.activeMode);
+        if (renderer) {
+            renderer.updateParameters(this.parameterManager.getAllParameters());
+        }
+    }
+
+    getParameters() {
+        return this.parameterManager.getAllParameters();
+    }
+
+    render(interaction) {
+        const renderer = this.modeRenderers.get(this.activeMode);
+        if (!renderer) return;
+        if (interaction) {
+            renderer.updateInteraction(interaction);
+        }
+        renderer.render();
+    }
+}

--- a/src/game/modes/ModeRenderer.js
+++ b/src/game/modes/ModeRenderer.js
@@ -1,0 +1,103 @@
+import { IntegratedHolographicVisualizer } from '../../core/Visualizer.js';
+import { QuantumHolographicVisualizer } from '../../quantum/QuantumVisualizer.js';
+import { HolographicVisualizer } from '../../holograms/HolographicVisualizer.js';
+
+const LAYERS = [
+    { key: 'background', role: 'background', reactivity: 0.5 },
+    { key: 'shadow', role: 'shadow', reactivity: 0.7 },
+    { key: 'content', role: 'content', reactivity: 0.9 },
+    { key: 'highlight', role: 'highlight', reactivity: 1.1 },
+    { key: 'accent', role: 'accent', reactivity: 1.4 }
+];
+
+const VISUALIZER_MAP = {
+    faceted: IntegratedHolographicVisualizer,
+    quantum: QuantumHolographicVisualizer,
+    holographic: HolographicVisualizer
+};
+
+export class ModeRenderer {
+    constructor({ name, container, parameterManager, variantResolver }) {
+        this.name = name;
+        this.container = container;
+        this.parameterManager = parameterManager;
+        this.variantResolver = variantResolver;
+        this.canvasElements = new Map();
+        this.visualizers = [];
+        this.active = false;
+        this.createCanvasStack();
+        this.initVisualizers();
+    }
+
+    createCanvasStack() {
+        const modeContainer = document.createElement('div');
+        modeContainer.className = 'mode-layer';
+        modeContainer.dataset.mode = this.name;
+        this.container.appendChild(modeContainer);
+        this.modeContainer = modeContainer;
+
+        LAYERS.forEach(layer => {
+            const canvas = document.createElement('canvas');
+            canvas.id = `${this.name}-${layer.key}-canvas`;
+            canvas.className = 'visual-canvas';
+            canvas.setAttribute('data-role', layer.role);
+            modeContainer.appendChild(canvas);
+            this.canvasElements.set(layer.key, canvas);
+        });
+    }
+
+    initVisualizers() {
+        const VisualizerClass = VISUALIZER_MAP[this.name];
+        const variant = this.variantResolver?.(0) ?? 0;
+
+        this.visualizers = LAYERS.map(layer =>
+            new VisualizerClass(`${this.name}-${layer.key}-canvas`, layer.role, layer.reactivity, variant)
+        );
+    }
+
+    setActive(active) {
+        this.active = active;
+        if (!this.modeContainer) return;
+        this.modeContainer.style.display = active ? 'block' : 'none';
+        this.visualizers.forEach(v => (v.isActive = active));
+    }
+
+    updateParameters(params) {
+        this.visualizers.forEach(visualizer => {
+            if (visualizer?.updateParameters) {
+                visualizer.updateParameters(params);
+            }
+        });
+    }
+
+    updateInteraction(interaction) {
+        if (!interaction) return;
+        this.visualizers.forEach(visualizer => {
+            if (visualizer?.updateInteraction) {
+                visualizer.updateInteraction(
+                    interaction.x,
+                    interaction.y,
+                    interaction.intensity
+                );
+            }
+        });
+    }
+
+    render() {
+        if (!this.active) return;
+        this.visualizers.forEach(visualizer => {
+            if (visualizer?.render) {
+                visualizer.render();
+            }
+        });
+    }
+
+    setVariant(variant) {
+        this.visualizers.forEach(visualizer => {
+            visualizer.variant = variant;
+            if (visualizer.variantParams && visualizer.generateVariantParams) {
+                visualizer.variantParams = visualizer.generateVariantParams(variant);
+            }
+        });
+    }
+}

--- a/src/game/performance/PerformanceController.js
+++ b/src/game/performance/PerformanceController.js
@@ -1,0 +1,54 @@
+export class PerformanceController {
+    constructor({ modeController, windowSize = 120 }) {
+        this.modeController = modeController;
+        this.windowSize = windowSize;
+        this.samples = [];
+        this.lastTime = performance.now();
+        this.lodLevel = 0;
+    }
+
+    recordFrame(now = performance.now()) {
+        const delta = now - this.lastTime;
+        this.lastTime = now;
+        if (delta <= 0) return;
+        const fps = 1000 / delta;
+        this.samples.push(fps);
+        if (this.samples.length > this.windowSize) {
+            this.samples.shift();
+        }
+    }
+
+    getAverageFps() {
+        if (!this.samples.length) return 60;
+        const sum = this.samples.reduce((a, b) => a + b, 0);
+        return sum / this.samples.length;
+    }
+
+    update() {
+        const fps = this.getAverageFps();
+        if (fps < 50 && this.lodLevel < 2) {
+            this.lodLevel += 1;
+            this.applyLOD();
+        } else if (fps > 58 && this.lodLevel > 0) {
+            this.lodLevel -= 1;
+            this.applyLOD();
+        }
+    }
+
+    applyLOD() {
+        const params = this.modeController.getParameters();
+        const adjustments = { ...params };
+        if (this.lodLevel === 0) {
+            adjustments.gridDensity = Math.max(params.gridDensity, 18);
+            adjustments.intensity = Math.min(params.intensity + 0.1, 1);
+        } else if (this.lodLevel === 1) {
+            adjustments.gridDensity = Math.min(params.gridDensity, 14);
+            adjustments.chaos = Math.min(params.chaos, 0.25);
+        } else {
+            adjustments.gridDensity = Math.min(params.gridDensity, 10);
+            adjustments.chaos = Math.min(params.chaos, 0.18);
+            adjustments.intensity = Math.max(params.intensity - 0.1, 0.35);
+        }
+        this.modeController.updateParameters(adjustments);
+    }
+}

--- a/src/game/spawn/SpawnSystem.js
+++ b/src/game/spawn/SpawnSystem.js
@@ -1,0 +1,134 @@
+let TARGET_ID = 0;
+
+export class SpawnSystem {
+    constructor({ geometryController, audioService, difficulty = 1.0 }) {
+        this.geometryController = geometryController;
+        this.audioService = audioService;
+        this.difficulty = difficulty;
+        this.activeTargets = [];
+        this.beatCount = 0;
+        this.listeners = { spawn: new Set(), resolve: new Set(), miss: new Set() };
+        this.spawnOverrides = {};
+    }
+
+    initialize() {
+        if (this.audioService) {
+            this.audioService.onBeat(() => this.handleBeat());
+        }
+    }
+
+    on(event, callback) {
+        if (this.listeners[event]) {
+            this.listeners[event].add(callback);
+        }
+        return () => this.listeners[event]?.delete(callback);
+    }
+
+    emit(event, payload) {
+        this.listeners[event]?.forEach(cb => cb(payload));
+    }
+
+    handleBeat() {
+        const spawns = this.geometryController.generateSpawn(
+            this.beatCount,
+            this.difficulty,
+            this.spawnOverrides
+        );
+        spawns.forEach(spawn => {
+            const target = {
+                ...spawn,
+                id: TARGET_ID++,
+                age: 0,
+                captured: false
+            };
+            this.activeTargets.push(target);
+            this.emit('spawn', target);
+        });
+        this.beatCount += 1;
+    }
+
+    update(dt) {
+        this.activeTargets = this.activeTargets.filter(target => {
+            target.age += dt;
+            if (target.age > target.lifespan) {
+                this.emit('miss', target);
+                return false;
+            }
+
+            this.advanceTarget(target, dt);
+            return true;
+        });
+    }
+
+    advanceTarget(target, dt) {
+        switch (target.type) {
+            case 'node':
+                target.radius *= 0.995;
+                target.y -= dt * target.speed * 0.2;
+                break;
+            case 'belt':
+                target.x += dt * target.speed * target.direction * 0.6;
+                if (target.x < 0.1 || target.x > 0.9) {
+                    target.direction *= -1;
+                }
+                break;
+            case 'orb':
+                target.orbitAngle = (target.orbitAngle || 0) + dt * target.orbitSpeed;
+                const angle = target.orbitAngle;
+                target.x = 0.5 + Math.cos(angle) * target.orbitRadius * 0.5;
+                target.y = 0.5 + Math.sin(angle) * target.orbitRadius * 0.5;
+                break;
+            case 'ring':
+                target.x += dt * target.speed * target.direction;
+                if (target.x < 0.1 || target.x > 0.9) {
+                    target.direction *= -1;
+                }
+                break;
+            case 'arc':
+                target.rotationAngle = (target.rotationAngle || 0) + dt * target.rotationSpeed;
+                target.x = 0.5 + Math.sin(target.rotationAngle) * 0.3;
+                target.y = 0.5 + Math.cos(target.rotationAngle) * 0.2;
+                break;
+            case 'chain':
+                target.y += Math.sin((target.age + target.x) * 3.1) * dt * 0.2;
+                break;
+            case 'wave':
+                target.x += dt * target.speed;
+                target.y = 0.2 + Math.sin(target.wavePhase + target.age * target.waveFrequency) * target.waveAmplitude;
+                break;
+            case 'shard':
+                target.x += dt * target.speed * target.direction;
+                target.y -= dt * target.speed * 0.5;
+                break;
+            default:
+                break;
+        }
+    }
+
+    resolveTarget(id) {
+        const index = this.activeTargets.findIndex(target => target.id === id);
+        if (index >= 0) {
+            const [target] = this.activeTargets.splice(index, 1);
+            target.captured = true;
+            this.emit('resolve', target);
+            return target;
+        }
+        return null;
+    }
+
+    getTargets() {
+        return this.activeTargets;
+    }
+
+    configure({ difficulty, spawn } = {}) {
+        if (typeof difficulty === 'number') {
+            this.difficulty = difficulty;
+        }
+        if (spawn) {
+            this.spawnOverrides = {
+                pattern: spawn.pattern,
+                density: spawn.density
+            };
+        }
+    }
+}

--- a/src/game/state/LevelManager.js
+++ b/src/game/state/LevelManager.js
@@ -1,0 +1,82 @@
+import { SeededRandom } from '../utils/SeededRandom.js';
+
+export class LevelManager {
+    constructor({ storageKey = 'latticePulseProgress' } = {}) {
+        this.storageKey = storageKey;
+        this.levels = [];
+        this.currentIndex = 0;
+        this.progress = this.loadProgress();
+        this.random = new SeededRandom(1);
+    }
+
+    loadProgress() {
+        try {
+            const stored = localStorage.getItem(this.storageKey);
+            if (!stored) return {};
+            return JSON.parse(stored);
+        } catch (error) {
+            console.warn('Level progress load failed:', error);
+            return {};
+        }
+    }
+
+    saveProgress() {
+        try {
+            localStorage.setItem(this.storageKey, JSON.stringify(this.progress));
+        } catch (error) {
+            console.warn('Level progress save failed:', error);
+        }
+    }
+
+    setLevels(levelArray) {
+        this.levels = levelArray;
+        this.currentIndex = 0;
+    }
+
+    getCurrentLevel() {
+        return this.levels[this.currentIndex] || null;
+    }
+
+    advanceLevel() {
+        if (this.currentIndex < this.levels.length - 1) {
+            this.currentIndex += 1;
+        }
+        return this.getCurrentLevel();
+    }
+
+    recordScore(levelId, score) {
+        const levelProgress = this.progress[levelId] || { best: 0, attempts: 0 };
+        levelProgress.best = Math.max(levelProgress.best, score);
+        levelProgress.attempts += 1;
+        this.progress[levelId] = levelProgress;
+        this.saveProgress();
+    }
+
+    getLevelProgress(levelId) {
+        return this.progress[levelId] || { best: 0, attempts: 0 };
+    }
+
+    applyLevelSettings(level, { modeController, geometryController, audioService }) {
+        if (!level) return;
+        if (geometryController) {
+            geometryController.setGeometry(level.geometryIndex || 0);
+            geometryController.setMode(level.system || 'faceted');
+            geometryController.setSeed(level.seed || 1);
+        }
+        if (modeController) {
+            modeController.setMode(level.system || 'faceted');
+            modeController.setGeometry(level.geometryIndex || 0);
+            modeController.updateParameters({
+                speed: level.difficulty?.speed || 1,
+                chaos: level.difficulty?.chaos || 0.1,
+                gridDensity: level.difficulty?.gridDensity || 18,
+                hue: level.palette?.hue || 210,
+                intensity: level.palette?.intensity || 0.6,
+                saturation: level.palette?.saturation || 0.85
+            });
+        }
+        if (audioService && level.bpm) {
+            audioService.setBpm(level.bpm);
+        }
+    }
+}

--- a/src/game/state/defaultLevels.js
+++ b/src/game/state/defaultLevels.js
@@ -1,0 +1,44 @@
+export const DEFAULT_LEVELS = [
+    {
+        id: 'lvl-01-faceted-torus',
+        name: 'Lattice Breaker',
+        system: 'faceted',
+        geometryIndex: 3,
+        track: 'suno:track_001',
+        bpm: 128,
+        seed: 4711,
+        planes: ['XW', 'YW'],
+        windowMs: 150,
+        spawn: { pattern: 'torusLane', density: 0.8 },
+        difficulty: { speed: 1.0, chaos: 0.12, gridDensity: 18 },
+        palette: { hue: 210, saturation: 0.85, intensity: 0.6 }
+    },
+    {
+        id: 'lvl-02-quantum-sphere',
+        name: 'Quantum Bloom',
+        system: 'quantum',
+        geometryIndex: 2,
+        track: 'suno:track_014',
+        bpm: 140,
+        seed: 8722,
+        planes: ['XW', 'ZW'],
+        windowMs: 140,
+        spawn: { pattern: 'orbitalShells', density: 1.0 },
+        difficulty: { speed: 1.2, chaos: 0.2, gridDensity: 20 },
+        palette: { hue: 268, saturation: 0.92, intensity: 0.72 }
+    },
+    {
+        id: 'lvl-03-holographic-crystal',
+        name: 'Crystal Resonance',
+        system: 'holographic',
+        geometryIndex: 7,
+        track: 'suno:track_029',
+        bpm: 122,
+        seed: 1299,
+        planes: ['YW', 'ZW'],
+        windowMs: 160,
+        spawn: { pattern: 'crystalShards', density: 1.1 },
+        difficulty: { speed: 1.1, chaos: 0.18, gridDensity: 22 },
+        palette: { hue: 188, saturation: 0.88, intensity: 0.66 }
+    }
+];

--- a/src/game/ui/HudController.js
+++ b/src/game/ui/HudController.js
@@ -1,0 +1,82 @@
+export class HudController {
+    constructor(root) {
+        this.root = root;
+        this.elements = {
+            score: root.querySelector('[data-hud="score"]'),
+            combo: root.querySelector('[data-hud="combo"]'),
+            mode: root.querySelector('[data-hud="mode"]'),
+            geometry: root.querySelector('[data-hud="geometry"]'),
+            level: root.querySelector('[data-hud="level"]'),
+            bpm: root.querySelector('[data-hud="bpm"]'),
+            fps: root.querySelector('[data-hud="fps"]'),
+            pulse: root.querySelector('[data-hud="pulse"]'),
+            shield: root.querySelector('[data-hud="shield"]'),
+            toast: root.querySelector('[data-hud="toast"]')
+        };
+    }
+
+    setScore(score) {
+        if (this.elements.score) {
+            this.elements.score.textContent = score.toLocaleString();
+        }
+    }
+
+    setCombo(combo) {
+        if (this.elements.combo) {
+            this.elements.combo.textContent = combo > 1 ? `${combo}x` : '—';
+        }
+    }
+
+    setMode(mode) {
+        if (this.elements.mode) {
+            this.elements.mode.textContent = mode.toUpperCase();
+        }
+    }
+
+    setGeometry(name) {
+        if (this.elements.geometry) {
+            this.elements.geometry.textContent = name;
+        }
+    }
+
+    setLevel(label) {
+        if (this.elements.level) {
+            this.elements.level.textContent = label;
+        }
+    }
+
+    setBpm(bpm) {
+        if (this.elements.bpm) {
+            this.elements.bpm.textContent = `${Math.round(bpm)} BPM`;
+        }
+    }
+
+    setFps(fps) {
+        if (this.elements.fps) {
+            this.elements.fps.textContent = `${Math.round(fps)} FPS`;
+        }
+    }
+
+    setPulseMeter(value) {
+        if (this.elements.pulse) {
+            const scaled = Math.min(1, value / 0.2);
+            this.elements.pulse.style.setProperty('--pulse-level', scaled);
+        }
+    }
+
+    setShieldMeter(value) {
+        if (this.elements.shield) {
+            this.elements.shield.style.setProperty('--shield-level', Math.min(1, value));
+        }
+    }
+
+    showToast(message, duration = 1200) {
+        if (!this.elements.toast) return;
+        this.elements.toast.textContent = message;
+        this.elements.toast.classList.add('visible');
+        clearTimeout(this.toastTimeout);
+        this.toastTimeout = setTimeout(() => {
+            this.elements.toast.classList.remove('visible');
+        }, duration);
+    }
+}

--- a/src/game/utils/SeededRandom.js
+++ b/src/game/utils/SeededRandom.js
@@ -1,0 +1,26 @@
+export class SeededRandom {
+    constructor(seed = 1) {
+        this.setSeed(seed);
+    }
+
+    setSeed(seed) {
+        // Use a simple LCG (Lehmer) for determinism across browsers
+        this.state = (seed >>> 0) || 1;
+    }
+
+    next() {
+        // Park-Miller LCG
+        this.state = (this.state * 48271) % 0x7fffffff;
+        return this.state / 0x7fffffff;
+    }
+
+    range(min, max) {
+        return min + (max - min) * this.next();
+    }
+
+    pick(array) {
+        if (!array.length) return undefined;
+        const index = Math.floor(this.next() * array.length);
+        return array[index];
+    }
+}

--- a/styles/lattice-pulse.css
+++ b/styles/lattice-pulse.css
@@ -1,0 +1,208 @@
+:root {
+  color-scheme: dark;
+  --bg: #050018;
+  --fg: #f5f7ff;
+  --accent: #5c6bff;
+  --accent-alt: #24e0ff;
+  --card: rgba(10, 5, 32, 0.75);
+  --card-border: rgba(180, 200, 255, 0.25);
+  --safe: env(safe-area-inset-bottom, 16px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(44, 34, 94, 0.6), transparent),
+              radial-gradient(circle at 80% 0%, rgba(12, 242, 255, 0.18), transparent),
+              var(--bg);
+  color: var(--fg);
+  height: 100vh;
+  overflow: hidden;
+}
+
+#app {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.visualizer {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.mode-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.visual-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  mix-blend-mode: screen;
+}
+
+.hud {
+  position: fixed;
+  top: max(16px, env(safe-area-inset-top));
+  left: 0;
+  right: 0;
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.hud-row {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.hud-card {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 10px 16px;
+  min-width: 120px;
+  backdrop-filter: blur(18px);
+  pointer-events: auto;
+}
+
+.hud-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.hud-value {
+  font-size: 1.6rem;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.hud-small {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.hud-meter {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  margin-top: 8px;
+}
+
+.hud-meter::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--level, 0));
+  background: linear-gradient(90deg, var(--accent), var(--accent-alt));
+  transition: transform 0.18s ease;
+}
+
+[data-hud="pulse"] {
+  --level: var(--pulse-level, 0);
+}
+
+[data-hud="shield"] {
+  --level: var(--shield-level, 1);
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(80px + var(--safe));
+  transform: translateX(-50%) translateY(40px);
+  background: rgba(15, 12, 52, 0.8);
+  border: 1px solid rgba(92, 107, 255, 0.45);
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 6;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.controls {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(16px + var(--safe));
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.control-button {
+  pointer-events: auto;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(15, 12, 52, 0.8);
+  color: var(--fg);
+  padding: 14px 18px;
+  border-radius: 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  min-width: 120px;
+  backdrop-filter: blur(18px);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.control-button:active {
+  transform: translateY(2px);
+  border-color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .hud-row {
+    flex-wrap: wrap;
+  }
+  .hud-card {
+    flex: 1 1 calc(50% - 12px);
+  }
+  .control-button {
+    min-width: 100px;
+    font-size: 0.85rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hud-card {
+    padding: 8px 12px;
+    min-width: 100px;
+  }
+  .hud-value {
+    font-size: 1.3rem;
+  }
+}

--- a/sw-lattice-pulse.js
+++ b/sw-lattice-pulse.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'lattice-pulse-v1';
+const ASSETS = [
+  './lattice-pulse.html',
+  './styles/lattice-pulse.css',
+  './js/lattice-pulse.js',
+  './lattice-pulse.webmanifest',
+  './assets/icons/lattice-pulse-icon.svg',
+  './src/game/LatticePulseGame.js',
+  './src/game/GameLoop.js',
+  './src/game/audio/AudioService.js',
+  './src/game/modes/ModeController.js',
+  './src/game/modes/ModeRenderer.js',
+  './src/game/geometry/GeometryController.js',
+  './src/game/spawn/SpawnSystem.js',
+  './src/game/collision/CollisionSystem.js',
+  './src/game/input/InputMapping.js',
+  './src/game/effects/EffectsManager.js',
+  './src/game/performance/PerformanceController.js',
+  './src/game/state/LevelManager.js',
+  './src/game/state/defaultLevels.js',
+  './src/game/ui/HudController.js',
+  './src/game/utils/SeededRandom.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  event.respondWith(
+    caches.match(request).then(cached => {
+      if (cached) return cached;
+      return fetch(request)
+        .then(response => {
+          if (!response || response.status !== 200) return response;
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, cloned));
+          return response;
+        })
+        .catch(() => caches.match('./lattice-pulse.html'));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a new `lattice-pulse.html` entry point that bundles the existing VIB34D visualizers into a mobile-first rhythm game UI
- implement a full game stack under `src/game/` (loop, audio beats, gesture input, geometry-aware spawns, collision, HUD, performance tuning)
- package the experience as a PWA with dedicated styling, manifest, icon, and offline service worker

## Testing
- `npm test` *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4a3bd81c83298af0624151c20b75