### PR TITLE
Fix Lattice Pulse visualizer initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ python3 -m http.server 8080
 http://localhost:8080/index-clean.html
 ```
 
+### 🎯 Lattice Pulse – Mobile Game
+
+The new **Lattice Pulse** mode turns the faceted/quantum/holographic renderers into a rhythm-arcade loop.
+
+- Launch the PWA: `http://localhost:8080/lattice-pulse.html`
+- Tap the start screen to unlock audio and begin.
+- **Tap** to pulse captures, **swipe** to rotate 4D planes, **pinch** to shift dimensional depth, **long-press** to enter a slow-motion phase, and **tilt** (optional) for drift correction.
+- Runs as a deterministic 60 Hz loop with beat-driven spawns (Suno BPM metadata) and offline caching via `sw-lattice-pulse.js`.
+- Progression currently ships with three seedable level JSONs covering Faceted Torus, Quantum Sphere, and Holographic Crystal lattices—each targeting 60 FPS on modern phones.
+
 ## 🎮 The 4 Systems
 
 **🔷 FACETED** - Simple 2D geometric patterns  

--- a/icons/lattice-192.svg
+++ b/icons/lattice-192.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-labelledby="title desc">
+  <title id="title">Lattice Pulse Icon</title>
+  <desc id="desc">Abstract lattice grid representing the Lattice Pulse rhythm game.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a2e" />
+      <stop offset="100%" stop-color="#6622cc" />
+    </linearGradient>
+    <linearGradient id="pulse" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff6ad5" />
+      <stop offset="100%" stop-color="#ffe45e" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" fill="url(#bg)" rx="24" ry="24" />
+  <g stroke="#2de2e6" stroke-width="6" opacity="0.45">
+    <path d="M32 32h128M32 64h128M32 96h128M32 128h128M32 160h128" />
+    <path d="M32 32v128M64 32v128M96 32v128M128 32v128M160 32v128" />
+  </g>
+  <path d="M48 132l36-60 24 36 18-28 18 28" fill="none" stroke="url(#pulse)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="84" cy="72" r="10" fill="#ffe45e" />
+  <circle cx="126" cy="100" r="12" fill="#ff6ad5" />
+</svg>

--- a/icons/lattice-512.svg
+++ b/icons/lattice-512.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Lattice Pulse Icon Large</title>
+  <desc id="desc">Large icon featuring the lattice pulse motif.</desc>
+  <defs>
+    <linearGradient id="bg512" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d1321" />
+      <stop offset="100%" stop-color="#5f0f99" />
+    </linearGradient>
+    <linearGradient id="pulse512" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff8ae2" />
+      <stop offset="100%" stop-color="#f9ff9d" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#bg512)" rx="72" ry="72" />
+  <g stroke="#41ead4" stroke-width="16" opacity="0.45">
+    <path d="M96 96h320M96 160h320M96 224h320M96 288h320M96 352h320M96 416h320" />
+    <path d="M96 96v320M160 96v320M224 96v320M288 96v320M352 96v320M416 96v320" />
+  </g>
+  <path d="M128 368l92-160 64 96 48-76 48 76" fill="none" stroke="url(#pulse512)" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="220" cy="212" r="32" fill="#f9ff9d" />
+  <circle cx="332" cy="272" r="38" fill="#ff8ae2" />
+</svg>

--- a/lattice-pulse-manifest.json
+++ b/lattice-pulse-manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Lattice Pulse",
+  "short_name": "LatticePulse",
+  "start_url": "./lattice-pulse.html",
+  "display": "standalone",
+  "background_color": "#020407",
+  "theme_color": "#020407",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "./icons/lattice-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "./icons/lattice-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/lattice-pulse.html
+++ b/lattice-pulse.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#020407">
+  <title>Lattice Pulse • VIB34D</title>
+  <link rel="manifest" href="./lattice-pulse-manifest.json">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap">
+  <link rel="stylesheet" href="./styles/lattice-pulse.css">
+</head>
+<body>
+  <div id="lp-app">
+    <div id="lp-canvas-root"></div>
+    <div id="lp-input-layer"></div>
+    <div id="lp-hud"></div>
+    <div id="lp-start-screen">
+      <div class="lp-start-title">Lattice Pulse</div>
+      <div class="lp-start-subtitle">Tap to pulse, swipe to steer the lattice. Hold to phase shift and glide through beats.</div>
+      <button id="lp-start-button">Start</button>
+    </div>
+  </div>
+  <script type="module" src="./src/game/LatticePulseGame.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw-lattice-pulse.js').catch((err) => console.warn('SW registration failed', err));
+      });
+    }
+  </script>
+</body>
+</html>

--- a/src/game/AudioService.js
+++ b/src/game/AudioService.js
@@ -1,0 +1,182 @@
+/**
+ * Audio playback + beat clock with analyser-driven reactivity.
+ */
+export class AudioService {
+    constructor() {
+        this.audioContext = null;
+        this.masterGain = null;
+        this.analyser = null;
+        this.source = null;
+        this.trackBuffer = null;
+        this.trackConfig = null;
+        this.isPlaying = false;
+        this.useMetronome = false;
+        this.metronomeOscillator = null;
+        this.beatInterval = 0.5; // default 120 BPM
+        this.beatAccumulator = 0;
+        this.beatListeners = new Set();
+        this.measureListeners = new Set();
+        this.frequencyBins = null;
+        this.phase = 0;
+        this.measureBeats = 4;
+        this.beatIndex = 0;
+        this.startTime = 0;
+    }
+
+    async init() {
+        if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            this.masterGain = this.audioContext.createGain();
+            this.masterGain.connect(this.audioContext.destination);
+            this.analyser = this.audioContext.createAnalyser();
+            this.analyser.fftSize = 2048;
+            this.analyser.smoothingTimeConstant = 0.7;
+            this.frequencyBins = new Uint8Array(this.analyser.frequencyBinCount);
+            this.analyser.connect(this.masterGain);
+        }
+        return this.audioContext;
+    }
+
+    async loadTrack(trackConfig) {
+        await this.init();
+        this.trackConfig = trackConfig;
+        const bpm = trackConfig?.bpm || 120;
+        this.setBPM(bpm);
+
+        if (!trackConfig?.url) {
+            console.warn('AudioService: No track URL, using metronome fallback');
+            this.useMetronome = true;
+            return false;
+        }
+
+        try {
+            const response = await fetch(trackConfig.url);
+            const arrayBuffer = await response.arrayBuffer();
+            this.trackBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+            this.useMetronome = false;
+            console.log('AudioService: Track loaded');
+            return true;
+        } catch (err) {
+            console.warn('AudioService: Failed to load track, falling back to metronome', err);
+            this.trackBuffer = null;
+            this.useMetronome = true;
+            return false;
+        }
+    }
+
+    setBPM(bpm) {
+        this.beatInterval = 60 / (bpm || 120);
+    }
+
+    async start() {
+        await this.init();
+        await this.audioContext.resume();
+        this.stop();
+
+        if (this.useMetronome || !this.trackBuffer) {
+            this.startMetronome();
+        } else {
+            this.startTrack();
+        }
+
+        this.isPlaying = true;
+        this.startTime = this.audioContext.currentTime;
+        window.audioEnabled = true;
+    }
+
+    startTrack() {
+        this.source = this.audioContext.createBufferSource();
+        this.source.buffer = this.trackBuffer;
+        this.source.loop = true;
+        this.source.connect(this.analyser);
+        this.source.start();
+    }
+
+    startMetronome() {
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = 880;
+        gain.gain.value = 0;
+        osc.connect(gain);
+        gain.connect(this.analyser);
+        osc.start();
+        this.metronomeOscillator = { osc, gain };
+    }
+
+    stop() {
+        if (this.source) {
+            try { this.source.stop(); } catch (_) { /* ignore */ }
+            this.source.disconnect();
+            this.source = null;
+        }
+        if (this.metronomeOscillator) {
+            try { this.metronomeOscillator.osc.stop(); } catch (_) {}
+            this.metronomeOscillator.osc.disconnect();
+            this.metronomeOscillator.gain.disconnect();
+            this.metronomeOscillator = null;
+        }
+        this.isPlaying = false;
+        window.audioEnabled = false;
+    }
+
+    onBeat(callback) {
+        this.beatListeners.add(callback);
+        return () => this.beatListeners.delete(callback);
+    }
+
+    onMeasure(callback) {
+        this.measureListeners.add(callback);
+        return () => this.measureListeners.delete(callback);
+    }
+
+    update(dt) {
+        if (!this.isPlaying) return;
+
+        this.beatAccumulator += dt * (this.trackConfig?.playbackRate || 1);
+        if (this.beatAccumulator >= this.beatInterval) {
+            this.beatAccumulator -= this.beatInterval;
+            this.beatIndex += 1;
+            const beatInfo = {
+                time: this.audioContext?.currentTime || performance.now() / 1000,
+                beat: this.beatIndex,
+                interval: this.beatInterval
+            };
+            this.beatListeners.forEach((cb) => cb(beatInfo));
+            if (this.beatIndex % this.measureBeats === 0) {
+                this.measureListeners.forEach((cb) => cb({
+                    measure: this.beatIndex / this.measureBeats,
+                    beatInfo
+                }));
+            }
+            if (this.metronomeOscillator) {
+                this.metronomeOscillator.gain.gain.cancelScheduledValues(0);
+                this.metronomeOscillator.gain.gain.setValueAtTime(0.25, this.audioContext.currentTime);
+                this.metronomeOscillator.gain.gain.exponentialRampToValueAtTime(0.001, this.audioContext.currentTime + 0.15);
+            }
+        }
+
+        if (this.analyser && this.frequencyBins) {
+            this.analyser.getByteFrequencyData(this.frequencyBins);
+            const bass = averageRange(this.frequencyBins, 0, 24);
+            const mid = averageRange(this.frequencyBins, 24, 96);
+            const high = averageRange(this.frequencyBins, 96, 256);
+            window.audioReactive = {
+                bass,
+                mid,
+                high
+            };
+        }
+    }
+}
+
+function averageRange(array, start, end) {
+    let sum = 0;
+    let count = 0;
+    const clampedEnd = Math.min(array.length, end);
+    for (let i = start; i < clampedEnd; i++) {
+        sum += array[i] / 255;
+        count += 1;
+    }
+    return count ? sum / count : 0;
+}

--- a/src/game/CollisionSystem.js
+++ b/src/game/CollisionSystem.js
@@ -1,0 +1,126 @@
+import { distanceSq } from './utils/Math4D.js';
+
+/**
+ * Screen-space collision grid for touch pulses and active targets.
+ */
+export class CollisionSystem {
+    constructor({ size = 32 } = {}) {
+        this.gridSize = size;
+        this.cells = new Map();
+        this.lastTargets = [];
+    }
+
+    rebuild(targets) {
+        this.cells.clear();
+        this.lastTargets = targets;
+        targets.forEach((target) => {
+            const entries = expandTarget(target);
+            entries.forEach(({ center, radius }) => {
+                const bounds = radiusBounds(center, radius, this.gridSize);
+                for (let gx = bounds.minX; gx <= bounds.maxX; gx++) {
+                    for (let gy = bounds.minY; gy <= bounds.maxY; gy++) {
+                        const key = `${gx}:${gy}`;
+                        if (!this.cells.has(key)) {
+                            this.cells.set(key, []);
+                        }
+                        this.cells.get(key).push({ target, center, radius });
+                    }
+                }
+            });
+        });
+    }
+
+    query(point, radius) {
+        const bounds = radiusBounds(point, radius, this.gridSize);
+        const candidates = [];
+        for (let gx = bounds.minX; gx <= bounds.maxX; gx++) {
+            for (let gy = bounds.minY; gy <= bounds.maxY; gy++) {
+                const key = `${gx}:${gy}`;
+                const cell = this.cells.get(key);
+                if (cell) {
+                    cell.forEach((entry) => candidates.push(entry));
+                }
+            }
+        }
+        return candidates;
+    }
+
+    resolvePulse(pulse) {
+        const hits = [];
+        const candidates = this.query(pulse.position, pulse.radius);
+        const unique = new Set();
+        candidates.forEach(({ target, center, radius }) => {
+            if (unique.has(target.id)) return;
+            if (target.type === 'lane') {
+                const dist = distanceToSegmentSq(pulse.position, target.screenA, target.screenB);
+                if (dist <= (pulse.radius + radius) * (pulse.radius + radius)) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            } else if (target.type === 'cluster') {
+                const hitChild = target.children?.find((child) => {
+                    const dist = distanceSq(child.screen, pulse.position);
+                    return dist <= Math.pow(pulse.radius + (child.radius || 0.05), 2);
+                });
+                if (hitChild) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            } else {
+                const dist = distanceSq(center, pulse.position);
+                if (dist <= Math.pow(pulse.radius + (target.radius || 0.08), 2)) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            }
+        });
+        return hits;
+    }
+}
+
+function expandTarget(target) {
+    if (target.type === 'lane') {
+        const mid = {
+            x: (target.screenA.x + target.screenB.x) / 2,
+            y: (target.screenA.y + target.screenB.y) / 2
+        };
+        return [{ center: mid, radius: target.radius || 0.05 }];
+    }
+    if (target.type === 'cluster') {
+        return (target.children || []).map((child) => ({
+            center: child.screen,
+            radius: child.radius || 0.04
+        }));
+    }
+    return [{ center: target.screen, radius: target.radius || 0.08 }];
+}
+
+function radiusBounds(center, radius, grid) {
+    const minX = Math.max(0, Math.floor((center.x - radius) * grid));
+    const minY = Math.max(0, Math.floor((center.y - radius) * grid));
+    const maxX = Math.min(grid - 1, Math.floor((center.x + radius) * grid));
+    const maxY = Math.min(grid - 1, Math.floor((center.y + radius) * grid));
+    return { minX, minY, maxX, maxY };
+}
+
+function distanceToSegmentSq(point, a, b) {
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const apx = point.x - a.x;
+    const apy = point.y - a.y;
+    const abLenSq = abx * abx + aby * aby;
+    const t = abLenSq === 0 ? 0 : Math.max(0, Math.min(1, (apx * abx + apy * aby) / abLenSq));
+    const closestX = a.x + abx * t;
+    const closestY = a.y + aby * t;
+    const dx = point.x - closestX;
+    const dy = point.y - closestY;
+    return dx * dx + dy * dy;
+}
+
+function pulseQuality(target) {
+    if (target.remaining == null) return 'good';
+    const window = Math.abs(target.remaining);
+    if (window < 0.05) return 'perfect';
+    if (window < 0.12) return 'great';
+    return 'good';
+}

--- a/src/game/EffectsManager.js
+++ b/src/game/EffectsManager.js
@@ -1,0 +1,67 @@
+/**
+ * Maintains shader-facing parameter easings for score/miss/combo feedback.
+ */
+export class EffectsManager {
+    constructor() {
+        this.scorePulse = 0;
+        this.missPulse = 0;
+        this.comboShift = 0;
+        this.perfectSnap = 0;
+        this.shield = 0;
+    }
+
+    trigger(event, detail = {}) {
+        switch (event) {
+            case 'score':
+                this.scorePulse = Math.min(1, this.scorePulse + (detail.quality === 'perfect' ? 0.8 : 0.5));
+                if (detail.quality === 'perfect') {
+                    this.perfectSnap = 1;
+                }
+                break;
+            case 'miss':
+                this.missPulse = 1;
+                break;
+            case 'combo':
+                this.comboShift = Math.min(1, this.comboShift + 0.15);
+                break;
+            case 'shield':
+                this.shield = Math.min(1, this.shield + 0.4);
+                break;
+            default:
+                break;
+        }
+    }
+
+    update(dt, params, state) {
+        const result = { ...params };
+        this.scorePulse = Math.max(0, this.scorePulse - dt * 1.8);
+        this.missPulse = Math.max(0, this.missPulse - dt * 2.2);
+        this.comboShift = Math.max(0, this.comboShift - dt * 0.5);
+        this.perfectSnap = Math.max(0, this.perfectSnap - dt * 3.5);
+        this.shield = Math.max(0, this.shield - dt * 0.4);
+
+        result.intensity += this.scorePulse * 0.25;
+        result.hue = (result.hue + this.comboShift * 40 + (state.combo % 8) * 2) % 360;
+        result.chaos += (this.scorePulse * 0.1) - (this.missPulse * 0.25);
+        result.saturation = Math.min(1, result.saturation + this.scorePulse * 0.15 - this.missPulse * 0.2);
+
+        if (state.phaseActive) {
+            result.speed *= 0.75;
+            result.intensity *= 0.9;
+        }
+
+        if (this.missPulse) {
+            result.intensity *= 0.7;
+        }
+
+        if (this.perfectSnap) {
+            result.speed *= 1 + this.perfectSnap * 0.05;
+        }
+
+        if (this.shield > 0) {
+            result.chaos *= 0.85;
+        }
+
+        return result;
+    }
+}

--- a/src/game/GameLoop.js
+++ b/src/game/GameLoop.js
@@ -1,0 +1,47 @@
+const STEP = 1 / 60;
+
+/**
+ * Deterministic fixed-step game loop with decoupled rendering.
+ */
+export class GameLoop {
+    constructor(update, render, { maxSubSteps = 5 } = {}) {
+        this.update = update;
+        this.render = render;
+        this.maxSubSteps = maxSubSteps;
+        this.accumulator = 0;
+        this.lastTime = null;
+        this.running = false;
+        this.rafId = null;
+    }
+
+    start() {
+        if (this.running) return;
+        this.running = true;
+        this.lastTime = performance.now();
+        const tick = (time) => {
+            if (!this.running) return;
+            const delta = (time - this.lastTime) / 1000;
+            this.lastTime = time;
+            this.accumulator += delta;
+            let steps = 0;
+            while (this.accumulator >= STEP && steps < this.maxSubSteps) {
+                this.update(STEP);
+                this.accumulator -= STEP;
+                steps += 1;
+            }
+            this.render();
+            this.rafId = requestAnimationFrame(tick);
+        };
+        this.rafId = requestAnimationFrame(tick);
+    }
+
+    stop() {
+        this.running = false;
+        if (this.rafId) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+        }
+    }
+}
+
+export { STEP as FIXED_STEP };

--- a/src/game/GameState.js
+++ b/src/game/GameState.js
@@ -1,0 +1,137 @@
+/**
+ * Core gameplay state: score, combo, timers, and parameter targets.
+ */
+export class GameState {
+    constructor(levelConfig) {
+        this.level = levelConfig;
+        this.score = 0;
+        this.combo = 0;
+        this.maxCombo = 0;
+        this.multiplier = 1;
+        this.lives = 3;
+        this.health = 1.0;
+        this.beatIndex = 0;
+        this.elapsedBeats = 0;
+        this.remainingBeats = levelConfig.targetBeats || 64;
+        this.pulseWindow = (levelConfig.windowMs || 150) / 1000;
+        this.phaseEnergy = 1.0;
+        this.phaseActive = false;
+        this.phaseCooldown = 0;
+        this.comboTimer = 0;
+        this.comboTimeout = 4; // seconds to maintain combo
+
+        this.parameters = {
+            geometry: levelConfig.geometryIndex ?? 0,
+            variant: levelConfig.variantIndex ?? levelConfig.geometryIndex ?? 0,
+            gridDensity: levelConfig.difficulty?.density ?? 18,
+            morphFactor: levelConfig.difficulty?.morph ?? 1.0,
+            chaos: levelConfig.difficulty?.chaos ?? 0.15,
+            speed: levelConfig.difficulty?.speed ?? 1.0,
+            hue: levelConfig.color?.hue ?? 200,
+            intensity: levelConfig.color?.intensity ?? 0.55,
+            saturation: levelConfig.color?.saturation ?? 0.85,
+            dimension: levelConfig.difficulty?.dimension ?? 3.6,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.targetParameters = { ...this.parameters };
+    }
+
+    /** Update timers each fixed tick */
+    update(dt) {
+        this.comboTimer += dt;
+        if (this.comboTimer > this.comboTimeout) {
+            this.resetCombo();
+        }
+
+        if (this.phaseActive) {
+            this.phaseEnergy = Math.max(0, this.phaseEnergy - dt * 0.45);
+            if (this.phaseEnergy <= 0) {
+                this.stopPhase();
+                this.phaseCooldown = 2.5; // seconds before next activation
+            }
+        } else if (this.phaseCooldown > 0) {
+            this.phaseCooldown = Math.max(0, this.phaseCooldown - dt);
+        } else {
+            this.phaseEnergy = Math.min(1, this.phaseEnergy + dt * 0.25);
+        }
+    }
+
+    applyParameterDelta(delta) {
+        Object.keys(delta).forEach((key) => {
+            if (key in this.targetParameters) {
+                this.targetParameters[key] += delta[key];
+            }
+        });
+    }
+
+    setTargetParameter(name, value) {
+        if (name in this.targetParameters) {
+            this.targetParameters[name] = value;
+        }
+    }
+
+    getParameters() {
+        return this.parameters;
+    }
+
+    /** Ease parameters towards targets */
+    settleParameters(dt) {
+        const ease = 8;
+        Object.keys(this.parameters).forEach((key) => {
+            const current = this.parameters[key];
+            const target = this.targetParameters[key];
+            if (typeof current === 'number' && typeof target === 'number') {
+                this.parameters[key] = current + (target - current) * Math.min(1, ease * dt);
+            }
+        });
+    }
+
+    registerBeat() {
+        this.beatIndex += 1;
+        this.elapsedBeats += 1;
+        this.remainingBeats = Math.max(0, (this.level.targetBeats || 64) - this.elapsedBeats);
+    }
+
+    registerHit(quality = 'good') {
+        this.comboTimer = 0;
+        this.combo += 1;
+        this.maxCombo = Math.max(this.maxCombo, this.combo);
+        const qualityMult = quality === 'perfect' ? 1.5 : quality === 'great' ? 1.2 : 1;
+        this.multiplier = 1 + Math.floor(this.combo / 8) * 0.25;
+        const baseScore = 100;
+        this.score += Math.floor(baseScore * qualityMult * this.multiplier);
+    }
+
+    registerMiss() {
+        this.lives = Math.max(0, this.lives - 1);
+        this.health = Math.max(0, this.health - 0.18);
+        this.resetCombo();
+    }
+
+    resetCombo() {
+        this.combo = 0;
+        this.multiplier = 1;
+        this.comboTimer = 0;
+    }
+
+    startPhase() {
+        if (this.phaseCooldown > 0 || this.phaseEnergy <= 0.2) return false;
+        this.phaseActive = true;
+        return true;
+    }
+
+    stopPhase() {
+        this.phaseActive = false;
+    }
+
+    isLevelComplete() {
+        return this.elapsedBeats >= (this.level.targetBeats || 64);
+    }
+
+    isGameOver() {
+        return this.lives <= 0;
+    }
+}

--- a/src/game/GeometryController.js
+++ b/src/game/GeometryController.js
@@ -1,0 +1,249 @@
+import { createSeededRNG } from './utils/Random.js';
+
+const FACETED_GEOMETRIES = ['TETRA', 'CUBE', 'SPHERE', 'TORUS', 'KLEIN', 'FRACTAL', 'WAVE', 'CRYSTAL'];
+const HOLO_CATEGORY_MAP = [
+    0, 0, 0, 0,
+    1, 1, 1, 1,
+    2, 2, 2, 2,
+    3, 3, 3, 3,
+    4, 4, 4, 4,
+    5, 5, 5,
+    6, 6, 6,
+    7, 7, 7, 7
+];
+
+/**
+ * Geometry-driven spawn rules and visual tweaks.
+ */
+export class GeometryController {
+    constructor(seed = 1234) {
+        this.rng = createSeededRNG(seed);
+        this.mode = 'faceted';
+        this.geometryIndex = 0;
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+    }
+
+    setGeometry(index) {
+        this.geometryIndex = index;
+    }
+
+    /**
+     * Determine geometry id across all systems.
+     */
+    getGeometryId() {
+        if (this.mode === 'holographic') {
+            const category = HOLO_CATEGORY_MAP[this.geometryIndex] ?? 0;
+            return FACETED_GEOMETRIES[Math.min(category, FACETED_GEOMETRIES.length - 1)];
+        }
+        return FACETED_GEOMETRIES[this.geometryIndex % FACETED_GEOMETRIES.length];
+    }
+
+    /**
+     * Generate spawn targets for a beat.
+     */
+    generateTargets(beat, difficulty) {
+        const geometry = this.getGeometryId();
+        const generator = GEOMETRY_GENERATORS[geometry] || GEOMETRY_GENERATORS.TETRA;
+        const density = difficulty?.density ?? 0.9;
+        const speed = difficulty?.speed ?? 1.0;
+        const chaos = difficulty?.chaos ?? 0.15;
+
+        const amount = Math.max(1, Math.round(density * (0.8 + this.rng.nextFloat())));
+        const targets = [];
+        for (let i = 0; i < amount; i++) {
+            targets.push(generator(this.rng, beat + i * 0.1, { speed, chaos }));
+        }
+        return targets;
+    }
+
+    /**
+     * Provide per-geometry parameter biases.
+     */
+    getParameterBias() {
+        const geometry = this.getGeometryId();
+        return GEOMETRY_PARAMETER_BIAS[geometry] || { hueShift: 0, chaos: 1, speed: 1 };
+    }
+}
+
+function randomSign(rng) {
+    return rng.nextFloat() > 0.5 ? 1 : -1;
+}
+
+const GEOMETRY_GENERATORS = {
+    TETRA(rng, beat) {
+        const base = 0.65;
+        return {
+            id: `tetra-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: randomSign(rng) * base,
+                y: randomSign(rng) * base,
+                z: randomSign(rng) * base,
+                w: randomSign(rng) * base
+            },
+            radius: 0.08,
+            dueBeat: beat + 1.5,
+            behavior: 'pulse'
+        };
+    },
+    CUBE(rng, beat) {
+        const axis = rng.choose(['x', 'y', 'z']);
+        const pos = {
+            x: rng.nextRange(-0.9, 0.9),
+            y: rng.nextRange(-0.9, 0.9),
+            z: rng.nextRange(-0.9, 0.9),
+            w: rng.nextRange(-0.7, 0.7)
+        };
+        const offset = rng.nextRange(0.35, 0.8);
+        const other = { ...pos };
+        other[axis] += offset;
+        pos[axis] -= offset;
+        return {
+            id: `cube-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: pos,
+            vec4b: other,
+            radius: 0.05,
+            dueBeat: beat + 1.8,
+            behavior: 'slide'
+        };
+    },
+    SPHERE(rng, beat) {
+        const theta = rng.nextRange(0, Math.PI);
+        const phi = rng.nextRange(0, Math.PI * 2);
+        const radius = 0.85;
+        return {
+            id: `sphere-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: radius * Math.sin(theta) * Math.cos(phi),
+                y: radius * Math.cos(theta),
+                z: radius * Math.sin(theta) * Math.sin(phi),
+                w: rng.nextRange(-0.4, 0.4)
+            },
+            radius: 0.09,
+            dueBeat: beat + 1.3,
+            behavior: 'orbit'
+        };
+    },
+    TORUS(rng, beat) {
+        const major = 0.75;
+        const minor = 0.25;
+        const angle = (beat * 0.9 + rng.nextFloat()) * Math.PI * 2;
+        return {
+            id: `torus-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: {
+                x: (major + minor * Math.cos(angle)) * Math.cos(angle),
+                y: minor * Math.sin(angle * 2),
+                z: (major + minor * Math.cos(angle)) * Math.sin(angle),
+                w: rng.nextRange(-0.5, 0.5)
+            },
+            vec4b: {
+                x: (major + minor * Math.cos(angle + 0.3)) * Math.cos(angle + 0.3),
+                y: minor * Math.sin((angle + 0.3) * 2),
+                z: (major + minor * Math.cos(angle + 0.3)) * Math.sin(angle + 0.3),
+                w: rng.nextRange(-0.5, 0.5)
+            },
+            radius: 0.04,
+            dueBeat: beat + 2,
+            behavior: 'belt'
+        };
+    },
+    KLEIN(rng, beat) {
+        const u = rng.nextRange(0, Math.PI * 2);
+        const v = rng.nextRange(0, Math.PI * 2);
+        const r = 0.4;
+        const cosU = Math.cos(u);
+        const sinU = Math.sin(u);
+        const cosV = Math.cos(v);
+        const sinV = Math.sin(v);
+        const x = (r + cosU / 2) * cosV;
+        const y = (r + cosU / 2) * sinV;
+        const z = sinU / 2;
+        const w = Math.sin(u) * Math.cos(v);
+        return {
+            id: `klein-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: { x, y, z, w },
+            radius: 0.07,
+            dueBeat: beat + 1.6,
+            behavior: 'invert'
+        };
+    },
+    FRACTAL(rng, beat) {
+        const depth = rng.nextInt(2, 5);
+        const scale = 0.5 / depth;
+        const offsets = [rng.nextRange(-1, 1), rng.nextRange(-1, 1), rng.nextRange(-1, 1)];
+        return {
+            id: `fractal-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'cluster',
+            children: Array.from({ length: depth * 2 }, (_, idx) => ({
+                vec4: {
+                    x: offsets[0] + scale * ((idx % 2) ? 1 : -1),
+                    y: offsets[1] + scale * ((idx & 2) ? 1 : -1),
+                    z: offsets[2] + scale * ((idx & 4) ? 1 : -1),
+                    w: rng.nextRange(-0.6, 0.6)
+                },
+                radius: 0.04
+            })),
+            dueBeat: beat + 2.2,
+            radius: 0.04,
+            behavior: 'chain'
+        };
+    },
+    WAVE(rng, beat) {
+        const phase = beat * 0.5 + rng.nextRange(0, Math.PI * 2);
+        const amplitude = 0.7;
+        return {
+            id: `wave-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: {
+                x: -0.9,
+                y: Math.sin(phase) * amplitude,
+                z: Math.cos(phase * 1.2) * 0.4,
+                w: Math.sin(phase * 0.7) * 0.4
+            },
+            vec4b: {
+                x: 0.9,
+                y: Math.sin(phase + 0.5) * amplitude,
+                z: Math.cos((phase + 0.5) * 1.2) * 0.4,
+                w: Math.sin((phase + 0.5) * 0.7) * 0.4
+            },
+            radius: 0.05,
+            dueBeat: beat + 1.4,
+            behavior: 'sweep'
+        };
+    },
+    CRYSTAL(rng, beat) {
+        const spikeDir = rng.nextRange(0, Math.PI * 2);
+        const height = rng.nextRange(0.4, 0.9);
+        return {
+            id: `crystal-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: Math.cos(spikeDir) * 0.4,
+                y: height,
+                z: Math.sin(spikeDir) * 0.4,
+                w: rng.nextRange(-0.3, 0.3)
+            },
+            radius: 0.06,
+            dueBeat: beat + 1.7,
+            behavior: 'shard'
+        };
+    }
+};
+
+const GEOMETRY_PARAMETER_BIAS = {
+    TETRA: { hueShift: 0, chaos: 0.8, speed: 1.05 },
+    CUBE: { hueShift: 12, chaos: 1.0, speed: 1.0 },
+    SPHERE: { hueShift: 48, chaos: 0.9, speed: 0.95 },
+    TORUS: { hueShift: 84, chaos: 1.1, speed: 1.1 },
+    KLEIN: { hueShift: 132, chaos: 1.3, speed: 0.9 },
+    FRACTAL: { hueShift: 210, chaos: 1.5, speed: 0.85 },
+    WAVE: { hueShift: 280, chaos: 1.2, speed: 1.2 },
+    CRYSTAL: { hueShift: 320, chaos: 0.75, speed: 0.9 }
+};

--- a/src/game/InputMapping.js
+++ b/src/game/InputMapping.js
@@ -1,0 +1,172 @@
+/**
+ * Maps touch + pointer gestures into high-level events for the game.
+ */
+export class InputMapping {
+    constructor(element, { planes = ['XW', 'YW'] } = {}) {
+        this.element = element;
+        this.planes = planes;
+        this.listeners = new Map();
+        this.pulses = [];
+        this.activePointers = new Map();
+        this.initialPinchDistance = null;
+        this.lastTilt = { beta: 0, gamma: 0 };
+
+        ['rotate', 'pulse', 'pinch', 'longpressstart', 'longpressend', 'tilt'].forEach((evt) => {
+            this.listeners.set(evt, new Set());
+        });
+
+        this.element.addEventListener('pointerdown', (e) => this.onPointerDown(e));
+        this.element.addEventListener('pointermove', (e) => this.onPointerMove(e));
+        this.element.addEventListener('pointerup', (e) => this.onPointerUp(e));
+        this.element.addEventListener('pointercancel', (e) => this.onPointerCancel(e));
+        this.element.addEventListener('pointerout', (e) => this.onPointerCancel(e));
+
+        this.setupTilt();
+    }
+
+    on(event, callback) {
+        const set = this.listeners.get(event);
+        if (!set) return () => {};
+        set.add(callback);
+        return () => set.delete(callback);
+    }
+
+    emit(event, detail) {
+        const set = this.listeners.get(event);
+        if (!set) return;
+        set.forEach((callback) => callback(detail));
+    }
+
+    onPointerDown(event) {
+        this.element.setPointerCapture?.(event.pointerId);
+        const pointer = this.createPointerState(event);
+        this.activePointers.set(event.pointerId, pointer);
+        pointer.longPressTimeout = setTimeout(() => {
+            pointer.longPressed = true;
+            this.emit('longpressstart', { position: pointer.position });
+        }, 450);
+    }
+
+    onPointerMove(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (!pointer) return;
+        const prevPos = pointer.position;
+        pointer.position = this.normalizePosition(event);
+        pointer.deltaX += pointer.position.x - prevPos.x;
+        pointer.deltaY += pointer.position.y - prevPos.y;
+
+        if (this.activePointers.size === 2) {
+            this.handlePinch();
+        } else {
+            this.emit('rotate', {
+                deltaX: pointer.position.x - prevPos.x,
+                deltaY: pointer.position.y - prevPos.y,
+                plane: this.planes[0]
+            });
+        }
+    }
+
+    onPointerUp(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (!pointer) return;
+        clearTimeout(pointer.longPressTimeout);
+
+        const elapsed = performance.now() - pointer.startTime;
+        const moved = Math.hypot(pointer.deltaX, pointer.deltaY);
+
+        if (pointer.longPressed) {
+            this.emit('longpressend', {});
+        } else if (elapsed < 250 && moved < 0.03) {
+            // tap -> pulse
+            const pulse = {
+                position: pointer.position,
+                radius: 0.1,
+                timestamp: performance.now()
+            };
+            this.pulses.push(pulse);
+            this.emit('pulse', pulse);
+        } else {
+            this.emit('rotate', {
+                deltaX: pointer.deltaX,
+                deltaY: pointer.deltaY,
+                plane: this.planes[1] || this.planes[0]
+            });
+        }
+
+        this.activePointers.delete(event.pointerId);
+        if (this.activePointers.size < 2) {
+            this.initialPinchDistance = null;
+        }
+    }
+
+    onPointerCancel(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (pointer) {
+            clearTimeout(pointer.longPressTimeout);
+        }
+        this.activePointers.delete(event.pointerId);
+    }
+
+    handlePinch() {
+        const pointers = Array.from(this.activePointers.values());
+        if (pointers.length !== 2) return;
+        const [a, b] = pointers;
+        const dx = a.position.x - b.position.x;
+        const dy = a.position.y - b.position.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (this.initialPinchDistance == null) {
+            this.initialPinchDistance = distance;
+            return;
+        }
+        const scale = distance / (this.initialPinchDistance || 0.0001);
+        this.emit('pinch', { scaleDelta: scale - 1 });
+        this.initialPinchDistance = distance;
+    }
+
+    setupTilt() {
+        if (typeof DeviceOrientationEvent === 'undefined') return;
+        const handler = (event) => {
+            this.lastTilt = { beta: event.beta || 0, gamma: event.gamma || 0 };
+            this.emit('tilt', this.lastTilt);
+        };
+        if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+            window.addEventListener('click', async () => {
+                try {
+                    const res = await DeviceOrientationEvent.requestPermission();
+                    if (res === 'granted') {
+                        window.addEventListener('deviceorientation', handler);
+                    }
+                } catch (err) {
+                    console.warn('Tilt permission denied', err);
+                }
+            }, { once: true });
+        } else {
+            window.addEventListener('deviceorientation', handler);
+        }
+    }
+
+    createPointerState(event) {
+        return {
+            startTime: performance.now(),
+            position: this.normalizePosition(event),
+            deltaX: 0,
+            deltaY: 0,
+            longPressTimeout: null,
+            longPressed: false
+        };
+    }
+
+    normalizePosition(event) {
+        const rect = this.element.getBoundingClientRect();
+        return {
+            x: (event.clientX - rect.left) / rect.width,
+            y: (event.clientY - rect.top) / rect.height
+        };
+    }
+
+    consumePulses() {
+        const output = this.pulses.slice();
+        this.pulses.length = 0;
+        return output;
+    }
+}

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -1,0 +1,285 @@
+import { GameLoop } from './GameLoop.js';
+import { AudioService } from './AudioService.js';
+import { ModeController } from './ModeController.js';
+import { GeometryController } from './GeometryController.js';
+import { SpawnSystem } from './SpawnSystem.js';
+import { CollisionSystem } from './CollisionSystem.js';
+import { InputMapping } from './InputMapping.js';
+import { EffectsManager } from './EffectsManager.js';
+import { PerformanceController } from './PerformanceController.js';
+import { LevelManager } from './LevelManager.js';
+import { GameState } from './GameState.js';
+import { LocalPersistence } from './persistence/LocalPersistence.js';
+import { HUDRenderer } from './ui/HUDRenderer.js';
+
+let canvasRoot;
+let inputLayer;
+let hudRoot;
+let startScreen;
+let startButton;
+let modeController;
+let audioService;
+let geometryController;
+let spawnSystem;
+let collisionSystem;
+let inputMapping;
+let effectsManager;
+let performanceController;
+let levelManager;
+let persistence;
+let hud;
+let gameState;
+let currentLevel;
+let gameLoop;
+let awaitingStart = true;
+let startButtonAction = null;
+
+window.audioReactive = { bass: 0, mid: 0, high: 0 };
+
+function ready(fn) {
+    if (document.readyState !== 'loading') {
+        fn();
+    } else {
+        document.addEventListener('DOMContentLoaded', fn);
+    }
+}
+
+ready(async () => {
+    canvasRoot = document.getElementById('lp-canvas-root');
+    inputLayer = document.getElementById('lp-input-layer');
+    hudRoot = document.getElementById('lp-hud');
+    startScreen = document.getElementById('lp-start-screen');
+    startButton = document.getElementById('lp-start-button');
+    startButton.addEventListener('click', handleStartButton);
+
+    persistence = new LocalPersistence();
+    modeController = new ModeController(canvasRoot);
+    audioService = new AudioService();
+    collisionSystem = new CollisionSystem();
+    effectsManager = new EffectsManager();
+    performanceController = new PerformanceController((lod) => modeController.applyLOD(lod));
+    hud = new HUDRenderer(hudRoot, persistence);
+    inputMapping = new InputMapping(inputLayer);
+
+    levelManager = new LevelManager();
+    const levels = await levelManager.load();
+    currentLevel = levels[0];
+
+    await configureLevel(currentLevel);
+    startScreen.querySelector('.lp-start-title').textContent = 'Lattice Pulse';
+    startScreen.querySelector('.lp-start-subtitle').textContent = `First up: ${currentLevel.id}`;
+    startButton.textContent = 'Start';
+
+    setupInput();
+    setupAudioCallbacks();
+
+    const update = (dt) => {
+        if (awaitingStart) return;
+        audioService.update(dt);
+        gameState.update(dt);
+        gameState.settleParameters(dt);
+
+        const biasedParams = applyGeometryBias(gameState.getParameters(), geometryController.getParameterBias());
+        const finalParams = clampParameters(effectsManager.update(dt, biasedParams, gameState));
+        const aspect = canvasRoot.clientWidth / canvasRoot.clientHeight;
+        const { expiredTargets } = spawnSystem.update(dt, finalParams, aspect);
+        collisionSystem.rebuild(spawnSystem.getActiveTargets());
+
+        processPulses();
+        handleExpired(expiredTargets);
+
+        modeController.updateParameters(finalParams);
+        hud.update(gameState);
+        checkLevelEnd();
+    };
+
+    const render = () => {
+        performanceController.beginFrame();
+        modeController.render();
+        performanceController.endFrame();
+    };
+
+    gameLoop = new GameLoop(update, render);
+
+    startButtonAction = async () => {
+        if (!awaitingStart) return;
+        awaitingStart = false;
+        startScreen.classList.add('hidden');
+        await audioService.start();
+        hud.setStatus('Ride the lattice. Tap beats, swipe space.');
+        gameLoop.start();
+    };
+});
+
+async function handleStartButton() {
+    if (typeof startButtonAction === 'function') {
+        await startButtonAction();
+    }
+}
+
+function setupInput() {
+    inputMapping.on('rotate', ({ deltaX, deltaY }) => {
+        const factor = 3.0;
+        gameState.applyParameterDelta({
+            rot4dXW: deltaY * factor,
+            rot4dYW: deltaX * factor
+        });
+    });
+
+    inputMapping.on('pinch', ({ scaleDelta }) => {
+        gameState.applyParameterDelta({ dimension: scaleDelta * 1.2 });
+    });
+
+    inputMapping.on('pulse', () => {
+        gameState.applyParameterDelta({ intensity: 0.05 });
+    });
+
+    inputMapping.on('longpressstart', () => {
+        if (gameState.startPhase()) {
+            effectsManager.trigger('shield');
+            hud.flash('Phase Shift');
+        }
+    });
+
+    inputMapping.on('longpressend', () => {
+        gameState.stopPhase();
+    });
+
+    inputMapping.on('tilt', ({ beta, gamma }) => {
+        const tiltX = gamma / 180;
+        const tiltY = beta / 180;
+        gameState.applyParameterDelta({ rot4dXW: tiltY * 0.02, rot4dYW: tiltX * 0.02 });
+    });
+}
+
+function setupAudioCallbacks() {
+    audioService.onBeat((beatInfo) => {
+        if (awaitingStart) return;
+        spawnSystem.handleBeat(beatInfo);
+        gameState.registerBeat();
+    });
+}
+
+function processPulses() {
+    const pulses = inputMapping.consumePulses();
+    pulses.forEach((pulse) => {
+        pulse.radius = 0.08 + gameState.pulseWindow * 0.6;
+        const hits = collisionSystem.resolvePulse(pulse);
+        if (hits.length) {
+            hits.forEach(({ target, quality }) => {
+                spawnSystem.removeTarget(target.id);
+                gameState.registerHit(quality);
+                effectsManager.trigger('score', { quality });
+            });
+            collisionSystem.rebuild(spawnSystem.getActiveTargets());
+        } else {
+            gameState.registerMiss();
+            effectsManager.trigger('miss');
+            hud.flash('Miss');
+        }
+    });
+}
+
+function handleExpired(expiredTargets) {
+    expiredTargets.forEach(() => {
+        gameState.registerMiss();
+        effectsManager.trigger('miss');
+    });
+}
+
+async function configureLevel(level) {
+    geometryController = new GeometryController(level.seed || Math.floor(Math.random() * 10000));
+    geometryController.setMode(level.system);
+    geometryController.setGeometry(level.geometryIndex || 0);
+    spawnSystem = new SpawnSystem(geometryController);
+    spawnSystem.setDifficulty(level.difficulty || {});
+    gameState = new GameState(level);
+    modeController.setActiveMode(level.system);
+    modeController.setVariant(level.variantIndex ?? level.geometryIndex ?? 0);
+    modeController.resize();
+    hud.setLevel(level);
+
+    await audioService.loadTrack({ url: level.track?.url || null, bpm: level.bpm });
+    audioService.setBPM(level.bpm);
+}
+
+function checkLevelEnd() {
+    if (gameState.isGameOver()) {
+        awaitingStart = true;
+        hud.setStatus('Try again. Tap to restart.', 'alert');
+        audioService.stop();
+        gameLoop.stop();
+        startScreen.classList.remove('hidden');
+        startScreen.querySelector('.lp-start-title').textContent = 'Try Again';
+        startButton.textContent = 'Restart';
+        startScreen.querySelector('.lp-start-subtitle').textContent = 'Resetting the lattice...';
+        startButtonAction = async () => {
+            startScreen.classList.add('hidden');
+            awaitingStart = false;
+            gameState = new GameState(currentLevel);
+            spawnSystem.reset();
+            await audioService.start();
+            hud.setStatus('Stay in phase.');
+            gameLoop.start();
+        };
+        return;
+    }
+
+    if (gameState.isLevelComplete()) {
+        const isRecord = persistence.recordScore(currentLevel.id, gameState.score, gameState.maxCombo);
+        if (isRecord) {
+            hud.flash('New Record!');
+            hud.setLevel(currentLevel);
+        } else {
+            hud.flash('Level Clear!');
+        }
+        const nextLevel = levelManager.nextLevel();
+        currentLevel = nextLevel;
+        awaitingStart = true;
+        audioService.stop();
+        gameLoop.stop();
+        configureLevel(nextLevel).then(() => {
+            startScreen.classList.remove('hidden');
+            startScreen.querySelector('.lp-start-title').textContent = 'Next Level';
+            startScreen.querySelector('.lp-start-subtitle').textContent = `Up next: ${nextLevel.id}`;
+            startButton.textContent = 'Launch';
+            startButtonAction = async () => {
+                awaitingStart = false;
+                startScreen.classList.add('hidden');
+                await audioService.start();
+                hud.setStatus('Sync with the beat lattice.');
+                gameLoop.start();
+            };
+        });
+    }
+}
+
+function applyGeometryBias(params, bias) {
+    const result = { ...params };
+    if (!bias) return result;
+    result.hue = (result.hue + bias.hueShift) % 360;
+    result.chaos *= bias.chaos;
+    result.speed *= bias.speed;
+    return result;
+}
+
+function clampParameters(params) {
+    return {
+        ...params,
+        gridDensity: clamp(params.gridDensity, 5, 90),
+        morphFactor: clamp(params.morphFactor, 0, 2),
+        chaos: clamp(params.chaos, 0, 1.5),
+        speed: clamp(params.speed, 0.3, 3.2),
+        hue: ((params.hue % 360) + 360) % 360,
+        intensity: clamp(params.intensity, 0.1, 1.2),
+        saturation: clamp(params.saturation, 0, 1),
+        dimension: clamp(params.dimension, 3.0, 4.5),
+        rot4dXW: clamp(params.rot4dXW, -2.5, 2.5),
+        rot4dYW: clamp(params.rot4dYW, -2.5, 2.5),
+        rot4dZW: clamp(params.rot4dZW, -2.5, 2.5)
+    };
+}
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}

--- a/src/game/LevelManager.js
+++ b/src/game/LevelManager.js
@@ -1,0 +1,79 @@
+/**
+ * Loads seedable level presets and advances through the campaign graph.
+ */
+export class LevelManager {
+    constructor() {
+        this.levels = [];
+        this.currentIndex = 0;
+        this.loaded = false;
+    }
+
+    async load() {
+        const levelFiles = [
+            'lvl-01-faceted-torus.json',
+            'lvl-02-quantum-sphere.json',
+            'lvl-03-holographic-crystal.json'
+        ];
+        const loadedLevels = [];
+        for (const file of levelFiles) {
+            try {
+                const url = new URL(`./levels/${file}`, import.meta.url);
+                const response = await fetch(url);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const data = await response.json();
+                loadedLevels.push(data);
+            } catch (err) {
+                console.warn(`LevelManager: failed to load ${file}`, err);
+            }
+        }
+        if (loadedLevels.length === 0) {
+            console.warn('LevelManager: Falling back to default inline level.');
+            loadedLevels.push(defaultLevel());
+        }
+        this.levels = loadedLevels;
+        this.loaded = true;
+        return this.levels;
+    }
+
+    getCurrentLevel() {
+        return this.levels[this.currentIndex];
+    }
+
+    nextLevel() {
+        this.currentIndex = (this.currentIndex + 1) % this.levels.length;
+        return this.getCurrentLevel();
+    }
+
+    reset() {
+        this.currentIndex = 0;
+    }
+}
+
+function defaultLevel() {
+    return {
+        id: 'fallback-faceted',
+        system: 'faceted',
+        geometryIndex: 3,
+        track: {
+            url: null,
+            id: 'metronome'
+        },
+        bpm: 120,
+        seed: 1024,
+        planes: ['XW', 'YW'],
+        windowMs: 160,
+        spawn: { pattern: 'belt', density: 0.8 },
+        powerups: ['pulse+'],
+        targetBeats: 64,
+        difficulty: {
+            speed: 1.0,
+            chaos: 0.15,
+            density: 1.0
+        },
+        color: {
+            hue: 210,
+            intensity: 0.55,
+            saturation: 0.85
+        }
+    };
+}

--- a/src/game/ModeController.js
+++ b/src/game/ModeController.js
@@ -1,0 +1,225 @@
+import { IntegratedHolographicVisualizer } from '../core/Visualizer.js';
+import { QuantumHolographicVisualizer } from '../quantum/QuantumVisualizer.js';
+import { HolographicVisualizer } from '../holograms/HolographicVisualizer.js';
+
+const LAYERS = [
+    { role: 'background', reactivity: 0.5 },
+    { role: 'shadow', reactivity: 0.7 },
+    { role: 'content', reactivity: 0.9 },
+    { role: 'highlight', reactivity: 1.1 },
+    { role: 'accent', reactivity: 1.45 }
+];
+
+const MODE_CONFIG = {
+    faceted: IntegratedHolographicVisualizer,
+    quantum: QuantumHolographicVisualizer,
+    holographic: HolographicVisualizer
+};
+
+/**
+ * Instantiates and coordinates the visualizer stack per mode.
+ */
+export class ModeController {
+    constructor(rootElement) {
+        this.root = rootElement;
+        this.modes = new Map();
+        this.activeMode = null;
+        this.currentVariant = 0;
+        this.lodBias = 0;
+        this.lastParameters = null;
+        this.resizeHandler = () => this.resize();
+
+        Object.entries(MODE_CONFIG).forEach(([modeName, Visualizer]) => {
+            this.createMode(modeName, Visualizer);
+        });
+
+        window.addEventListener('resize', this.resizeHandler, { passive: true });
+        this.setActiveMode('faceted');
+    }
+
+    createMode(name, VisualizerClass) {
+        const container = document.createElement('div');
+        container.className = 'lp-mode-stage';
+        container.dataset.mode = name;
+        container.style.visibility = 'hidden';
+        container.style.opacity = '0';
+        this.root.appendChild(container);
+
+        this.modes.set(name, {
+            container,
+            VisualizerClass,
+            layers: [],
+            params: null,
+            variant: this.currentVariant,
+            initialized: false
+        });
+    }
+
+    setActiveMode(name) {
+        if (!this.modes.has(name)) return;
+        const targetMode = this.ensureModeInitialized(name);
+        this.modes.forEach((mode, key) => {
+            const isActive = key === name;
+            mode.container.classList.toggle('active', isActive);
+            mode.container.style.visibility = isActive ? 'visible' : 'hidden';
+            mode.container.style.opacity = isActive ? '1' : '0';
+        });
+        this.activeMode = name;
+        if (targetMode && this.lastParameters) {
+            this.updateParameters(this.lastParameters);
+        }
+    }
+
+    getActiveMode() {
+        return this.activeMode;
+    }
+
+    setVariant(variant) {
+        this.currentVariant = variant;
+        this.modes.forEach((mode) => {
+            mode.variant = variant;
+            if (!mode.initialized) return;
+            mode.layers.forEach(({ visualizer }) => {
+                visualizer.variant = variant;
+                if (typeof visualizer.generateVariantParams === 'function') {
+                    visualizer.variantParams = visualizer.generateVariantParams(variant);
+                    if (typeof visualizer.generateRoleParams === 'function') {
+                        visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
+                    }
+                }
+                if (typeof visualizer.updateParameters === 'function') {
+                    visualizer.updateParameters({ geometry: variant % 8 });
+                }
+            });
+        });
+    }
+
+    updateParameters(params) {
+        this.lastParameters = params;
+        const active = this.ensureModeInitialized(this.activeMode);
+        if (!active) return;
+        active.params = params;
+        const adjusted = paramsWithLod(params, this.lodBias);
+        active.layers.forEach(({ visualizer }) => {
+            if (typeof visualizer.updateParameters === 'function') {
+                visualizer.updateParameters(adjusted);
+            }
+        });
+    }
+
+    render() {
+        const active = this.ensureModeInitialized(this.activeMode);
+        if (!active) return;
+        active.layers.forEach(({ visualizer }) => {
+            if (typeof visualizer.render === 'function') {
+                visualizer.render();
+            }
+        });
+    }
+
+    applyLOD(level) {
+        this.lodBias = level;
+        if (this.lastParameters) {
+            this.updateParameters(this.lastParameters);
+        }
+    }
+
+    resize() {
+        this.modes.forEach((mode) => {
+            if (!mode.initialized) return;
+            mode.layers.forEach(({ canvas, visualizer }) => {
+                const dpr = Math.min(window.devicePixelRatio || 1, 2);
+                const width = canvas.clientWidth || mode.container.clientWidth || this.root.clientWidth || window.innerWidth;
+                const height = canvas.clientHeight || mode.container.clientHeight || this.root.clientHeight || window.innerHeight;
+                if (!width || !height) return;
+                const bufferWidth = Math.floor(width * dpr);
+                const bufferHeight = Math.floor(height * dpr);
+                if (canvas.width !== bufferWidth || canvas.height !== bufferHeight) {
+                    canvas.width = bufferWidth;
+                    canvas.height = bufferHeight;
+                }
+                if (visualizer && typeof visualizer.resize === 'function') {
+                    visualizer.resize();
+                } else if (visualizer?.gl) {
+                    visualizer.gl.viewport(0, 0, canvas.width, canvas.height);
+                }
+            });
+        });
+    }
+
+    ensureModeInitialized(name) {
+        const mode = this.modes.get(name);
+        if (!mode || mode.initialized) {
+            return mode;
+        }
+
+        mode.layers = LAYERS.map((layer, index) => {
+            const canvas = document.createElement('canvas');
+            canvas.id = `lp-${name}-${index}`;
+            canvas.className = 'lp-canvas-layer';
+            mode.container.appendChild(canvas);
+            const visualizer = new mode.VisualizerClass(canvas.id, layer.role, layer.reactivity, this.currentVariant);
+
+            if (typeof visualizer.generateVariantParams === 'function') {
+                visualizer.variantParams = visualizer.generateVariantParams(this.currentVariant);
+                if (typeof visualizer.generateRoleParams === 'function') {
+                    visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
+                }
+            }
+
+            if (typeof visualizer.updateParameters === 'function') {
+                visualizer.updateParameters({ geometry: this.currentVariant % 8 });
+            }
+
+            return { canvas, visualizer, layer };
+        });
+
+        mode.initialized = true;
+        mode.variant = this.currentVariant;
+
+        this.resizeMode(mode);
+
+        if (this.lastParameters) {
+            const adjusted = paramsWithLod(this.lastParameters, this.lodBias);
+            mode.layers.forEach(({ visualizer }) => {
+                if (typeof visualizer.updateParameters === 'function') {
+                    visualizer.updateParameters(adjusted);
+                }
+            });
+        }
+
+        return mode;
+    }
+
+    resizeMode(mode) {
+        if (!mode.initialized) return;
+        const dpr = Math.min(window.devicePixelRatio || 1, 2);
+        mode.layers.forEach(({ canvas, visualizer }) => {
+            const width = canvas.clientWidth || mode.container.clientWidth || this.root.clientWidth || window.innerWidth;
+            const height = canvas.clientHeight || mode.container.clientHeight || this.root.clientHeight || window.innerHeight;
+            if (!width || !height) return;
+            const bufferWidth = Math.floor(width * dpr);
+            const bufferHeight = Math.floor(height * dpr);
+            if (canvas.width !== bufferWidth || canvas.height !== bufferHeight) {
+                canvas.width = bufferWidth;
+                canvas.height = bufferHeight;
+            }
+            if (visualizer && typeof visualizer.resize === 'function') {
+                visualizer.resize();
+            } else if (visualizer?.gl) {
+                visualizer.gl.viewport(0, 0, canvas.width, canvas.height);
+            }
+        });
+    }
+}
+
+function paramsWithLod(params, lodBias) {
+    if (!lodBias) return params;
+    const factor = Math.max(0.4, 1 - 0.25 * lodBias);
+    return {
+        ...params,
+        gridDensity: params.gridDensity * factor,
+        chaos: params.chaos * factor,
+        intensity: params.intensity * (1 - 0.1 * lodBias)
+    };
+}

--- a/src/game/PerformanceController.js
+++ b/src/game/PerformanceController.js
@@ -1,0 +1,41 @@
+/**
+ * Monitors render frame times and requests LOD adjustments when needed.
+ */
+export class PerformanceController {
+    constructor(callback) {
+        this.callback = callback;
+        this.samples = [];
+        this.windowSize = 90;
+        this.currentLevel = 0; // 0 = high, 1 = medium, 2 = low
+        this.frameStart = 0;
+    }
+
+    beginFrame() {
+        this.frameStart = performance.now();
+    }
+
+    endFrame() {
+        if (!this.frameStart) return;
+        const duration = performance.now() - this.frameStart;
+        this.samples.push(duration);
+        if (this.samples.length >= this.windowSize) {
+            const avgDuration = this.samples.reduce((acc, val) => acc + val, 0) / this.samples.length;
+            const fps = 1000 / avgDuration;
+            let targetLevel = this.currentLevel;
+            if (fps < 48) {
+                targetLevel = 2;
+            } else if (fps < 55) {
+                targetLevel = Math.max(targetLevel, 1);
+            } else if (fps > 58 && this.currentLevel > 0) {
+                targetLevel = this.currentLevel - 1;
+            }
+            if (targetLevel !== this.currentLevel) {
+                this.currentLevel = targetLevel;
+                if (this.callback) {
+                    this.callback(targetLevel);
+                }
+            }
+            this.samples.length = 0;
+        }
+    }
+}

--- a/src/game/SpawnSystem.js
+++ b/src/game/SpawnSystem.js
@@ -1,0 +1,102 @@
+import { project4DToScreen } from './utils/Math4D.js';
+
+/**
+ * Beat-driven spawn manager. Keeps targets in deterministic order and
+ * computes their projected positions for collision tests.
+ */
+export class SpawnSystem {
+    constructor(geometryController) {
+        this.geometryController = geometryController;
+        this.targets = [];
+        this.newTargets = [];
+        this.expiredTargets = [];
+        this.aspect = 1;
+        this.currentInterval = 0.5;
+        this.difficulty = { density: 1, speed: 1, chaos: 0.2 };
+        this.lastParams = null;
+    }
+
+    setDifficulty(difficulty) {
+        this.difficulty = { ...this.difficulty, ...difficulty };
+    }
+
+    handleBeat(beatInfo) {
+        this.currentInterval = beatInfo.interval;
+        const spawnDefs = this.geometryController.generateTargets(beatInfo.beat, this.difficulty);
+        spawnDefs.forEach((def) => {
+            const beatsAhead = Math.max(1, def.dueBeat - beatInfo.beat);
+            const timeToImpact = beatsAhead * beatInfo.interval;
+            this.targets.push({
+                ...def,
+                state: 'incoming',
+                timer: 0,
+                timeToImpact,
+                lifespan: timeToImpact + beatInfo.interval * 1.25,
+                screenA: null,
+                screenB: null,
+                children: def.children ? def.children.map((child) => ({ ...child, timer: 0 })) : null
+            });
+        });
+    }
+
+    update(dt, params, aspect) {
+        this.lastParams = params;
+        this.aspect = aspect;
+        this.newTargets.length = 0;
+        this.expiredTargets.length = 0;
+
+        const remaining = [];
+        this.targets.forEach((target) => {
+            target.timer += dt;
+            if (target.children) {
+                target.children.forEach((child) => {
+                    child.timer += dt;
+                    child.screen = project4DToScreen(child.vec4, params, aspect);
+                    child.alpha = Math.min(1, child.timer / target.timeToImpact);
+                });
+            }
+
+            if (target.state === 'incoming' && target.timer > target.timeToImpact * 0.35) {
+                target.state = 'active';
+                this.newTargets.push(target);
+            }
+
+            target.remaining = target.timeToImpact - target.timer;
+            if (target.type === 'lane') {
+                target.screenA = project4DToScreen(target.vec4, params, aspect);
+                target.screenB = project4DToScreen(target.vec4b, params, aspect);
+            } else if (target.type === 'cluster') {
+                // cluster uses children already projected
+            } else {
+                target.screen = project4DToScreen(target.vec4, params, aspect);
+            }
+
+            if (target.timer > target.lifespan) {
+                target.state = 'expired';
+                this.expiredTargets.push(target);
+            } else {
+                remaining.push(target);
+            }
+        });
+        this.targets = remaining;
+        return {
+            newTargets: this.newTargets,
+            expiredTargets: this.expiredTargets
+        };
+    }
+
+    getActiveTargets() {
+        return this.targets.filter((t) => t.state === 'active');
+    }
+
+    removeTarget(id) {
+        const index = this.targets.findIndex((t) => t.id === id);
+        if (index >= 0) {
+            this.targets.splice(index, 1);
+        }
+    }
+
+    reset() {
+        this.targets.length = 0;
+    }
+}

--- a/src/game/levels/lvl-01-faceted-torus.json
+++ b/src/game/levels/lvl-01-faceted-torus.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-01-faceted-torus",
+  "system": "faceted",
+  "geometryIndex": 3,
+  "variantIndex": 12,
+  "track": {
+    "id": "suno:track_001",
+    "url": null
+  },
+  "bpm": 128,
+  "seed": 4711,
+  "planes": ["XW", "YW"],
+  "windowMs": 150,
+  "spawn": { "pattern": "belt", "density": 0.85 },
+  "powerups": ["pulse+"],
+  "targetBeats": 64,
+  "difficulty": {
+    "speed": 1.0,
+    "chaos": 0.12,
+    "density": 0.95
+  },
+  "color": {
+    "hue": 210,
+    "intensity": 0.6,
+    "saturation": 0.88
+  }
+}

--- a/src/game/levels/lvl-02-quantum-sphere.json
+++ b/src/game/levels/lvl-02-quantum-sphere.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-02-quantum-sphere",
+  "system": "quantum",
+  "geometryIndex": 2,
+  "variantIndex": 10,
+  "track": {
+    "id": "suno:track_009",
+    "url": null
+  },
+  "bpm": 140,
+  "seed": 9913,
+  "planes": ["XW", "ZW"],
+  "windowMs": 140,
+  "spawn": { "pattern": "orbit", "density": 1.05 },
+  "powerups": ["phase"],
+  "targetBeats": 72,
+  "difficulty": {
+    "speed": 1.15,
+    "chaos": 0.22,
+    "density": 1.1
+  },
+  "color": {
+    "hue": 32,
+    "intensity": 0.7,
+    "saturation": 0.92
+  }
+}

--- a/src/game/levels/lvl-03-holographic-crystal.json
+++ b/src/game/levels/lvl-03-holographic-crystal.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-03-holographic-crystal",
+  "system": "holographic",
+  "geometryIndex": 28,
+  "variantIndex": 28,
+  "track": {
+    "id": "suno:track_024",
+    "url": null
+  },
+  "bpm": 110,
+  "seed": 2048,
+  "planes": ["YW", "ZW"],
+  "windowMs": 170,
+  "spawn": { "pattern": "shard", "density": 0.9 },
+  "powerups": ["pulse+", "phase"],
+  "targetBeats": 80,
+  "difficulty": {
+    "speed": 0.95,
+    "chaos": 0.28,
+    "density": 1.0
+  },
+  "color": {
+    "hue": 320,
+    "intensity": 0.65,
+    "saturation": 0.9
+  }
+}

--- a/src/game/persistence/LocalPersistence.js
+++ b/src/game/persistence/LocalPersistence.js
@@ -1,0 +1,61 @@
+const STORAGE_KEY = 'latticePulseProgress';
+
+export class LocalPersistence {
+    constructor() {
+        this.state = {
+            highScores: {},
+            settings: {
+                audio: true,
+                tilt: false
+            }
+        };
+        this.load();
+    }
+
+    load() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                this.state = { ...this.state, ...parsed };
+            }
+        } catch (err) {
+            console.warn('LocalPersistence: failed to load state', err);
+        }
+    }
+
+    save() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.state));
+        } catch (err) {
+            console.warn('LocalPersistence: failed to save state', err);
+        }
+    }
+
+    recordScore(levelId, score, combo) {
+        const existing = this.state.highScores[levelId];
+        if (!existing || score > existing.score) {
+            this.state.highScores[levelId] = {
+                score,
+                combo,
+                timestamp: Date.now()
+            };
+            this.save();
+            return true;
+        }
+        return false;
+    }
+
+    getBestScore(levelId) {
+        return this.state.highScores[levelId] || null;
+    }
+
+    updateSettings(updates) {
+        this.state.settings = { ...this.state.settings, ...updates };
+        this.save();
+    }
+
+    getSettings() {
+        return this.state.settings;
+    }
+}

--- a/src/game/ui/HUDRenderer.js
+++ b/src/game/ui/HUDRenderer.js
@@ -1,0 +1,78 @@
+/**
+ * Renders the mobile-friendly HUD overlay.
+ */
+export class HUDRenderer {
+    constructor(root, persistence) {
+        this.root = root;
+        this.persistence = persistence;
+        this.build();
+    }
+
+    build() {
+        this.root.innerHTML = `
+            <div class="hud-safe-area">
+                <div class="hud-top">
+                    <div class="hud-level">
+                        <span class="hud-label">LEVEL</span>
+                        <span class="hud-value" id="hud-level-id">--</span>
+                    </div>
+                    <div class="hud-score">
+                        <span class="hud-label">SCORE</span>
+                        <span class="hud-value" id="hud-score">0</span>
+                    </div>
+                    <div class="hud-combo">
+                        <span class="hud-label">COMBO</span>
+                        <span class="hud-value" id="hud-combo">0</span>
+                    </div>
+                </div>
+                <div class="hud-bars">
+                    <div class="hud-bar hud-health">
+                        <div class="hud-bar-fill" id="hud-health-fill"></div>
+                    </div>
+                    <div class="hud-bar hud-phase">
+                        <div class="hud-bar-fill" id="hud-phase-fill"></div>
+                    </div>
+                </div>
+                <div class="hud-bottom">
+                    <div class="hud-status" id="hud-status">Tap the beat to pulse.</div>
+                    <div class="hud-best" id="hud-best"></div>
+                </div>
+            </div>
+        `;
+        this.levelEl = this.root.querySelector('#hud-level-id');
+        this.scoreEl = this.root.querySelector('#hud-score');
+        this.comboEl = this.root.querySelector('#hud-combo');
+        this.healthFill = this.root.querySelector('#hud-health-fill');
+        this.phaseFill = this.root.querySelector('#hud-phase-fill');
+        this.statusEl = this.root.querySelector('#hud-status');
+        this.bestEl = this.root.querySelector('#hud-best');
+    }
+
+    setLevel(level) {
+        this.levelEl.textContent = level?.id?.toUpperCase() || '--';
+        const best = this.persistence.getBestScore(level.id);
+        if (best) {
+            this.bestEl.textContent = `BEST ${best.score} • MAX COMBO ${best.combo}`;
+        } else {
+            this.bestEl.textContent = '';
+        }
+    }
+
+    update(state) {
+        this.scoreEl.textContent = state.score.toLocaleString();
+        this.comboEl.textContent = state.combo ? `x${state.combo}` : '0';
+        this.healthFill.style.transform = `scaleX(${Math.max(0, state.health)})`;
+        this.phaseFill.style.transform = `scaleX(${Math.max(0, state.phaseEnergy)})`;
+    }
+
+    setStatus(text, variant = 'info') {
+        this.statusEl.textContent = text;
+        this.statusEl.dataset.variant = variant;
+    }
+
+    flash(text) {
+        this.setStatus(text, 'pulse');
+        this.statusEl.classList.add('flash');
+        setTimeout(() => this.statusEl.classList.remove('flash'), 600);
+    }
+}

--- a/src/game/utils/Math4D.js
+++ b/src/game/utils/Math4D.js
@@ -1,0 +1,103 @@
+/**
+ * Minimal 4D math helpers for projecting game geometry to screen space.
+ */
+
+/**
+ * Apply 4D rotations in XW, YW, ZW planes.
+ * @param {{x:number,y:number,z:number,w:number}} vec
+ * @param {{rot4dXW:number,rot4dYW:number,rot4dZW:number}} angles
+ */
+export function rotate4D(vec, angles) {
+    let { x, y, z, w } = vec;
+
+    if (angles.rot4dXW) {
+        const cos = Math.cos(angles.rot4dXW);
+        const sin = Math.sin(angles.rot4dXW);
+        const nx = x * cos - w * sin;
+        const nw = x * sin + w * cos;
+        x = nx;
+        w = nw;
+    }
+
+    if (angles.rot4dYW) {
+        const cos = Math.cos(angles.rot4dYW);
+        const sin = Math.sin(angles.rot4dYW);
+        const ny = y * cos - w * sin;
+        const nw = y * sin + w * cos;
+        y = ny;
+        w = nw;
+    }
+
+    if (angles.rot4dZW) {
+        const cos = Math.cos(angles.rot4dZW);
+        const sin = Math.sin(angles.rot4dZW);
+        const nz = z * cos - w * sin;
+        const nw = z * sin + w * cos;
+        z = nz;
+        w = nw;
+    }
+
+    return { x, y, z, w };
+}
+
+/**
+ * Simple 4D → 3D projection that blends W into scale.
+ * @param {{x:number,y:number,z:number,w:number}} vec
+ * @param {number} dimension - effective dimensionality (3-4)
+ */
+export function project4Dto3D(vec, dimension) {
+    const depth = Math.max(0.5, dimension);
+    const scale = 1 / (depth + 1 - vec.w * 0.5);
+    return {
+        x: vec.x * scale,
+        y: vec.y * scale,
+        z: vec.z * scale
+    };
+}
+
+/**
+ * Project 3D coordinates to 2D normalized screen space (0..1).
+ * @param {{x:number,y:number,z:number}} vec3
+ * @param {number} aspect
+ */
+export function project3DtoScreen(vec3, aspect = 1) {
+    const perspective = 1 / (1 + Math.max(-0.8, Math.min(0.8, vec3.z)));
+    const x = 0.5 + vec3.x * perspective * 0.45 * aspect;
+    const y = 0.5 - vec3.y * perspective * 0.45;
+    return { x, y };
+}
+
+/**
+ * Combined helper: rotate + project to screen.
+ * @param {object} vec4
+ * @param {object} params - expects rot4dXW/YW/ZW and dimension.
+ * @param {number} aspect
+ */
+export function project4DToScreen(vec4, params, aspect = 1) {
+    const rotated = rotate4D(vec4, params);
+    const vec3 = project4Dto3D(rotated, params.dimension || 3.5);
+    return project3DtoScreen(vec3, aspect);
+}
+
+/**
+ * Compute squared distance between two points in normalized screen space.
+ */
+export function distanceSq(a, b) {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    return dx * dx + dy * dy;
+}
+
+/**
+ * Linear interpolation.
+ */
+export function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+/**
+ * Exponential decay helper.
+ */
+export function damp(value, target, lambda, dt) {
+    return lerp(value, target, 1 - Math.exp(-lambda * dt));
+}

--- a/src/game/utils/Random.js
+++ b/src/game/utils/Random.js
@@ -1,0 +1,58 @@
+/**
+ * Deterministic random utilities for seeded gameplay.
+ * Provides simple Mulberry32 implementation and helpers.
+ */
+
+/**
+ * Mulberry32 RNG implementation.
+ * @param {number} seed - unsigned 32-bit seed
+ * @returns {() => number} function returning floats in [0, 1)
+ */
+export function mulberry32(seed) {
+    let t = seed >>> 0;
+    return function () {
+        t += 0x6D2B79F5;
+        let r = Math.imul(t ^ (t >>> 15), t | 1);
+        r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+        return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/**
+ * Creates a RNG helper with common convenience methods.
+ * @param {number} seed
+ */
+export function createSeededRNG(seed) {
+    const rand = mulberry32(seed);
+    return {
+        nextFloat: () => rand(),
+        nextRange: (min, max) => min + (max - min) * rand(),
+        nextInt: (min, max) => Math.floor(min + (max - min + 1) * rand()),
+        choose: (array) => array[Math.floor(rand() * array.length)],
+        shuffle(array) {
+            const copy = array.slice();
+            for (let i = copy.length - 1; i > 0; i--) {
+                const j = Math.floor(rand() * (i + 1));
+                [copy[i], copy[j]] = [copy[j], copy[i]];
+            }
+            return copy;
+        }
+    };
+}
+
+/**
+ * Hash string into a numeric seed for deterministic RNG.
+ * @param {string} str
+ */
+export function hashStringToSeed(str) {
+    let h1 = 0xdeadbeef ^ str.length;
+    let h2 = 0x41c6ce57 ^ str.length;
+    for (let i = 0, ch; i < str.length; i++) {
+        ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return (h1 >>> 0) ^ (h2 >>> 0);
+}

--- a/styles/lattice-pulse.css
+++ b/styles/lattice-pulse.css
@@ -1,0 +1,239 @@
+:root {
+  --bg-color: radial-gradient(circle at 20% 20%, #0d1b2a, #020407 70%);
+  --accent: #6fffe9;
+  --danger: #ff4d6d;
+  --text-primary: #e0fbfc;
+  --text-muted: rgba(224, 251, 252, 0.7);
+  --hud-bg: rgba(10, 15, 25, 0.7);
+  --hud-border: rgba(111, 255, 233, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-color);
+  font-family: 'Orbitron', 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  overscroll-behavior: none;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+#lp-app {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+#lp-canvas-root {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.lp-mode-stage {
+  position: absolute;
+  inset: 0;
+  transition: opacity 0.45s ease;
+}
+
+.lp-mode-stage:not(.active) {
+  pointer-events: none;
+}
+
+.lp-canvas-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  pointer-events: none;
+}
+
+#lp-input-layer {
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+#lp-hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hud-safe-area {
+  width: min(92vw, 420px);
+  height: 100%;
+  padding: 1.75rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hud-top {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.hud-label {
+  display: block;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.hud-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.hud-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hud-bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hud-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), #60efff);
+  transform-origin: left center;
+  transform: scaleX(1);
+  transition: transform 0.15s ease;
+}
+
+.hud-bar.hud-phase .hud-bar-fill {
+  background: linear-gradient(90deg, #ff9f1c, #ffbf69);
+}
+
+.hud-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hud-status {
+  font-size: 0.8rem;
+  min-height: 1.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hud-status[data-variant='alert'] {
+  color: var(--danger);
+}
+
+.hud-status.flash {
+  animation: hudFlash 0.4s ease;
+}
+
+@keyframes hudFlash {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.7; }
+}
+
+.hud-best {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(224, 251, 252, 0.6);
+}
+
+#lp-start-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(2, 4, 7, 0.86);
+  z-index: 30;
+  backdrop-filter: blur(12px);
+  text-align: center;
+  padding: 2rem;
+  transition: opacity 0.35s ease;
+}
+
+#lp-start-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lp-start-title {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.lp-start-subtitle {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  max-width: 320px;
+}
+
+#lp-start-button {
+  padding: 0.9rem 2.4rem;
+  background: linear-gradient(90deg, var(--accent), #64dfdf);
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #020407;
+  cursor: pointer;
+  box-shadow: 0 10px 35px rgba(100, 223, 223, 0.35);
+}
+
+#lp-start-button:active {
+  transform: scale(0.97);
+}
+
+@media (max-width: 640px) {
+  .hud-safe-area {
+    width: min(94vw, 360px);
+    padding: 1.25rem 1rem;
+  }
+  .hud-top {
+    gap: 0.5rem;
+  }
+  .hud-value {
+    font-size: 1.2rem;
+  }
+}

--- a/sw-lattice-pulse.js
+++ b/sw-lattice-pulse.js
@@ -1,0 +1,57 @@
+const CACHE_NAME = 'lattice-pulse-v1';
+const PRECACHE = [
+  './lattice-pulse.html',
+  './styles/lattice-pulse.css',
+  './src/game/LatticePulseGame.js',
+  './src/game/GameLoop.js',
+  './src/game/AudioService.js',
+  './src/game/ModeController.js',
+  './src/game/GeometryController.js',
+  './src/game/SpawnSystem.js',
+  './src/game/CollisionSystem.js',
+  './src/game/InputMapping.js',
+  './src/game/EffectsManager.js',
+  './src/game/PerformanceController.js',
+  './src/game/LevelManager.js',
+  './src/game/GameState.js',
+  './src/game/utils/Random.js',
+  './src/game/utils/Math4D.js',
+  './src/game/persistence/LocalPersistence.js',
+  './src/game/ui/HUDRenderer.js',
+  './src/game/levels/lvl-01-faceted-torus.json',
+  './src/game/levels/lvl-02-quantum-sphere.json',
+  './src/game/levels/lvl-03-holographic-crystal.json',
+  './icons/lattice-192.svg',
+  './icons/lattice-512.svg',
+  './lattice-pulse-manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.map((key) => {
+      if (key !== CACHE_NAME) {
+        return caches.delete(key);
+      }
+    }))).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      }).catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- lazily instantiate the faceted, quantum, and holographic canvas stacks so only the active mode consumes WebGL contexts
- add resize handling that reflows canvases and updates visualizer viewports when the window changes or a mode initializes
- trigger an initial resize after applying the level variant so the renderer has a correctly sized buffer before the first frame

## Testing
- npm test *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4a3bd81c83298af0624151c20b75