### PR TITLE
Add rogue-lite progression and audio-driven events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ python3 -m http.server 8080
 http://localhost:8080/index-clean.html
 ```
 
+### 🎯 Lattice Pulse – Mobile Game
+
+The new **Lattice Pulse** mode turns the faceted/quantum/holographic renderers into a rhythm-arcade loop.
+
+- Launch the PWA: `http://localhost:8080/lattice-pulse.html`
+- Tap the start screen to unlock audio and begin.
+- **Tap** to pulse captures, **swipe** to rotate 4D planes, **pinch** to shift dimensional depth, **double-tap** to trigger slow-motion, **long-press** to enter a phase shield, and **tilt** (optional) for drift correction.
+- Stage-based **rogue-lite climb**: the selected geometry/system stays fixed for the run while beats, density, and chaos scale every stage.
+- Audio-reactive director now detects drops, bridges, lulls, silences, rhythm shifts, and vocal spikes to inject WarioWare-style directives—Pulse Blast bursts, Hold the Phase, Swipe Sync, Freeze windows, and Quick Draws—layered atop the beat grid with bombastic callouts, glitches, reverses, and tempo warps.
+- Earn and spend pulse charges for slow-motion or bonus lives via double-tap specials, bank directive rewards for density/tempo boosts, track local best stages/scores, and keep the run going endlessly on any track.
+- Runs as a deterministic 60 Hz loop with beat-driven spawns (Suno BPM metadata) and offline caching via `sw-lattice-pulse.js`.
+- Ships with faceted, quantum, and holographic templates seeded for the rogue run starter set—each targeting 60 FPS on modern phones.
+
 ## 🎮 The 4 Systems
 
 **🔷 FACETED** - Simple 2D geometric patterns  

--- a/icons/lattice-192.svg
+++ b/icons/lattice-192.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-labelledby="title desc">
+  <title id="title">Lattice Pulse Icon</title>
+  <desc id="desc">Abstract lattice grid representing the Lattice Pulse rhythm game.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a2e" />
+      <stop offset="100%" stop-color="#6622cc" />
+    </linearGradient>
+    <linearGradient id="pulse" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff6ad5" />
+      <stop offset="100%" stop-color="#ffe45e" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" fill="url(#bg)" rx="24" ry="24" />
+  <g stroke="#2de2e6" stroke-width="6" opacity="0.45">
+    <path d="M32 32h128M32 64h128M32 96h128M32 128h128M32 160h128" />
+    <path d="M32 32v128M64 32v128M96 32v128M128 32v128M160 32v128" />
+  </g>
+  <path d="M48 132l36-60 24 36 18-28 18 28" fill="none" stroke="url(#pulse)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="84" cy="72" r="10" fill="#ffe45e" />
+  <circle cx="126" cy="100" r="12" fill="#ff6ad5" />
+</svg>

--- a/icons/lattice-512.svg
+++ b/icons/lattice-512.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Lattice Pulse Icon Large</title>
+  <desc id="desc">Large icon featuring the lattice pulse motif.</desc>
+  <defs>
+    <linearGradient id="bg512" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d1321" />
+      <stop offset="100%" stop-color="#5f0f99" />
+    </linearGradient>
+    <linearGradient id="pulse512" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff8ae2" />
+      <stop offset="100%" stop-color="#f9ff9d" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#bg512)" rx="72" ry="72" />
+  <g stroke="#41ead4" stroke-width="16" opacity="0.45">
+    <path d="M96 96h320M96 160h320M96 224h320M96 288h320M96 352h320M96 416h320" />
+    <path d="M96 96v320M160 96v320M224 96v320M288 96v320M352 96v320M416 96v320" />
+  </g>
+  <path d="M128 368l92-160 64 96 48-76 48 76" fill="none" stroke="url(#pulse512)" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="220" cy="212" r="32" fill="#f9ff9d" />
+  <circle cx="332" cy="272" r="38" fill="#ff8ae2" />
+</svg>

--- a/lattice-pulse-manifest.json
+++ b/lattice-pulse-manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Lattice Pulse",
+  "short_name": "LatticePulse",
+  "start_url": "./lattice-pulse.html",
+  "display": "standalone",
+  "background_color": "#020407",
+  "theme_color": "#020407",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "./icons/lattice-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "./icons/lattice-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/lattice-pulse.html
+++ b/lattice-pulse.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#020407">
+  <title>Lattice Pulse • VIB34D</title>
+  <link rel="manifest" href="./lattice-pulse-manifest.json">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap">
+  <link rel="stylesheet" href="./styles/lattice-pulse.css">
+</head>
+<body>
+  <div id="lp-app">
+    <div id="lp-canvas-root"></div>
+    <div id="lp-input-layer"></div>
+    <div id="lp-hud"></div>
+    <div id="lp-start-screen">
+      <div class="lp-start-title">Lattice Pulse</div>
+      <div class="lp-start-subtitle">Tap to pulse, swipe to steer. Double-tap for slow-mo or bonus life, hold for phase shield, and follow the music-driven directives as stages escalate.</div>
+      <button id="lp-start-button">Start</button>
+    </div>
+  </div>
+  <script type="module" src="./src/game/LatticePulseGame.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw-lattice-pulse.js').catch((err) => console.warn('SW registration failed', err));
+      });
+    }
+  </script>
+</body>
+</html>

--- a/src/game/AudioService.js
+++ b/src/game/AudioService.js
@@ -1,0 +1,312 @@
+/**
+ * Audio playback + beat clock with analyser-driven reactivity.
+ */
+export class AudioService {
+    constructor() {
+        this.audioContext = null;
+        this.masterGain = null;
+        this.analyser = null;
+        this.source = null;
+        this.trackBuffer = null;
+        this.trackConfig = null;
+        this.isPlaying = false;
+        this.useMetronome = false;
+        this.metronomeOscillator = null;
+        this.beatInterval = 0.5; // default 120 BPM
+        this.beatAccumulator = 0;
+        this.beatListeners = new Set();
+        this.measureListeners = new Set();
+        this.frequencyBins = null;
+        this.phase = 0;
+        this.measureBeats = 4;
+        this.beatIndex = 0;
+        this.startTime = 0;
+        this.analysis = { energy: 0, bass: 0, mid: 0, high: 0, flux: 0, drop: false, lull: false, silence: false };
+        this.energyAverage = 0;
+        this.lastEnergy = 0;
+        this.prevSpectrum = null;
+        this.audioEvents = [];
+        this.dropCooldownTimer = 0;
+        this.lullCooldownTimer = 0;
+        this.silenceCooldownTimer = 0;
+        this.lullHold = 0;
+        this.silenceHold = 0;
+        this.bridgeHold = 0;
+        this.vocalHold = 0;
+        this.vocalAverage = 0;
+        this.vocalCooldownTimer = 0;
+        this.bridgeCooldownTimer = 0;
+        this.rhythmShiftTimer = 0;
+    }
+
+    async init() {
+        if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            this.masterGain = this.audioContext.createGain();
+            this.masterGain.connect(this.audioContext.destination);
+            this.analyser = this.audioContext.createAnalyser();
+            this.analyser.fftSize = 2048;
+            this.analyser.smoothingTimeConstant = 0.7;
+            this.frequencyBins = new Uint8Array(this.analyser.frequencyBinCount);
+            this.prevSpectrum = new Float32Array(this.analyser.frequencyBinCount);
+            this.analyser.connect(this.masterGain);
+        }
+        return this.audioContext;
+    }
+
+    async loadTrack(trackConfig) {
+        await this.init();
+        this.trackConfig = trackConfig;
+        const bpm = trackConfig?.bpm || 120;
+        this.setBPM(bpm);
+
+        if (!trackConfig?.url) {
+            console.warn('AudioService: No track URL, using metronome fallback');
+            this.useMetronome = true;
+            return false;
+        }
+
+        try {
+            const response = await fetch(trackConfig.url);
+            const arrayBuffer = await response.arrayBuffer();
+            this.trackBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+            this.useMetronome = false;
+            console.log('AudioService: Track loaded');
+            return true;
+        } catch (err) {
+            console.warn('AudioService: Failed to load track, falling back to metronome', err);
+            this.trackBuffer = null;
+            this.useMetronome = true;
+            return false;
+        }
+    }
+
+    setBPM(bpm) {
+        this.beatInterval = 60 / (bpm || 120);
+    }
+
+    async start() {
+        await this.init();
+        await this.audioContext.resume();
+        this.stop();
+
+        if (this.useMetronome || !this.trackBuffer) {
+            this.startMetronome();
+        } else {
+            this.startTrack();
+        }
+
+        this.isPlaying = true;
+        this.startTime = this.audioContext.currentTime;
+        window.audioEnabled = true;
+    }
+
+    startTrack() {
+        this.source = this.audioContext.createBufferSource();
+        this.source.buffer = this.trackBuffer;
+        this.source.loop = true;
+        this.source.connect(this.analyser);
+        this.source.start();
+    }
+
+    startMetronome() {
+        const osc = this.audioContext.createOscillator();
+        const gain = this.audioContext.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = 880;
+        gain.gain.value = 0;
+        osc.connect(gain);
+        gain.connect(this.analyser);
+        osc.start();
+        this.metronomeOscillator = { osc, gain };
+    }
+
+    stop() {
+        if (this.source) {
+            try { this.source.stop(); } catch (_) { /* ignore */ }
+            this.source.disconnect();
+            this.source = null;
+        }
+        if (this.metronomeOscillator) {
+            try { this.metronomeOscillator.osc.stop(); } catch (_) {}
+            this.metronomeOscillator.osc.disconnect();
+            this.metronomeOscillator.gain.disconnect();
+            this.metronomeOscillator = null;
+        }
+        this.isPlaying = false;
+        window.audioEnabled = false;
+    }
+
+    onBeat(callback) {
+        this.beatListeners.add(callback);
+        return () => this.beatListeners.delete(callback);
+    }
+
+    onMeasure(callback) {
+        this.measureListeners.add(callback);
+        return () => this.measureListeners.delete(callback);
+    }
+
+    update(dt) {
+        if (!this.isPlaying) return;
+
+        this.beatAccumulator += dt * (this.trackConfig?.playbackRate || 1);
+        if (this.beatAccumulator >= this.beatInterval) {
+            this.beatAccumulator -= this.beatInterval;
+            this.beatIndex += 1;
+            const beatInfo = {
+                time: this.audioContext?.currentTime || performance.now() / 1000,
+                beat: this.beatIndex,
+                interval: this.beatInterval
+            };
+            this.beatListeners.forEach((cb) => cb(beatInfo));
+            if (this.beatIndex % this.measureBeats === 0) {
+                this.measureListeners.forEach((cb) => cb({
+                    measure: this.beatIndex / this.measureBeats,
+                    beatInfo
+                }));
+            }
+            if (this.metronomeOscillator) {
+                this.metronomeOscillator.gain.gain.cancelScheduledValues(0);
+                this.metronomeOscillator.gain.gain.setValueAtTime(0.25, this.audioContext.currentTime);
+                this.metronomeOscillator.gain.gain.exponentialRampToValueAtTime(0.001, this.audioContext.currentTime + 0.15);
+            }
+        }
+
+        this.dropCooldownTimer = Math.max(0, this.dropCooldownTimer - dt);
+        this.lullCooldownTimer = Math.max(0, this.lullCooldownTimer - dt);
+        this.silenceCooldownTimer = Math.max(0, this.silenceCooldownTimer - dt);
+        this.vocalCooldownTimer = Math.max(0, this.vocalCooldownTimer - dt);
+        this.bridgeCooldownTimer = Math.max(0, this.bridgeCooldownTimer - dt);
+        this.rhythmShiftTimer = Math.max(0, this.rhythmShiftTimer - dt);
+
+        if (this.analyser && this.frequencyBins) {
+            this.analyser.getByteFrequencyData(this.frequencyBins);
+            const bass = averageRange(this.frequencyBins, 0, 24);
+            const mid = averageRange(this.frequencyBins, 24, 96);
+            const high = averageRange(this.frequencyBins, 96, 256);
+            const flux = spectralFlux(this.frequencyBins, this.prevSpectrum);
+            const energy = bass * 0.6 + mid * 0.3 + high * 0.1;
+            this.energyAverage = this.energyAverage ? this.energyAverage * 0.92 + energy * 0.08 : energy;
+            const delta = energy - this.lastEnergy;
+            this.lastEnergy = energy;
+
+            const vocalScore = Math.max(0, mid * 0.7 + high * 0.5 - bass * 0.35);
+            this.vocalAverage = this.vocalAverage ? this.vocalAverage * 0.93 + vocalScore * 0.07 : vocalScore;
+            const vocalSpike = vocalScore > this.vocalAverage + 0.12 && flux > 0.015;
+
+            const dropTriggered = energy > this.energyAverage * 1.35 && delta > 0.06 && this.dropCooldownTimer <= 0;
+            if (dropTriggered) {
+                this.audioEvents.push({ type: 'drop', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.dropCooldownTimer = 1.5;
+            }
+
+            if (energy < this.energyAverage * 0.7) {
+                this.lullHold += dt;
+            } else {
+                this.lullHold = 0;
+            }
+            const lullTriggered = this.lullHold > 1.6 && this.lullCooldownTimer <= 0;
+            if (lullTriggered) {
+                this.audioEvents.push({ type: 'lull', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.lullCooldownTimer = 6;
+            }
+
+            if (energy < this.energyAverage * 0.82 && energy > 0.05) {
+                this.bridgeHold += dt;
+            } else {
+                this.bridgeHold = 0;
+            }
+            const bridgeTriggered = this.bridgeHold > 1.4 && this.bridgeCooldownTimer <= 0;
+            if (bridgeTriggered) {
+                this.audioEvents.push({ type: 'bridge', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.bridgeCooldownTimer = 8;
+            }
+
+            if (energy < 0.04) {
+                this.silenceHold += dt;
+            } else {
+                this.silenceHold = 0;
+            }
+            const silenceTriggered = this.silenceHold > 0.8 && this.silenceCooldownTimer <= 0;
+            if (silenceTriggered) {
+                this.audioEvents.push({ type: 'silence', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.silenceCooldownTimer = 8;
+            }
+
+            if (vocalSpike && this.vocalCooldownTimer <= 0) {
+                this.audioEvents.push({ type: 'vocal', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.vocalHold = 0.6;
+                this.vocalCooldownTimer = 4;
+            } else {
+                this.vocalHold = Math.max(0, this.vocalHold - dt);
+            }
+
+            const rhythmShift = flux > 0.05 && this.rhythmShiftTimer <= 0;
+            if (rhythmShift) {
+                this.audioEvents.push({ type: 'rhythm-shift', time: this.audioContext?.currentTime || performance.now() / 1000 });
+                this.rhythmShiftTimer = 3.2;
+            }
+
+            this.analysis = {
+                energy,
+                average: this.energyAverage,
+                delta,
+                bass,
+                mid,
+                high,
+                flux,
+                drop: dropTriggered,
+                lull: this.lullHold > 1.2,
+                silence: this.silenceHold > 0.6,
+                bridge: this.bridgeHold > 1.2,
+                vocal: this.vocalHold > 0,
+                rhythmShift
+            };
+
+            window.audioReactive = {
+                bass,
+                mid,
+                high,
+                energy,
+                vocal: vocalScore
+            };
+        }
+    }
+
+    getAnalysis() {
+        return { ...this.analysis };
+    }
+
+    consumeAudioEvents() {
+        const queue = this.audioEvents.slice();
+        this.audioEvents.length = 0;
+        return queue;
+    }
+}
+
+function averageRange(array, start, end) {
+    let sum = 0;
+    let count = 0;
+    const clampedEnd = Math.min(array.length, end);
+    for (let i = start; i < clampedEnd; i++) {
+        sum += array[i] / 255;
+        count += 1;
+    }
+    return count ? sum / count : 0;
+}
+
+function spectralFlux(currentBins, prevSpectrum) {
+    if (!prevSpectrum) return 0;
+    let flux = 0;
+    const len = Math.min(currentBins.length, prevSpectrum.length);
+    for (let i = 0; i < len; i++) {
+        const current = currentBins[i] / 255;
+        const diff = current - prevSpectrum[i];
+        if (diff > 0) {
+            flux += diff;
+        }
+        prevSpectrum[i] = current;
+    }
+    return flux / len;
+}

--- a/src/game/CollisionSystem.js
+++ b/src/game/CollisionSystem.js
@@ -1,0 +1,126 @@
+import { distanceSq } from './utils/Math4D.js';
+
+/**
+ * Screen-space collision grid for touch pulses and active targets.
+ */
+export class CollisionSystem {
+    constructor({ size = 32 } = {}) {
+        this.gridSize = size;
+        this.cells = new Map();
+        this.lastTargets = [];
+    }
+
+    rebuild(targets) {
+        this.cells.clear();
+        this.lastTargets = targets;
+        targets.forEach((target) => {
+            const entries = expandTarget(target);
+            entries.forEach(({ center, radius }) => {
+                const bounds = radiusBounds(center, radius, this.gridSize);
+                for (let gx = bounds.minX; gx <= bounds.maxX; gx++) {
+                    for (let gy = bounds.minY; gy <= bounds.maxY; gy++) {
+                        const key = `${gx}:${gy}`;
+                        if (!this.cells.has(key)) {
+                            this.cells.set(key, []);
+                        }
+                        this.cells.get(key).push({ target, center, radius });
+                    }
+                }
+            });
+        });
+    }
+
+    query(point, radius) {
+        const bounds = radiusBounds(point, radius, this.gridSize);
+        const candidates = [];
+        for (let gx = bounds.minX; gx <= bounds.maxX; gx++) {
+            for (let gy = bounds.minY; gy <= bounds.maxY; gy++) {
+                const key = `${gx}:${gy}`;
+                const cell = this.cells.get(key);
+                if (cell) {
+                    cell.forEach((entry) => candidates.push(entry));
+                }
+            }
+        }
+        return candidates;
+    }
+
+    resolvePulse(pulse) {
+        const hits = [];
+        const candidates = this.query(pulse.position, pulse.radius);
+        const unique = new Set();
+        candidates.forEach(({ target, center, radius }) => {
+            if (unique.has(target.id)) return;
+            if (target.type === 'lane') {
+                const dist = distanceToSegmentSq(pulse.position, target.screenA, target.screenB);
+                if (dist <= (pulse.radius + radius) * (pulse.radius + radius)) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            } else if (target.type === 'cluster') {
+                const hitChild = target.children?.find((child) => {
+                    const dist = distanceSq(child.screen, pulse.position);
+                    return dist <= Math.pow(pulse.radius + (child.radius || 0.05), 2);
+                });
+                if (hitChild) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            } else {
+                const dist = distanceSq(center, pulse.position);
+                if (dist <= Math.pow(pulse.radius + (target.radius || 0.08), 2)) {
+                    unique.add(target.id);
+                    hits.push({ target, quality: pulseQuality(target) });
+                }
+            }
+        });
+        return hits;
+    }
+}
+
+function expandTarget(target) {
+    if (target.type === 'lane') {
+        const mid = {
+            x: (target.screenA.x + target.screenB.x) / 2,
+            y: (target.screenA.y + target.screenB.y) / 2
+        };
+        return [{ center: mid, radius: target.radius || 0.05 }];
+    }
+    if (target.type === 'cluster') {
+        return (target.children || []).map((child) => ({
+            center: child.screen,
+            radius: child.radius || 0.04
+        }));
+    }
+    return [{ center: target.screen, radius: target.radius || 0.08 }];
+}
+
+function radiusBounds(center, radius, grid) {
+    const minX = Math.max(0, Math.floor((center.x - radius) * grid));
+    const minY = Math.max(0, Math.floor((center.y - radius) * grid));
+    const maxX = Math.min(grid - 1, Math.floor((center.x + radius) * grid));
+    const maxY = Math.min(grid - 1, Math.floor((center.y + radius) * grid));
+    return { minX, minY, maxX, maxY };
+}
+
+function distanceToSegmentSq(point, a, b) {
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const apx = point.x - a.x;
+    const apy = point.y - a.y;
+    const abLenSq = abx * abx + aby * aby;
+    const t = abLenSq === 0 ? 0 : Math.max(0, Math.min(1, (apx * abx + apy * aby) / abLenSq));
+    const closestX = a.x + abx * t;
+    const closestY = a.y + aby * t;
+    const dx = point.x - closestX;
+    const dy = point.y - closestY;
+    return dx * dx + dy * dy;
+}
+
+function pulseQuality(target) {
+    if (target.remaining == null) return 'good';
+    const window = Math.abs(target.remaining);
+    if (window < 0.05) return 'perfect';
+    if (window < 0.12) return 'great';
+    return 'good';
+}

--- a/src/game/EffectsManager.js
+++ b/src/game/EffectsManager.js
@@ -1,0 +1,146 @@
+/**
+ * Maintains shader-facing parameter easings for score/miss/combo feedback.
+ */
+export class EffectsManager {
+    constructor() {
+        this.scorePulse = 0;
+        this.missPulse = 0;
+        this.comboShift = 0;
+        this.perfectSnap = 0;
+        this.shield = 0;
+        this.glitchBoost = 0;
+        this.glitchPhase = 0;
+        this.reverseSweep = 0;
+        this.tempoWave = 0;
+        this.slowMoGlow = 0;
+        this.directivePulse = 0;
+        this.directiveAlert = 0;
+    }
+
+    trigger(event, detail = {}) {
+        switch (event) {
+            case 'score':
+                this.scorePulse = Math.min(1, this.scorePulse + (detail.quality === 'perfect' ? 0.8 : 0.5));
+                if (detail.quality === 'perfect') {
+                    this.perfectSnap = 1;
+                }
+                break;
+            case 'miss':
+                this.missPulse = 1;
+                break;
+            case 'combo':
+                this.comboShift = Math.min(1, this.comboShift + 0.15);
+                break;
+            case 'shield':
+                this.shield = Math.min(1, this.shield + 0.4);
+                break;
+            case 'glitch':
+                this.glitchBoost = Math.min(1, this.glitchBoost + 0.5);
+                break;
+            case 'reverse-start':
+                this.reverseSweep = 1;
+                break;
+            case 'reverse-end':
+                this.reverseSweep = 0;
+                break;
+            case 'tempo':
+                this.tempoWave = 1;
+                break;
+            case 'slowmo':
+                this.slowMoGlow = 1;
+                break;
+            case 'directive-start':
+                this.directivePulse = Math.min(1, this.directivePulse + 0.6);
+                break;
+            case 'directive-success':
+                this.directivePulse = 1.2;
+                break;
+            case 'directive-fail':
+                this.directiveAlert = 1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    update(dt, params, state, effectState = {}, analysis = {}) {
+        const result = { ...params };
+        this.scorePulse = Math.max(0, this.scorePulse - dt * 1.8);
+        this.missPulse = Math.max(0, this.missPulse - dt * 2.2);
+        this.comboShift = Math.max(0, this.comboShift - dt * 0.5);
+        this.perfectSnap = Math.max(0, this.perfectSnap - dt * 3.5);
+        this.shield = Math.max(0, this.shield - dt * 0.4);
+        this.glitchBoost = Math.max(0, this.glitchBoost - dt * 0.8);
+        this.reverseSweep = Math.max(0, this.reverseSweep - dt * 0.6);
+        this.tempoWave = Math.max(0, this.tempoWave - dt * 0.7);
+        this.slowMoGlow = Math.max(0, this.slowMoGlow - dt * 0.4);
+        this.directivePulse = Math.max(0, this.directivePulse - dt * 1.5);
+        this.directiveAlert = Math.max(0, this.directiveAlert - dt * 2.2);
+
+        const glitchLevel = typeof state.getGlitchLevel === 'function' ? state.getGlitchLevel() : 0;
+        if (glitchLevel > 0 || this.glitchBoost > 0) {
+            this.glitchPhase += dt * (1 + glitchLevel);
+        }
+
+        result.intensity += this.scorePulse * 0.25;
+        result.hue = (result.hue + this.comboShift * 40 + (state.combo % 8) * 2) % 360;
+        result.chaos += (this.scorePulse * 0.1) - (this.missPulse * 0.25);
+        result.saturation = Math.min(1, result.saturation + this.scorePulse * 0.15 - this.missPulse * 0.2);
+
+        if (state.phaseActive) {
+            result.speed *= 0.75;
+            result.intensity *= 0.9;
+        }
+
+        if (this.missPulse) {
+            result.intensity *= 0.7;
+        }
+
+        if (this.perfectSnap) {
+            result.speed *= 1 + this.perfectSnap * 0.05;
+        }
+
+        if (this.shield > 0) {
+            result.chaos *= 0.85;
+        }
+
+        if (glitchLevel > 0 || this.glitchBoost > 0) {
+            const glitchStrength = glitchLevel * 0.3 + this.glitchBoost * 0.25;
+            result.chaos += glitchStrength;
+            result.hue = (result.hue + Math.sin(this.glitchPhase * 6) * 40 * glitchStrength) % 360;
+            result.intensity += Math.sin(this.glitchPhase * 12) * 0.06 * glitchStrength;
+        }
+
+        if (this.reverseSweep > 0 || effectState?.reverseControls) {
+            result.hue = (result.hue + 180 * this.reverseSweep) % 360;
+            result.saturation = Math.max(0.4, result.saturation - 0.1 * this.reverseSweep);
+        }
+
+        if (this.tempoWave > 0 || (effectState?.tempoMultiplier && effectState.tempoMultiplier !== 1)) {
+            const tempoBoost = (effectState?.tempoMultiplier || 1) - 1 + this.tempoWave * 0.2;
+            result.speed *= 1 + tempoBoost * 0.4;
+            result.gridDensity *= 1 + tempoBoost * 0.2;
+        }
+
+        if (this.slowMoGlow > 0 || (state.getTimeWarp && state.getTimeWarp() < 1)) {
+            result.speed *= 0.92;
+            result.intensity = Math.min(1.4, result.intensity + 0.08 * this.slowMoGlow);
+        }
+
+        if (analysis && typeof analysis.energy === 'number') {
+            result.intensity += (analysis.energy - 0.5) * 0.1;
+        }
+
+        if (this.directivePulse > 0) {
+            result.intensity += this.directivePulse * 0.12;
+            result.hue = (result.hue + this.directivePulse * 22) % 360;
+        }
+
+        if (this.directiveAlert > 0) {
+            result.chaos += this.directiveAlert * 0.35;
+            result.intensity *= 1 - Math.min(0.3, this.directiveAlert * 0.2);
+        }
+
+        return result;
+    }
+}

--- a/src/game/GameLoop.js
+++ b/src/game/GameLoop.js
@@ -1,0 +1,47 @@
+const STEP = 1 / 60;
+
+/**
+ * Deterministic fixed-step game loop with decoupled rendering.
+ */
+export class GameLoop {
+    constructor(update, render, { maxSubSteps = 5 } = {}) {
+        this.update = update;
+        this.render = render;
+        this.maxSubSteps = maxSubSteps;
+        this.accumulator = 0;
+        this.lastTime = null;
+        this.running = false;
+        this.rafId = null;
+    }
+
+    start() {
+        if (this.running) return;
+        this.running = true;
+        this.lastTime = performance.now();
+        const tick = (time) => {
+            if (!this.running) return;
+            const delta = (time - this.lastTime) / 1000;
+            this.lastTime = time;
+            this.accumulator += delta;
+            let steps = 0;
+            while (this.accumulator >= STEP && steps < this.maxSubSteps) {
+                this.update(STEP);
+                this.accumulator -= STEP;
+                steps += 1;
+            }
+            this.render();
+            this.rafId = requestAnimationFrame(tick);
+        };
+        this.rafId = requestAnimationFrame(tick);
+    }
+
+    stop() {
+        this.running = false;
+        if (this.rafId) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+        }
+    }
+}
+
+export { STEP as FIXED_STEP };

--- a/src/game/GameState.js
+++ b/src/game/GameState.js
@@ -1,0 +1,423 @@
+/**
+ * Core gameplay state: score, combo, timers, and parameter targets.
+ */
+export class GameState {
+    constructor(levelConfig) {
+        this.level = levelConfig;
+        this.score = 0;
+        this.combo = 0;
+        this.maxCombo = 0;
+        this.multiplier = 1;
+        this.lives = 3;
+        this.health = 1.0;
+        this.beatIndex = 0;
+        this.elapsedBeats = 0;
+        this.remainingBeats = levelConfig.targetBeats || 64;
+        this.pulseWindow = (levelConfig.windowMs || 150) / 1000;
+        this.phaseEnergy = 1.0;
+        this.phaseActive = false;
+        this.phaseCooldown = 0;
+        this.comboTimer = 0;
+        this.comboTimeout = 4; // seconds to maintain combo
+        this.stage = levelConfig.stage || 1;
+        this.runId = levelConfig.runId || null;
+        this.endless = Boolean(levelConfig.endless);
+        this.runMultiplier = levelConfig.runMultiplier || 1;
+        this.stageTargetBeats = this.remainingBeats;
+        this.totalBeats = 0;
+        this.specialCharges = Math.min(levelConfig.maxCharges || 3, Math.max(0, Math.round(levelConfig.specialCharges ?? 1)));
+        this.maxCharges = levelConfig.maxCharges || 3;
+        this.phaseRegenBonus = 0;
+        this.timeWarp = 1;
+        this.timeWarpTarget = 1;
+        this.timeWarpTimer = 0;
+        this.controlInversion = false;
+        this.controlInversionTimer = 0;
+        this.glitchLevel = 0;
+        this.glitchTimer = 0;
+        this.modifierFlags = new Set(levelConfig.modifiers || []);
+
+        this.parameters = {
+            geometry: levelConfig.geometryIndex ?? 0,
+            variant: levelConfig.variantIndex ?? levelConfig.geometryIndex ?? 0,
+            gridDensity: levelConfig.difficulty?.density ?? 18,
+            morphFactor: levelConfig.difficulty?.morph ?? 1.0,
+            chaos: levelConfig.difficulty?.chaos ?? 0.15,
+            speed: levelConfig.difficulty?.speed ?? 1.0,
+            hue: levelConfig.color?.hue ?? 200,
+            intensity: levelConfig.color?.intensity ?? 0.55,
+            saturation: levelConfig.color?.saturation ?? 0.85,
+            dimension: levelConfig.difficulty?.dimension ?? 3.6,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.targetParameters = { ...this.parameters };
+        this.activeDirective = null;
+        this.directiveEvents = [];
+    }
+
+    /** Update timers each fixed tick */
+    update(dt) {
+        this.comboTimer += dt;
+        if (this.comboTimer > this.comboTimeout) {
+            this.resetCombo();
+        }
+
+        if (this.phaseActive) {
+            this.phaseEnergy = Math.max(0, this.phaseEnergy - dt * 0.45);
+            if (this.phaseEnergy <= 0) {
+                this.stopPhase();
+                this.phaseCooldown = 2.5; // seconds before next activation
+            }
+        } else if (this.phaseCooldown > 0) {
+            this.phaseCooldown = Math.max(0, this.phaseCooldown - dt);
+        } else {
+            const regen = 0.25 + this.phaseRegenBonus;
+            this.phaseEnergy = Math.min(1, this.phaseEnergy + dt * regen);
+        }
+
+        if (this.timeWarpTimer > 0) {
+            this.timeWarpTimer = Math.max(0, this.timeWarpTimer - dt);
+            if (this.timeWarpTimer === 0) {
+                this.timeWarpTarget = 1;
+            }
+        }
+        this.timeWarp += (this.timeWarpTarget - this.timeWarp) * Math.min(1, dt * 4);
+
+        if (this.controlInversionTimer > 0) {
+            this.controlInversionTimer = Math.max(0, this.controlInversionTimer - dt);
+            if (this.controlInversionTimer === 0) {
+                this.controlInversion = false;
+            }
+        }
+
+        if (this.glitchTimer > 0) {
+            this.glitchTimer = Math.max(0, this.glitchTimer - dt);
+            if (this.glitchTimer === 0) {
+                this.glitchLevel = 0;
+            }
+        }
+
+        this.updateDirective(dt);
+    }
+
+    applyParameterDelta(delta) {
+        Object.keys(delta).forEach((key) => {
+            if (key in this.targetParameters) {
+                this.targetParameters[key] += delta[key];
+            }
+        });
+    }
+
+    setTargetParameter(name, value) {
+        if (name in this.targetParameters) {
+            this.targetParameters[name] = value;
+        }
+    }
+
+    getParameters() {
+        return this.parameters;
+    }
+
+    /** Ease parameters towards targets */
+    settleParameters(dt) {
+        const ease = 8;
+        Object.keys(this.parameters).forEach((key) => {
+            const current = this.parameters[key];
+            const target = this.targetParameters[key];
+            if (typeof current === 'number' && typeof target === 'number') {
+                this.parameters[key] = current + (target - current) * Math.min(1, ease * dt);
+            }
+        });
+    }
+
+    registerBeat() {
+        this.beatIndex += 1;
+        this.elapsedBeats += 1;
+        this.totalBeats += 1;
+        const target = this.level.targetBeats || this.stageTargetBeats || 64;
+        this.stageTargetBeats = target;
+        this.remainingBeats = Math.max(0, target - this.elapsedBeats);
+    }
+
+    registerHit(quality = 'good') {
+        this.comboTimer = 0;
+        this.combo += 1;
+        this.maxCombo = Math.max(this.maxCombo, this.combo);
+        const qualityMult = quality === 'perfect' ? 1.5 : quality === 'great' ? 1.2 : 1;
+        this.multiplier = 1 + Math.floor(this.combo / 8) * 0.25;
+        if (this.combo && this.combo % 12 === 0) {
+            this.gainSpecialCharge(1);
+        }
+        const baseScore = 100 * (this.runMultiplier || 1);
+        this.score += Math.floor(baseScore * qualityMult * this.multiplier);
+    }
+
+    registerMiss() {
+        this.lives = Math.max(0, this.lives - 1);
+        this.health = Math.max(0, this.health - 0.18);
+        this.resetCombo();
+    }
+
+    resetCombo() {
+        this.combo = 0;
+        this.multiplier = 1;
+        this.comboTimer = 0;
+    }
+
+    startPhase() {
+        if (this.phaseCooldown > 0 || this.phaseEnergy <= 0.2) return false;
+        this.phaseActive = true;
+        return true;
+    }
+
+    stopPhase() {
+        this.phaseActive = false;
+    }
+
+    isLevelComplete() {
+        const target = this.level.targetBeats || this.stageTargetBeats || 64;
+        return this.elapsedBeats >= target;
+    }
+
+    isGameOver() {
+        return this.lives <= 0;
+    }
+
+    applyStage(levelConfig) {
+        this.level = levelConfig;
+        this.stage = levelConfig.stage || this.stage;
+        this.stageTargetBeats = levelConfig.targetBeats || this.stageTargetBeats;
+        this.elapsedBeats = 0;
+        this.remainingBeats = this.stageTargetBeats;
+        this.pulseWindow = (levelConfig.windowMs || 150) / 1000;
+        if (levelConfig.runMultiplier) {
+            this.runMultiplier = levelConfig.runMultiplier;
+        }
+        if (Array.isArray(levelConfig.modifiers)) {
+            this.setModifierFlags(levelConfig.modifiers);
+        }
+        this.activeDirective = null;
+        this.directiveEvents.length = 0;
+        if (typeof levelConfig.specialCharges === 'number') {
+            this.specialCharges = Math.min(this.maxCharges, Math.max(0, Math.round(levelConfig.specialCharges)));
+        }
+        this.targetParameters = {
+            ...this.targetParameters,
+            gridDensity: levelConfig.difficulty?.density ?? this.targetParameters.gridDensity,
+            morphFactor: levelConfig.difficulty?.morph ?? this.targetParameters.morphFactor,
+            chaos: levelConfig.difficulty?.chaos ?? this.targetParameters.chaos,
+            speed: levelConfig.difficulty?.speed ?? this.targetParameters.speed
+        };
+    }
+
+    setPhaseRegenBonus(value = 0) {
+        this.phaseRegenBonus = Math.max(0, value);
+    }
+
+    activateSlowMo(duration = 3, factor = 0.6) {
+        this.timeWarpTarget = Math.max(0.3, factor);
+        this.timeWarpTimer = Math.max(this.timeWarpTimer, duration);
+        this.timeWarp = this.timeWarpTarget;
+    }
+
+    getTimeWarp() {
+        return this.timeWarp;
+    }
+
+    activateReverseControls(duration = 4) {
+        this.controlInversion = true;
+        this.controlInversionTimer = Math.max(this.controlInversionTimer, duration);
+    }
+
+    isControlInverted() {
+        return this.controlInversion;
+    }
+
+    applyGlitch(level = 1, duration = 2) {
+        this.glitchLevel = Math.max(this.glitchLevel, level);
+        this.glitchTimer = Math.max(this.glitchTimer, duration);
+    }
+
+    getGlitchLevel() {
+        return this.glitchLevel;
+    }
+
+    grantLife() {
+        this.lives = Math.min(5, this.lives + 1);
+        this.health = Math.min(1, this.health + 0.25);
+    }
+
+    gainSpecialCharge(amount = 1) {
+        const delta = Math.max(0, Math.floor(amount));
+        if (!delta) return;
+        this.specialCharges = Math.min(this.maxCharges, this.specialCharges + delta);
+    }
+
+    consumeSpecialCharge() {
+        return this.spendSpecialCharges(1);
+    }
+
+    getChargeState() {
+        return { current: this.specialCharges, max: this.maxCharges };
+    }
+
+    spendSpecialCharges(count = 1) {
+        const needed = Math.max(0, Math.floor(count));
+        if (needed <= 0) return true;
+        if (this.specialCharges < needed) {
+            return false;
+        }
+        this.specialCharges = Math.max(0, this.specialCharges - needed);
+        return true;
+    }
+
+    setModifierFlags(flags = []) {
+        this.modifierFlags = new Set(flags);
+    }
+
+    hasModifier(id) {
+        return this.modifierFlags.has(id);
+    }
+
+    startDirective(definition = {}) {
+        if (!definition) return;
+        if (this.activeDirective) {
+            this.completeDirective(false, 'replaced');
+        }
+        const duration = Math.max(1, definition.duration ?? 3);
+        this.activeDirective = {
+            id: definition.id || `directive-${Date.now()}`,
+            label: definition.label || 'Directive',
+            requirement: definition.requirement || 'pulse-count',
+            goal: Math.max(1, definition.goal ?? 1),
+            progress: 0,
+            remaining: duration,
+            duration,
+            threshold: definition.threshold ?? 0.15,
+            reward: definition.reward || {},
+            penalty: definition.penalty || {},
+            variant: definition.variant || 'info',
+            accumulated: 0
+        };
+        this.directiveEvents.push({ type: 'directive-start', directive: this.getDirectiveState() });
+    }
+
+    updateDirective(dt) {
+        if (!this.activeDirective) return;
+        const directive = this.activeDirective;
+        directive.remaining = Math.max(0, directive.remaining - dt);
+        if (directive.requirement === 'phase-hold') {
+            if (this.phaseActive) {
+                directive.accumulated += dt;
+                directive.progress = directive.accumulated;
+                if (directive.progress >= directive.goal) {
+                    this.completeDirective(true, 'phase-hold');
+                    return;
+                }
+            }
+        }
+        if (directive.remaining <= 0) {
+            if (directive.requirement === 'no-pulse') {
+                this.completeDirective(true, 'timed');
+            } else if (directive.requirement === 'phase-hold') {
+                this.completeDirective(false, 'timeout');
+            } else if (directive.progress < directive.goal) {
+                this.completeDirective(false, 'timeout');
+            }
+        }
+    }
+
+    registerDirectiveAction(action, detail = {}) {
+        if (!this.activeDirective) return false;
+        const directive = this.activeDirective;
+        switch (directive.requirement) {
+            case 'pulse-count':
+                if (action === 'pulse' && detail.success !== false) {
+                    directive.progress += 1;
+                }
+                break;
+            case 'pulse-precision':
+                if (action === 'pulse' && (detail.quality === 'perfect' || detail.quality === 'great')) {
+                    directive.progress += 1;
+                }
+                break;
+            case 'swipe':
+                if (action === 'swipe' && (detail.magnitude || 0) >= (directive.threshold || 0.15)) {
+                    directive.progress += 1;
+                }
+                break;
+            case 'phase-hold':
+                if (action === 'phase-end' && (directive.progress || directive.accumulated || 0) < directive.goal) {
+                    this.completeDirective(false, 'phase-drop');
+                    return true;
+                }
+                break;
+            case 'no-pulse':
+                if (action === 'pulse') {
+                    this.completeDirective(false, 'pulse');
+                    return true;
+                }
+                break;
+            case 'special':
+                if (action === 'special') {
+                    directive.progress += 1;
+                }
+                break;
+            default:
+                break;
+        }
+        if (directive.requirement !== 'phase-hold' && directive.requirement !== 'no-pulse' && directive.progress >= directive.goal) {
+            this.completeDirective(true, 'progress');
+            return true;
+        }
+        return false;
+    }
+
+    completeDirective(success, reason = '') {
+        if (!this.activeDirective) return;
+        const directive = this.activeDirective;
+        const payload = {
+            type: success ? 'directive-complete' : 'directive-fail',
+            status: success ? 'success' : 'fail',
+            id: directive.id,
+            label: directive.label,
+            reward: success ? directive.reward : null,
+            penalty: success ? null : directive.penalty,
+            reason
+        };
+        this.directiveEvents.push(payload);
+        this.activeDirective = null;
+    }
+
+    consumeDirectiveEvents() {
+        if (!this.directiveEvents.length) return [];
+        const events = this.directiveEvents.slice();
+        this.directiveEvents.length = 0;
+        return events;
+    }
+
+    getDirectiveState() {
+        if (!this.activeDirective) return null;
+        const directive = this.activeDirective;
+        const progress = directive.requirement === 'phase-hold'
+            ? Math.min(directive.accumulated || directive.progress || 0, directive.goal)
+            : Math.min(directive.progress, directive.goal);
+        return {
+            id: directive.id,
+            label: directive.label,
+            requirement: directive.requirement,
+            goal: directive.goal,
+            progress,
+            remaining: directive.remaining,
+            duration: directive.duration,
+            variant: directive.variant
+        };
+    }
+
+    hasActiveDirective() {
+        return Boolean(this.activeDirective);
+    }
+}

--- a/src/game/GeometryController.js
+++ b/src/game/GeometryController.js
@@ -1,0 +1,322 @@
+import { createSeededRNG } from './utils/Random.js';
+
+const FACETED_GEOMETRIES = ['TETRA', 'CUBE', 'SPHERE', 'TORUS', 'KLEIN', 'FRACTAL', 'WAVE', 'CRYSTAL'];
+const HOLO_CATEGORY_MAP = [
+    0, 0, 0, 0,
+    1, 1, 1, 1,
+    2, 2, 2, 2,
+    3, 3, 3, 3,
+    4, 4, 4, 4,
+    5, 5, 5,
+    6, 6, 6,
+    7, 7, 7, 7
+];
+
+/**
+ * Geometry-driven spawn rules and visual tweaks.
+ */
+export class GeometryController {
+    constructor(seed = 1234) {
+        this.rng = createSeededRNG(seed);
+        this.mode = 'faceted';
+        this.geometryIndex = 0;
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+    }
+
+    setGeometry(index) {
+        this.geometryIndex = index;
+    }
+
+    /**
+     * Determine geometry id across all systems.
+     */
+    getGeometryId() {
+        if (this.mode === 'holographic') {
+            const category = HOLO_CATEGORY_MAP[this.geometryIndex] ?? 0;
+            return FACETED_GEOMETRIES[Math.min(category, FACETED_GEOMETRIES.length - 1)];
+        }
+        return FACETED_GEOMETRIES[this.geometryIndex % FACETED_GEOMETRIES.length];
+    }
+
+    /**
+     * Generate spawn targets for a beat.
+     */
+    generateTargets(beat, difficulty, audio = {}, modifiers = {}) {
+        const geometry = this.getGeometryId();
+        const generator = GEOMETRY_GENERATORS[geometry] || GEOMETRY_GENERATORS.TETRA;
+        const densityBase = difficulty?.density ?? 0.9;
+        const speed = difficulty?.speed ?? 1.0;
+        const chaos = difficulty?.chaos ?? 0.15;
+        const energy = audio?.energy ?? 0.5;
+        const bass = audio?.bass ?? 0.3;
+        const flux = audio?.flux ?? 0;
+        const densityBias = 0.6 + energy * 0.9 + (modifiers.densityBoost || 0) + (modifiers.bassBias || 0) * bass;
+        const amount = Math.max(1, Math.round(densityBase * (0.5 + densityBias + this.rng.nextFloat() * 0.5)));
+        const targets = [];
+        for (let i = 0; i < amount; i++) {
+            targets.push(generator(this.rng, beat + i * 0.1, { speed, chaos, audio, modifiers, flux }));
+        }
+        return targets;
+    }
+
+    /**
+     * Provide per-geometry parameter biases.
+     */
+    getParameterBias() {
+        const geometry = this.getGeometryId();
+        return GEOMETRY_PARAMETER_BIAS[geometry] || { hueShift: 0, chaos: 1, speed: 1 };
+    }
+
+    generateEventTargets(type, options = {}) {
+        const geometry = this.getGeometryId();
+        switch (type) {
+            case 'quickdraw':
+                return generateQuickDrawTargets(this.rng, geometry, options);
+            case 'burst':
+                return generateBurstTargets(this.rng, geometry, options);
+            default:
+                return [];
+        }
+    }
+}
+
+function randomSign(rng) {
+    return rng.nextFloat() > 0.5 ? 1 : -1;
+}
+
+const GEOMETRY_GENERATORS = {
+    TETRA(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const flux = ctx.flux || audio.flux || 0;
+        const chaosBoost = (ctx.modifiers?.glitchLevel || 0) * 0.2;
+        const base = 0.55 + (audio.mid || 0) * 0.25;
+        return {
+            id: `tetra-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: randomSign(rng) * base,
+                y: randomSign(rng) * base,
+                z: randomSign(rng) * base,
+                w: randomSign(rng) * base
+            },
+            radius: 0.08 + chaosBoost * 0.12,
+            dueBeat: beat + 1.4 - Math.min(0.6, (audio.energy || 0) * 0.35),
+            behavior: flux > 0.25 ? 'pulse-glitch' : 'pulse'
+        };
+    },
+    CUBE(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const reverse = ctx.modifiers?.reverseControls;
+        const axis = rng.choose(['x', 'y', 'z']);
+        const pos = {
+            x: rng.nextRange(-0.9, 0.9),
+            y: rng.nextRange(-0.9, 0.9),
+            z: rng.nextRange(-0.9, 0.9),
+            w: rng.nextRange(-0.7, 0.7)
+        };
+        const offset = rng.nextRange(0.35, 0.8 + (audio.energy || 0) * 0.15);
+        const other = { ...pos };
+        other[axis] += offset;
+        pos[axis] -= offset;
+        return {
+            id: `cube-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: pos,
+            vec4b: other,
+            radius: 0.05,
+            dueBeat: beat + 1.6,
+            behavior: reverse ? 'slide-reverse' : 'slide'
+        };
+    },
+    SPHERE(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const theta = rng.nextRange(0, Math.PI);
+        const phi = rng.nextRange(0, Math.PI * 2);
+        const radius = 0.75 + (audio.energy || 0) * 0.25;
+        return {
+            id: `sphere-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: radius * Math.sin(theta) * Math.cos(phi),
+                y: radius * Math.cos(theta),
+                z: radius * Math.sin(theta) * Math.sin(phi),
+                w: rng.nextRange(-0.4, 0.4)
+            },
+            radius: 0.09 + (audio.high || 0) * 0.04,
+            dueBeat: beat + 1.2 - Math.min(0.4, (audio.energy || 0) * 0.25),
+            behavior: (audio.mid || 0) > 0.5 ? 'orbit-flare' : 'orbit'
+        };
+    },
+    TORUS(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const reverse = ctx.modifiers?.reverseControls;
+        const major = 0.7 + (audio.bass || 0) * 0.25;
+        const minor = 0.22 + (audio.energy || 0) * 0.12;
+        const angle = (beat * (reverse ? -0.9 : 0.9) + rng.nextFloat()) * Math.PI * 2;
+        return {
+            id: `torus-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: {
+                x: (major + minor * Math.cos(angle)) * Math.cos(angle),
+                y: minor * Math.sin(angle * 2),
+                z: (major + minor * Math.cos(angle)) * Math.sin(angle),
+                w: rng.nextRange(-0.5, 0.5)
+            },
+            vec4b: {
+                x: (major + minor * Math.cos(angle + 0.3)) * Math.cos(angle + 0.3),
+                y: minor * Math.sin((angle + 0.3) * 2),
+                z: (major + minor * Math.cos(angle + 0.3)) * Math.sin(angle + 0.3),
+                w: rng.nextRange(-0.5, 0.5)
+            },
+            radius: 0.04 + (audio.mid || 0) * 0.03,
+            dueBeat: beat + 1.8,
+            behavior: reverse ? 'belt-reverse' : 'belt'
+        };
+    },
+    KLEIN(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const u = rng.nextRange(0, Math.PI * 2);
+        const v = rng.nextRange(0, Math.PI * 2);
+        const r = 0.4;
+        const cosU = Math.cos(u);
+        const sinU = Math.sin(u);
+        const cosV = Math.cos(v);
+        const sinV = Math.sin(v);
+        const x = (r + cosU / 2) * cosV;
+        const y = (r + cosU / 2) * sinV;
+        const z = sinU / 2;
+        const w = Math.sin(u) * Math.cos(v);
+        return {
+            id: `klein-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: { x, y, z, w },
+            radius: 0.07 + (audio.high || 0) * 0.03,
+            dueBeat: beat + 1.5 - Math.min(0.4, (audio.energy || 0) * 0.25),
+            behavior: 'invert'
+        };
+    },
+    FRACTAL(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const depth = rng.nextInt(2, 5 + Math.floor((audio.energy || 0) * 3));
+        const scale = 0.5 / depth;
+        const offsets = [rng.nextRange(-1, 1), rng.nextRange(-1, 1), rng.nextRange(-1, 1)];
+        return {
+            id: `fractal-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'cluster',
+            children: Array.from({ length: depth * 2 }, (_, idx) => ({
+                vec4: {
+                    x: offsets[0] + scale * ((idx % 2) ? 1 : -1),
+                    y: offsets[1] + scale * ((idx & 2) ? 1 : -1),
+                    z: offsets[2] + scale * ((idx & 4) ? 1 : -1),
+                    w: rng.nextRange(-0.6, 0.6)
+                },
+                radius: 0.04
+            })),
+            dueBeat: beat + 2.2,
+            radius: 0.04,
+            behavior: ctx.modifiers?.clusterBias ? 'chain-chaos' : 'chain'
+        };
+    },
+    WAVE(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const phase = beat * 0.5 + rng.nextRange(0, Math.PI * 2);
+        const amplitude = 0.6 + (audio.high || 0) * 0.4;
+        return {
+            id: `wave-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'lane',
+            vec4: {
+                x: -0.9,
+                y: Math.sin(phase) * amplitude,
+                z: Math.cos(phase * 1.2) * 0.4,
+                w: Math.sin(phase * 0.7) * 0.4
+            },
+            vec4b: {
+                x: 0.9,
+                y: Math.sin(phase + 0.5) * amplitude,
+                z: Math.cos((phase + 0.5) * 1.2) * 0.4,
+                w: Math.sin((phase + 0.5) * 0.7) * 0.4
+            },
+            radius: 0.05,
+            dueBeat: beat + 1.3,
+            behavior: (audio.mid || 0) > 0.6 ? 'sweep-sync' : 'sweep'
+        };
+    },
+    CRYSTAL(rng, beat, ctx = {}) {
+        const audio = ctx.audio || {};
+        const spikeDir = rng.nextRange(0, Math.PI * 2);
+        const height = rng.nextRange(0.4, 0.9 + (audio.energy || 0) * 0.3);
+        return {
+            id: `crystal-${beat.toFixed(2)}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: Math.cos(spikeDir) * 0.4,
+                y: height,
+                z: Math.sin(spikeDir) * 0.4,
+                w: rng.nextRange(-0.3, 0.3)
+            },
+            radius: 0.06 + (audio.high || 0) * 0.05,
+            dueBeat: beat + 1.6 - Math.min(0.3, (audio.energy || 0) * 0.2),
+            behavior: ctx.modifiers?.glitchLevel ? 'shard-glitch' : 'shard'
+        };
+    }
+};
+
+const GEOMETRY_PARAMETER_BIAS = {
+    TETRA: { hueShift: 0, chaos: 0.8, speed: 1.05 },
+    CUBE: { hueShift: 12, chaos: 1.0, speed: 1.0 },
+    SPHERE: { hueShift: 48, chaos: 0.9, speed: 0.95 },
+    TORUS: { hueShift: 84, chaos: 1.1, speed: 1.1 },
+    KLEIN: { hueShift: 132, chaos: 1.3, speed: 0.9 },
+    FRACTAL: { hueShift: 210, chaos: 1.5, speed: 0.85 },
+    WAVE: { hueShift: 280, chaos: 1.2, speed: 1.2 },
+    CRYSTAL: { hueShift: 320, chaos: 0.75, speed: 0.9 }
+};
+
+function generateQuickDrawTargets(rng, geometry, { count = 3 } = {}) {
+    const targets = [];
+    for (let i = 0; i < count; i++) {
+        const angle = rng.nextRange(0, Math.PI * 2);
+        const radial = 0.55 + rng.nextRange(-0.15, 0.2);
+        const height = geometry === 'CRYSTAL' ? rng.nextRange(0.2, 0.9) : rng.nextRange(-0.4, 0.6);
+        targets.push({
+            id: `quick-${geometry.toLowerCase()}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: Math.cos(angle) * radial,
+                y: height,
+                z: Math.sin(angle) * radial,
+                w: rng.nextRange(-0.35, 0.35)
+            },
+            radius: 0.12,
+            dueBeat: 0.2,
+            behavior: 'quickdraw'
+        });
+    }
+    return targets;
+}
+
+function generateBurstTargets(rng, geometry, { count = 5 } = {}) {
+    const targets = [];
+    for (let i = 0; i < count; i++) {
+        const angle = (i / Math.max(1, count)) * Math.PI * 2 + rng.nextRange(-0.2, 0.2);
+        const radial = 0.4 + rng.nextRange(-0.08, 0.12);
+        const height = geometry === 'CRYSTAL' ? rng.nextRange(0.2, 0.85) : rng.nextRange(-0.35, 0.6);
+        targets.push({
+            id: `burst-${geometry.toLowerCase()}-${rng.nextInt(0, 9999)}`,
+            type: 'node',
+            vec4: {
+                x: Math.cos(angle) * radial,
+                y: height,
+                z: Math.sin(angle) * radial,
+                w: rng.nextRange(-0.3, 0.3)
+            },
+            radius: 0.1,
+            dueBeat: 0.4 + (i % 3) * 0.1,
+            behavior: 'burst'
+        });
+    }
+    return targets;
+}

--- a/src/game/InputMapping.js
+++ b/src/game/InputMapping.js
@@ -1,0 +1,187 @@
+/**
+ * Maps touch + pointer gestures into high-level events for the game.
+ */
+export class InputMapping {
+    constructor(element, { planes = ['XW', 'YW'] } = {}) {
+        this.element = element;
+        this.planes = planes;
+        this.listeners = new Map();
+        this.pulses = [];
+        this.activePointers = new Map();
+        this.initialPinchDistance = null;
+        this.lastTilt = { beta: 0, gamma: 0 };
+
+        ['rotate', 'pulse', 'pinch', 'longpressstart', 'longpressend', 'tilt', 'special', 'swipeend'].forEach((evt) => {
+            this.listeners.set(evt, new Set());
+        });
+
+        this.element.addEventListener('pointerdown', (e) => this.onPointerDown(e));
+        this.element.addEventListener('pointermove', (e) => this.onPointerMove(e));
+        this.element.addEventListener('pointerup', (e) => this.onPointerUp(e));
+        this.element.addEventListener('pointercancel', (e) => this.onPointerCancel(e));
+        this.element.addEventListener('pointerout', (e) => this.onPointerCancel(e));
+
+        this.setupTilt();
+
+        this.lastTapTime = 0;
+        this.specialTapWindow = 220;
+    }
+
+    on(event, callback) {
+        const set = this.listeners.get(event);
+        if (!set) return () => {};
+        set.add(callback);
+        return () => set.delete(callback);
+    }
+
+    emit(event, detail) {
+        const set = this.listeners.get(event);
+        if (!set) return;
+        set.forEach((callback) => callback(detail));
+    }
+
+    onPointerDown(event) {
+        this.element.setPointerCapture?.(event.pointerId);
+        const pointer = this.createPointerState(event);
+        this.activePointers.set(event.pointerId, pointer);
+        pointer.longPressTimeout = setTimeout(() => {
+            pointer.longPressed = true;
+            this.emit('longpressstart', { position: pointer.position });
+        }, 450);
+    }
+
+    onPointerMove(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (!pointer) return;
+        const prevPos = pointer.position;
+        pointer.position = this.normalizePosition(event);
+        pointer.deltaX += pointer.position.x - prevPos.x;
+        pointer.deltaY += pointer.position.y - prevPos.y;
+
+        if (this.activePointers.size === 2) {
+            this.handlePinch();
+        } else {
+            this.emit('rotate', {
+                deltaX: pointer.position.x - prevPos.x,
+                deltaY: pointer.position.y - prevPos.y,
+                plane: this.planes[0]
+            });
+        }
+    }
+
+    onPointerUp(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (!pointer) return;
+        clearTimeout(pointer.longPressTimeout);
+
+        const elapsed = performance.now() - pointer.startTime;
+        const moved = Math.hypot(pointer.deltaX, pointer.deltaY);
+
+        if (pointer.longPressed) {
+            this.emit('longpressend', {});
+        } else if (elapsed < 250 && moved < 0.03) {
+            // tap -> pulse
+            const pulse = {
+                position: pointer.position,
+                radius: 0.1,
+                timestamp: performance.now()
+            };
+            const now = performance.now();
+            if (now - this.lastTapTime < this.specialTapWindow) {
+                this.emit('special', { position: pointer.position });
+                this.lastTapTime = 0;
+            } else {
+                this.lastTapTime = now;
+            }
+            this.pulses.push(pulse);
+            this.emit('pulse', pulse);
+        } else {
+            this.emit('rotate', {
+                deltaX: pointer.deltaX,
+                deltaY: pointer.deltaY,
+                plane: this.planes[1] || this.planes[0]
+            });
+            this.emit('swipeend', {
+                deltaX: pointer.deltaX,
+                deltaY: pointer.deltaY,
+                duration: elapsed / 1000
+            });
+        }
+
+        this.activePointers.delete(event.pointerId);
+        if (this.activePointers.size < 2) {
+            this.initialPinchDistance = null;
+        }
+    }
+
+    onPointerCancel(event) {
+        const pointer = this.activePointers.get(event.pointerId);
+        if (pointer) {
+            clearTimeout(pointer.longPressTimeout);
+        }
+        this.activePointers.delete(event.pointerId);
+    }
+
+    handlePinch() {
+        const pointers = Array.from(this.activePointers.values());
+        if (pointers.length !== 2) return;
+        const [a, b] = pointers;
+        const dx = a.position.x - b.position.x;
+        const dy = a.position.y - b.position.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (this.initialPinchDistance == null) {
+            this.initialPinchDistance = distance;
+            return;
+        }
+        const scale = distance / (this.initialPinchDistance || 0.0001);
+        this.emit('pinch', { scaleDelta: scale - 1 });
+        this.initialPinchDistance = distance;
+    }
+
+    setupTilt() {
+        if (typeof DeviceOrientationEvent === 'undefined') return;
+        const handler = (event) => {
+            this.lastTilt = { beta: event.beta || 0, gamma: event.gamma || 0 };
+            this.emit('tilt', this.lastTilt);
+        };
+        if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+            window.addEventListener('click', async () => {
+                try {
+                    const res = await DeviceOrientationEvent.requestPermission();
+                    if (res === 'granted') {
+                        window.addEventListener('deviceorientation', handler);
+                    }
+                } catch (err) {
+                    console.warn('Tilt permission denied', err);
+                }
+            }, { once: true });
+        } else {
+            window.addEventListener('deviceorientation', handler);
+        }
+    }
+
+    createPointerState(event) {
+        return {
+            startTime: performance.now(),
+            position: this.normalizePosition(event),
+            deltaX: 0,
+            deltaY: 0,
+            longPressTimeout: null,
+            longPressed: false
+        };
+    }
+
+    normalizePosition(event) {
+        const rect = this.element.getBoundingClientRect();
+        return {
+            x: (event.clientX - rect.left) / rect.width,
+            y: (event.clientY - rect.top) / rect.height
+        };
+    }
+
+    consumePulses() {
+        const output = this.pulses.slice();
+        this.pulses.length = 0;
+        return output;
+    }
+}

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -1,0 +1,438 @@
+import { GameLoop } from './GameLoop.js';
+import { AudioService } from './AudioService.js';
+import { ModeController } from './ModeController.js';
+import { GeometryController } from './GeometryController.js';
+import { SpawnSystem } from './SpawnSystem.js';
+import { CollisionSystem } from './CollisionSystem.js';
+import { InputMapping } from './InputMapping.js';
+import { EffectsManager } from './EffectsManager.js';
+import { PerformanceController } from './PerformanceController.js';
+import { LevelManager } from './LevelManager.js';
+import { GameState } from './GameState.js';
+import { LocalPersistence } from './persistence/LocalPersistence.js';
+import { HUDRenderer } from './ui/HUDRenderer.js';
+import { RogueLiteManager } from './RogueLiteManager.js';
+
+let canvasRoot;
+let inputLayer;
+let hudRoot;
+let startScreen;
+let startButton;
+let modeController;
+let audioService;
+let geometryController;
+let spawnSystem;
+let collisionSystem;
+let inputMapping;
+let effectsManager;
+let performanceController;
+let levelManager;
+let persistence;
+let hud;
+let gameState;
+let currentLevel;
+let gameLoop;
+let rogueLite;
+let activeSpawnContext = {};
+let awaitingStart = true;
+let startButtonAction = null;
+
+window.audioReactive = { bass: 0, mid: 0, high: 0 };
+
+function ready(fn) {
+    if (document.readyState !== 'loading') {
+        fn();
+    } else {
+        document.addEventListener('DOMContentLoaded', fn);
+    }
+}
+
+ready(async () => {
+    canvasRoot = document.getElementById('lp-canvas-root');
+    inputLayer = document.getElementById('lp-input-layer');
+    hudRoot = document.getElementById('lp-hud');
+    startScreen = document.getElementById('lp-start-screen');
+    startButton = document.getElementById('lp-start-button');
+    startButton.addEventListener('click', handleStartButton);
+
+    persistence = new LocalPersistence();
+    modeController = new ModeController(canvasRoot);
+    audioService = new AudioService();
+    collisionSystem = new CollisionSystem();
+    effectsManager = new EffectsManager();
+    performanceController = new PerformanceController((lod) => modeController.applyLOD(lod));
+    hud = new HUDRenderer(hudRoot, persistence);
+    rogueLite = new RogueLiteManager({ audioService, hud, persistence });
+    inputMapping = new InputMapping(inputLayer);
+
+    levelManager = new LevelManager();
+    const levels = await levelManager.load();
+    rogueLite.setTemplates(levels);
+    currentLevel = rogueLite.startRun(levels[0]);
+
+    await configureLevel(currentLevel, { fresh: true });
+    startScreen.querySelector('.lp-start-title').textContent = 'Lattice Pulse';
+    startScreen.querySelector('.lp-start-subtitle').textContent = `Stage ${currentLevel.stage || 1} • ${currentLevel.id}`;
+    startButton.textContent = 'Start';
+
+    setupInput();
+    setupAudioCallbacks();
+
+        const update = (dt) => {
+            if (awaitingStart) return;
+            audioService.update(dt);
+            const analysis = audioService.getAnalysis();
+            const rogueUpdate = rogueLite.update(dt, analysis, gameState);
+        activeSpawnContext = {
+            ...(rogueUpdate.spawnModifiers || {}),
+            tempoMultiplier: rogueUpdate.effects?.tempoMultiplier || rogueUpdate.spawnModifiers?.tempoMultiplier || 1,
+            reverseControls: rogueUpdate.effects?.reverseControls || rogueUpdate.spawnModifiers?.reverseControls || false
+        };
+        spawnSystem.setSpawnContext(activeSpawnContext);
+            processRogueEvents(rogueUpdate.events);
+
+            gameState.update(dt);
+            const directiveEvents = gameState.consumeDirectiveEvents?.() || [];
+            processDirectiveEvents(directiveEvents);
+            gameState.settleParameters(dt);
+            const directiveState = gameState.getDirectiveState?.();
+
+            const biasedParams = applyGeometryBias(gameState.getParameters(), geometryController.getParameterBias());
+            const finalParams = clampParameters(effectsManager.update(dt, biasedParams, gameState, rogueUpdate.effects, analysis));
+            const aspect = canvasRoot.clientWidth / canvasRoot.clientHeight;
+            const scaledDt = dt * Math.max(0.25, gameState.getTimeWarp?.() || 1);
+        const { expiredTargets } = spawnSystem.update(scaledDt, finalParams, aspect, activeSpawnContext);
+        collisionSystem.rebuild(spawnSystem.getActiveTargets());
+
+        processPulses();
+        handleExpired(expiredTargets);
+
+        modeController.updateParameters(finalParams);
+            hud.update(gameState, {
+                stage: rogueUpdate.stage,
+                modifiers: rogueUpdate.persistentModifiers,
+                effects: rogueUpdate.effects,
+                analysis,
+                charges: gameState.getChargeState(),
+                runId: rogueUpdate.runId,
+                directive: directiveState
+            });
+            checkLevelEnd();
+        };
+
+    const render = () => {
+        performanceController.beginFrame();
+        modeController.render();
+        performanceController.endFrame();
+    };
+
+    gameLoop = new GameLoop(update, render);
+
+    startButtonAction = async () => {
+        if (!awaitingStart) return;
+        awaitingStart = false;
+        startScreen.classList.add('hidden');
+        await audioService.start();
+        hud.setStatus('Ride the lattice. Tap beats, swipe space.');
+        gameLoop.start();
+    };
+});
+
+async function handleStartButton() {
+    if (typeof startButtonAction === 'function') {
+        await startButtonAction();
+    }
+}
+
+function setupInput() {
+    inputMapping.on('rotate', ({ deltaX, deltaY }) => {
+        if (!gameState) return;
+        const invert = typeof gameState.isControlInverted === 'function' && gameState.isControlInverted() ? -1 : 1;
+        const factor = 3.0 * invert;
+        gameState.applyParameterDelta({
+            rot4dXW: deltaY * factor,
+            rot4dYW: deltaX * factor
+        });
+    });
+
+    inputMapping.on('swipeend', ({ deltaX, deltaY, duration }) => {
+        if (!gameState) return;
+        const magnitude = Math.hypot(deltaX, deltaY);
+        gameState.registerDirectiveAction?.('swipe', { magnitude, duration });
+    });
+
+    inputMapping.on('pinch', ({ scaleDelta }) => {
+        gameState.applyParameterDelta({ dimension: scaleDelta * 1.2 });
+    });
+
+    inputMapping.on('pulse', () => {
+        gameState.applyParameterDelta({ intensity: 0.05 });
+    });
+
+    inputMapping.on('special', () => {
+        if (awaitingStart) return;
+        const action = rogueLite?.handleSpecialTap(gameState);
+        if (!action) return;
+        if (action.type === 'slowmo') {
+            gameState.activateSlowMo(action.duration, action.factor);
+            effectsManager.trigger('slowmo');
+            hud.flash('Slow Motion');
+        } else if (action.type === 'extra-life') {
+            gameState.grantLife();
+            hud.flash('Extra Life');
+        }
+        gameState.registerDirectiveAction?.('special');
+    });
+
+    inputMapping.on('longpressstart', () => {
+        if (gameState.startPhase()) {
+            effectsManager.trigger('shield');
+            hud.flash('Phase Shift');
+        }
+    });
+
+    inputMapping.on('longpressend', () => {
+        gameState.stopPhase();
+        gameState.registerDirectiveAction?.('phase-end');
+    });
+
+    inputMapping.on('tilt', ({ beta, gamma }) => {
+        const tiltX = gamma / 180;
+        const tiltY = beta / 180;
+        gameState.applyParameterDelta({ rot4dXW: tiltY * 0.02, rot4dYW: tiltX * 0.02 });
+    });
+}
+
+function setupAudioCallbacks() {
+    audioService.onBeat((beatInfo) => {
+        if (awaitingStart) return;
+        const analysis = audioService.getAnalysis();
+        spawnSystem.handleBeat(beatInfo, analysis, activeSpawnContext);
+        gameState.registerBeat();
+    });
+}
+
+function processPulses() {
+    const pulses = inputMapping.consumePulses();
+    pulses.forEach((pulse) => {
+        pulse.radius = 0.08 + gameState.pulseWindow * 0.6;
+        const hits = collisionSystem.resolvePulse(pulse);
+        let bestQuality = 'miss';
+        if (hits.length) {
+            hits.forEach(({ target, quality }) => {
+                if (qualityScore(quality) > qualityScore(bestQuality)) {
+                    bestQuality = quality;
+                }
+                spawnSystem.removeTarget(target.id);
+                gameState.registerHit(quality);
+                effectsManager.trigger('score', { quality });
+                if (target.event) {
+                    rogueLite?.handleTargetResolved(target, quality);
+                }
+            });
+            collisionSystem.rebuild(spawnSystem.getActiveTargets());
+        } else {
+            gameState.registerMiss();
+            effectsManager.trigger('miss');
+            hud.flash('Miss');
+        }
+        gameState.registerDirectiveAction?.('pulse', { success: hits.length > 0, quality: hits.length ? bestQuality : 'miss' });
+    });
+}
+
+function handleExpired(expiredTargets) {
+    expiredTargets.forEach((target) => {
+        gameState.registerMiss();
+        effectsManager.trigger('miss');
+        if (target) {
+            rogueLite?.handleTargetExpired(target);
+        }
+    });
+}
+
+function processRogueEvents(events = []) {
+    events.forEach((event) => {
+        if (!event) return;
+        switch (event.type) {
+            case 'callout':
+                hud.showCallout(event.text, event.variant, event.duration);
+                break;
+            case 'effect-start':
+                if (event.id === 'glitch') {
+                    gameState.applyGlitch(event.data?.glitchLevel ?? 1, event.duration || 4);
+                    effectsManager.trigger('glitch');
+                } else if (event.id === 'reverse') {
+                    gameState.activateReverseControls(event.duration || 4);
+                    effectsManager.trigger('reverse-start');
+                    hud.flash('Reverse Flow');
+                } else if (event.id === 'tempo-shift') {
+                    effectsManager.trigger('tempo');
+                    hud.flash('Tempo Warp');
+                }
+                break;
+            case 'effect-end':
+                if (event.id === 'reverse') {
+                    effectsManager.trigger('reverse-end');
+                    hud.setStatus('Flow restored');
+                }
+                break;
+            case 'spawn-event':
+                spawnSystem.injectEventTargets(event.event);
+                break;
+            case 'directive':
+                if (event.directiveId) {
+                    const def = rogueLite.getDirectiveDefinition?.(event.directiveId);
+                    if (def) {
+                        gameState.startDirective(def);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+    });
+}
+
+function processDirectiveEvents(events = []) {
+    events.forEach((event) => {
+        if (!event) return;
+        switch (event.type) {
+            case 'directive-start':
+                if (event.directive) {
+                    hud.announceDirective(event.directive);
+                }
+                effectsManager.trigger('directive-start');
+                break;
+            case 'directive-complete':
+                effectsManager.trigger('directive-success');
+                rogueLite?.handleDirectiveOutcome(event, gameState);
+                hud.finishDirective('success', event);
+                break;
+            case 'directive-fail':
+                effectsManager.trigger('directive-fail');
+                rogueLite?.handleDirectiveOutcome(event, gameState);
+                hud.finishDirective('fail', event);
+                break;
+            default:
+                break;
+        }
+    });
+}
+
+async function configureLevel(level, { fresh = false } = {}) {
+    if (!geometryController || fresh) {
+        geometryController = new GeometryController(level.seed || Math.floor(Math.random() * 10000));
+        geometryController.setMode(level.system);
+        geometryController.setGeometry(level.geometryIndex || 0);
+        spawnSystem = new SpawnSystem(geometryController);
+    } else {
+        geometryController.setMode(level.system);
+        geometryController.setGeometry(level.geometryIndex ?? geometryController.geometryIndex);
+    }
+    spawnSystem.setDifficulty(level.difficulty || {});
+    spawnSystem.reset();
+    activeSpawnContext = {};
+
+    if (!gameState || fresh) {
+        gameState = new GameState(level);
+    } else {
+        gameState.applyStage(level);
+    }
+    if (Array.isArray(level.modifiers)) {
+        gameState.setModifierFlags(level.modifiers);
+    }
+
+    modeController.setActiveMode(level.system);
+    modeController.setVariant(level.variantIndex ?? level.geometryIndex ?? 0);
+    modeController.resize();
+    hud.setLevel(level, {
+        stage: level.stage || rogueLite?.getStage?.() || 1,
+        modifiers: rogueLite?.getPersistentModifiers?.() || []
+    });
+
+    if (fresh) {
+        await audioService.loadTrack({ url: level.track?.url || null, bpm: level.bpm });
+    }
+    audioService.setBPM(level.bpm);
+}
+
+function checkLevelEnd() {
+    if (gameState.isGameOver()) {
+        awaitingStart = true;
+        const summary = rogueLite?.completeRun(gameState);
+        const improved = summary ? persistence.recordRunResult(summary.baseId, summary) : false;
+        hud.setStatus('Run over. Tap to launch again.', 'alert');
+        if (summary) {
+            hud.showRunSummary(summary, improved);
+        }
+        audioService.stop();
+        gameLoop.stop();
+        startScreen.classList.remove('hidden');
+        startScreen.querySelector('.lp-start-title').textContent = 'Run Over';
+        startButton.textContent = 'New Run';
+        startScreen.querySelector('.lp-start-subtitle').textContent = 'Ready for another climb?';
+        startButtonAction = async () => {
+            startScreen.classList.add('hidden');
+            awaitingStart = false;
+            currentLevel = rogueLite.startRun();
+            await configureLevel(currentLevel, { fresh: true });
+            await audioService.start();
+            hud.setStatus('Stay in phase.');
+            gameLoop.start();
+        };
+        return;
+    }
+
+    if (gameState.isLevelComplete()) {
+        const nextStage = rogueLite?.advanceStage(gameState);
+        if (nextStage) {
+            currentLevel = nextStage;
+            configureLevel(nextStage);
+            hud.flash(`Stage ${nextStage.stage} Clear!`);
+            hud.setStatus('Stage up! Stay sharp.');
+        }
+    }
+}
+
+function applyGeometryBias(params, bias) {
+    const result = { ...params };
+    if (!bias) return result;
+    result.hue = (result.hue + bias.hueShift) % 360;
+    result.chaos *= bias.chaos;
+    result.speed *= bias.speed;
+    return result;
+}
+
+function clampParameters(params) {
+    return {
+        ...params,
+        gridDensity: clamp(params.gridDensity, 5, 90),
+        morphFactor: clamp(params.morphFactor, 0, 2),
+        chaos: clamp(params.chaos, 0, 1.5),
+        speed: clamp(params.speed, 0.3, 3.2),
+        hue: ((params.hue % 360) + 360) % 360,
+        intensity: clamp(params.intensity, 0.1, 1.2),
+        saturation: clamp(params.saturation, 0, 1),
+        dimension: clamp(params.dimension, 3.0, 4.5),
+        rot4dXW: clamp(params.rot4dXW, -2.5, 2.5),
+        rot4dYW: clamp(params.rot4dYW, -2.5, 2.5),
+        rot4dZW: clamp(params.rot4dZW, -2.5, 2.5)
+    };
+}
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+function qualityScore(quality) {
+    switch (quality) {
+        case 'perfect':
+            return 3;
+        case 'great':
+            return 2;
+        case 'good':
+            return 1;
+        default:
+            return 0;
+    }
+}

--- a/src/game/LevelManager.js
+++ b/src/game/LevelManager.js
@@ -1,0 +1,79 @@
+/**
+ * Loads seedable level presets and advances through the campaign graph.
+ */
+export class LevelManager {
+    constructor() {
+        this.levels = [];
+        this.currentIndex = 0;
+        this.loaded = false;
+    }
+
+    async load() {
+        const levelFiles = [
+            'lvl-01-faceted-torus.json',
+            'lvl-02-quantum-sphere.json',
+            'lvl-03-holographic-crystal.json'
+        ];
+        const loadedLevels = [];
+        for (const file of levelFiles) {
+            try {
+                const url = new URL(`./levels/${file}`, import.meta.url);
+                const response = await fetch(url);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const data = await response.json();
+                loadedLevels.push(data);
+            } catch (err) {
+                console.warn(`LevelManager: failed to load ${file}`, err);
+            }
+        }
+        if (loadedLevels.length === 0) {
+            console.warn('LevelManager: Falling back to default inline level.');
+            loadedLevels.push(defaultLevel());
+        }
+        this.levels = loadedLevels;
+        this.loaded = true;
+        return this.levels;
+    }
+
+    getCurrentLevel() {
+        return this.levels[this.currentIndex];
+    }
+
+    nextLevel() {
+        this.currentIndex = (this.currentIndex + 1) % this.levels.length;
+        return this.getCurrentLevel();
+    }
+
+    reset() {
+        this.currentIndex = 0;
+    }
+}
+
+function defaultLevel() {
+    return {
+        id: 'fallback-faceted',
+        system: 'faceted',
+        geometryIndex: 3,
+        track: {
+            url: null,
+            id: 'metronome'
+        },
+        bpm: 120,
+        seed: 1024,
+        planes: ['XW', 'YW'],
+        windowMs: 160,
+        spawn: { pattern: 'belt', density: 0.8 },
+        powerups: ['pulse+'],
+        targetBeats: 64,
+        difficulty: {
+            speed: 1.0,
+            chaos: 0.15,
+            density: 1.0
+        },
+        color: {
+            hue: 210,
+            intensity: 0.55,
+            saturation: 0.85
+        }
+    };
+}

--- a/src/game/ModeController.js
+++ b/src/game/ModeController.js
@@ -1,0 +1,225 @@
+import { IntegratedHolographicVisualizer } from '../core/Visualizer.js';
+import { QuantumHolographicVisualizer } from '../quantum/QuantumVisualizer.js';
+import { HolographicVisualizer } from '../holograms/HolographicVisualizer.js';
+
+const LAYERS = [
+    { role: 'background', reactivity: 0.5 },
+    { role: 'shadow', reactivity: 0.7 },
+    { role: 'content', reactivity: 0.9 },
+    { role: 'highlight', reactivity: 1.1 },
+    { role: 'accent', reactivity: 1.45 }
+];
+
+const MODE_CONFIG = {
+    faceted: IntegratedHolographicVisualizer,
+    quantum: QuantumHolographicVisualizer,
+    holographic: HolographicVisualizer
+};
+
+/**
+ * Instantiates and coordinates the visualizer stack per mode.
+ */
+export class ModeController {
+    constructor(rootElement) {
+        this.root = rootElement;
+        this.modes = new Map();
+        this.activeMode = null;
+        this.currentVariant = 0;
+        this.lodBias = 0;
+        this.lastParameters = null;
+        this.resizeHandler = () => this.resize();
+
+        Object.entries(MODE_CONFIG).forEach(([modeName, Visualizer]) => {
+            this.createMode(modeName, Visualizer);
+        });
+
+        window.addEventListener('resize', this.resizeHandler, { passive: true });
+        this.setActiveMode('faceted');
+    }
+
+    createMode(name, VisualizerClass) {
+        const container = document.createElement('div');
+        container.className = 'lp-mode-stage';
+        container.dataset.mode = name;
+        container.style.visibility = 'hidden';
+        container.style.opacity = '0';
+        this.root.appendChild(container);
+
+        this.modes.set(name, {
+            container,
+            VisualizerClass,
+            layers: [],
+            params: null,
+            variant: this.currentVariant,
+            initialized: false
+        });
+    }
+
+    setActiveMode(name) {
+        if (!this.modes.has(name)) return;
+        const targetMode = this.ensureModeInitialized(name);
+        this.modes.forEach((mode, key) => {
+            const isActive = key === name;
+            mode.container.classList.toggle('active', isActive);
+            mode.container.style.visibility = isActive ? 'visible' : 'hidden';
+            mode.container.style.opacity = isActive ? '1' : '0';
+        });
+        this.activeMode = name;
+        if (targetMode && this.lastParameters) {
+            this.updateParameters(this.lastParameters);
+        }
+    }
+
+    getActiveMode() {
+        return this.activeMode;
+    }
+
+    setVariant(variant) {
+        this.currentVariant = variant;
+        this.modes.forEach((mode) => {
+            mode.variant = variant;
+            if (!mode.initialized) return;
+            mode.layers.forEach(({ visualizer }) => {
+                visualizer.variant = variant;
+                if (typeof visualizer.generateVariantParams === 'function') {
+                    visualizer.variantParams = visualizer.generateVariantParams(variant);
+                    if (typeof visualizer.generateRoleParams === 'function') {
+                        visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
+                    }
+                }
+                if (typeof visualizer.updateParameters === 'function') {
+                    visualizer.updateParameters({ geometry: variant % 8 });
+                }
+            });
+        });
+    }
+
+    updateParameters(params) {
+        this.lastParameters = params;
+        const active = this.ensureModeInitialized(this.activeMode);
+        if (!active) return;
+        active.params = params;
+        const adjusted = paramsWithLod(params, this.lodBias);
+        active.layers.forEach(({ visualizer }) => {
+            if (typeof visualizer.updateParameters === 'function') {
+                visualizer.updateParameters(adjusted);
+            }
+        });
+    }
+
+    render() {
+        const active = this.ensureModeInitialized(this.activeMode);
+        if (!active) return;
+        active.layers.forEach(({ visualizer }) => {
+            if (typeof visualizer.render === 'function') {
+                visualizer.render();
+            }
+        });
+    }
+
+    applyLOD(level) {
+        this.lodBias = level;
+        if (this.lastParameters) {
+            this.updateParameters(this.lastParameters);
+        }
+    }
+
+    resize() {
+        this.modes.forEach((mode) => {
+            if (!mode.initialized) return;
+            mode.layers.forEach(({ canvas, visualizer }) => {
+                const dpr = Math.min(window.devicePixelRatio || 1, 2);
+                const width = canvas.clientWidth || mode.container.clientWidth || this.root.clientWidth || window.innerWidth;
+                const height = canvas.clientHeight || mode.container.clientHeight || this.root.clientHeight || window.innerHeight;
+                if (!width || !height) return;
+                const bufferWidth = Math.floor(width * dpr);
+                const bufferHeight = Math.floor(height * dpr);
+                if (canvas.width !== bufferWidth || canvas.height !== bufferHeight) {
+                    canvas.width = bufferWidth;
+                    canvas.height = bufferHeight;
+                }
+                if (visualizer && typeof visualizer.resize === 'function') {
+                    visualizer.resize();
+                } else if (visualizer?.gl) {
+                    visualizer.gl.viewport(0, 0, canvas.width, canvas.height);
+                }
+            });
+        });
+    }
+
+    ensureModeInitialized(name) {
+        const mode = this.modes.get(name);
+        if (!mode || mode.initialized) {
+            return mode;
+        }
+
+        mode.layers = LAYERS.map((layer, index) => {
+            const canvas = document.createElement('canvas');
+            canvas.id = `lp-${name}-${index}`;
+            canvas.className = 'lp-canvas-layer';
+            mode.container.appendChild(canvas);
+            const visualizer = new mode.VisualizerClass(canvas.id, layer.role, layer.reactivity, this.currentVariant);
+
+            if (typeof visualizer.generateVariantParams === 'function') {
+                visualizer.variantParams = visualizer.generateVariantParams(this.currentVariant);
+                if (typeof visualizer.generateRoleParams === 'function') {
+                    visualizer.roleParams = visualizer.generateRoleParams(visualizer.role);
+                }
+            }
+
+            if (typeof visualizer.updateParameters === 'function') {
+                visualizer.updateParameters({ geometry: this.currentVariant % 8 });
+            }
+
+            return { canvas, visualizer, layer };
+        });
+
+        mode.initialized = true;
+        mode.variant = this.currentVariant;
+
+        this.resizeMode(mode);
+
+        if (this.lastParameters) {
+            const adjusted = paramsWithLod(this.lastParameters, this.lodBias);
+            mode.layers.forEach(({ visualizer }) => {
+                if (typeof visualizer.updateParameters === 'function') {
+                    visualizer.updateParameters(adjusted);
+                }
+            });
+        }
+
+        return mode;
+    }
+
+    resizeMode(mode) {
+        if (!mode.initialized) return;
+        const dpr = Math.min(window.devicePixelRatio || 1, 2);
+        mode.layers.forEach(({ canvas, visualizer }) => {
+            const width = canvas.clientWidth || mode.container.clientWidth || this.root.clientWidth || window.innerWidth;
+            const height = canvas.clientHeight || mode.container.clientHeight || this.root.clientHeight || window.innerHeight;
+            if (!width || !height) return;
+            const bufferWidth = Math.floor(width * dpr);
+            const bufferHeight = Math.floor(height * dpr);
+            if (canvas.width !== bufferWidth || canvas.height !== bufferHeight) {
+                canvas.width = bufferWidth;
+                canvas.height = bufferHeight;
+            }
+            if (visualizer && typeof visualizer.resize === 'function') {
+                visualizer.resize();
+            } else if (visualizer?.gl) {
+                visualizer.gl.viewport(0, 0, canvas.width, canvas.height);
+            }
+        });
+    }
+}
+
+function paramsWithLod(params, lodBias) {
+    if (!lodBias) return params;
+    const factor = Math.max(0.4, 1 - 0.25 * lodBias);
+    return {
+        ...params,
+        gridDensity: params.gridDensity * factor,
+        chaos: params.chaos * factor,
+        intensity: params.intensity * (1 - 0.1 * lodBias)
+    };
+}

--- a/src/game/PerformanceController.js
+++ b/src/game/PerformanceController.js
@@ -1,0 +1,41 @@
+/**
+ * Monitors render frame times and requests LOD adjustments when needed.
+ */
+export class PerformanceController {
+    constructor(callback) {
+        this.callback = callback;
+        this.samples = [];
+        this.windowSize = 90;
+        this.currentLevel = 0; // 0 = high, 1 = medium, 2 = low
+        this.frameStart = 0;
+    }
+
+    beginFrame() {
+        this.frameStart = performance.now();
+    }
+
+    endFrame() {
+        if (!this.frameStart) return;
+        const duration = performance.now() - this.frameStart;
+        this.samples.push(duration);
+        if (this.samples.length >= this.windowSize) {
+            const avgDuration = this.samples.reduce((acc, val) => acc + val, 0) / this.samples.length;
+            const fps = 1000 / avgDuration;
+            let targetLevel = this.currentLevel;
+            if (fps < 48) {
+                targetLevel = 2;
+            } else if (fps < 55) {
+                targetLevel = Math.max(targetLevel, 1);
+            } else if (fps > 58 && this.currentLevel > 0) {
+                targetLevel = this.currentLevel - 1;
+            }
+            if (targetLevel !== this.currentLevel) {
+                this.currentLevel = targetLevel;
+                if (this.callback) {
+                    this.callback(targetLevel);
+                }
+            }
+            this.samples.length = 0;
+        }
+    }
+}

--- a/src/game/RogueLiteManager.js
+++ b/src/game/RogueLiteManager.js
@@ -1,0 +1,658 @@
+const MODIFIER_POOL = [
+    {
+        id: 'bass-rush',
+        label: 'Bass Rush',
+        description: 'Bass peaks slam extra lattice shards into the grid.',
+        effects: { densityBoost: 0.4, bassBias: 0.65 }
+    },
+    {
+        id: 'phase-loop',
+        label: 'Phase Loop',
+        description: 'Phase energy regenerates faster while combos stay alive.',
+        effects: { phaseRegenBonus: 0.25 }
+    },
+    {
+        id: 'fracture',
+        label: 'Fracture Chains',
+        description: 'Fractal and crystal geometries spawn more cluster events.',
+        effects: { clusterBias: 0.35 }
+    },
+    {
+        id: 'woah-drops',
+        label: 'WOAH Drops',
+        description: 'Huge drops trigger quick draw crystal challenges.',
+        effects: { dropQuickDraw: true }
+    }
+];
+
+const EFFECT_DEFS = {
+    glitch: {
+        id: 'glitch',
+        label: 'Glitch Storm',
+        variant: 'alert',
+        data: { glitchLevel: 1.1 }
+    },
+    reverse: {
+        id: 'reverse',
+        label: 'Reverse Flow',
+        variant: 'alert',
+        data: { invertControls: true }
+    },
+    'tempo-shift': {
+        id: 'tempo-shift',
+        label: 'Tempo Warp',
+        variant: 'info',
+        data: { tempoMultiplier: 1.2 }
+    }
+};
+
+const DIRECTIVE_DEFS = {
+    'pulse-blast': {
+        id: 'pulse-blast',
+        label: 'Pulse Blast',
+        shout: 'Pulse Blast!',
+        variant: 'alert',
+        requirement: 'pulse-count',
+        goal: 5,
+        duration: 3.8,
+        reward: {
+            score: 600,
+            charge: 1,
+            tempoBoost: 0.18,
+            tempoDuration: 5,
+            densityBoost: 0.25,
+            densityDuration: 5
+        },
+        penalty: {
+            glitch: 0.35
+        }
+    },
+    'phase-hold': {
+        id: 'phase-hold',
+        label: 'Hold the Phase',
+        shout: 'Hold the Phase!',
+        variant: 'info',
+        requirement: 'phase-hold',
+        goal: 2.8,
+        duration: 4.5,
+        reward: {
+            score: 450,
+            phaseEnergy: 0.4,
+            charge: 1
+        },
+        penalty: {
+            chaos: 0.25
+        }
+    },
+    'swipe-sync': {
+        id: 'swipe-sync',
+        label: 'Swipe Sync',
+        shout: 'Swipe Sync!',
+        variant: 'alert',
+        requirement: 'swipe',
+        goal: 2,
+        threshold: 0.18,
+        duration: 3.6,
+        reward: {
+            score: 520,
+            tempoBoost: 0.22,
+            tempoDuration: 4.5
+        },
+        penalty: {
+            reverse: true
+        }
+    },
+    'silence-freeze': {
+        id: 'silence-freeze',
+        label: 'Do Not Pulse',
+        shout: 'Freeze!',
+        variant: 'alert',
+        requirement: 'no-pulse',
+        duration: 3.2,
+        reward: {
+            score: 380,
+            charge: 1
+        },
+        penalty: {
+            glitch: 0.4,
+            chaos: 0.2
+        }
+    },
+    'echo-pulse': {
+        id: 'echo-pulse',
+        label: 'Echo the Vocal',
+        shout: 'Echo!',
+        variant: 'success',
+        requirement: 'pulse-precision',
+        goal: 2,
+        duration: 4,
+        reward: {
+            score: 700,
+            charge: 1,
+            densityBoost: 0.2,
+            densityDuration: 6
+        },
+        penalty: {
+            glitch: 0.25
+        }
+    }
+};
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+function choose(array) {
+    if (!array.length) return null;
+    const index = Math.floor(Math.random() * array.length);
+    return array[index];
+}
+
+function defaultTemplate() {
+    return {
+        id: 'rogue-default',
+        system: 'faceted',
+        geometryIndex: 3,
+        variantIndex: 12,
+        bpm: 128,
+        difficulty: { density: 0.9, speed: 1, chaos: 0.18 },
+        windowMs: 150
+    };
+}
+
+export class RogueLiteManager {
+    constructor({ audioService, hud, persistence } = {}) {
+        this.audioService = audioService;
+        this.hud = hud;
+        this.persistence = persistence;
+        this.templates = [];
+        this.currentRun = null;
+        this.activeEffects = [];
+        this.eventQueue = [];
+        this.cooldowns = { drop: 0, lull: 0, silence: 0, flux: 0, quickdraw: 0, directive: 0 };
+        this.activeDirective = null;
+        this.transientModifiers = { density: 0, chaos: 0, tempo: 1, remaining: 0, duration: 0 };
+    }
+
+    setTemplates(levels) {
+        this.templates = Array.isArray(levels) ? levels.slice() : [];
+    }
+
+    startRun(preferred) {
+        const base = preferred || choose(this.templates) || defaultTemplate();
+        this.currentRun = {
+            base,
+            stage: 1,
+            runId: `run-${base.id || 'base'}-${Date.now()}`,
+            modifiers: [],
+            charges: clamp(base.specialCharges ?? 1, 1, 3)
+        };
+        this.queueCallout('Rogue Run Initiated', 'info', 2.4);
+        this.activeDirective = null;
+        this.transientModifiers = { density: 0, chaos: 0, tempo: 1, remaining: 0, duration: 0 };
+        return this.buildStageConfig();
+    }
+
+    buildStageConfig() {
+        if (!this.currentRun) return null;
+        const { base, stage, runId, modifiers, charges } = this.currentRun;
+        const densityScale = 1 + (stage - 1) * 0.18;
+        const chaosScale = 1 + (stage - 1) * 0.14;
+        const speedScale = 1 + (stage - 1) * 0.1;
+        const beats = Math.min(64 + stage * 8, 180);
+        return {
+            ...base,
+            id: `${base.id || 'rogue'}-stage-${stage}`,
+            baseId: base.id || 'rogue',
+            stage,
+            runId,
+            endless: true,
+            targetBeats: beats,
+            specialCharges: charges,
+            runMultiplier: 1 + (stage - 1) * 0.06,
+            modifiers: modifiers.map((mod) => mod.id),
+            difficulty: {
+                ...base.difficulty,
+                density: (base.difficulty?.density ?? 1) * densityScale,
+                chaos: (base.difficulty?.chaos ?? 0.2) * chaosScale,
+                speed: (base.difficulty?.speed ?? 1) * speedScale
+            }
+        };
+    }
+
+    advanceStage(gameState) {
+        if (!this.currentRun) return null;
+        this.currentRun.stage += 1;
+        this.activeDirective = null;
+        const unlocked = this.unlockModifier();
+        this.currentRun.charges = clamp((this.currentRun.charges || 1) + 1, 1, 3);
+        if (gameState && gameState.lives < 3 && this.currentRun.stage % 3 === 0) {
+            gameState.grantLife?.();
+            this.queueCallout('Extra Life!', 'success', 1.6);
+        }
+        if (unlocked) {
+            this.queueCallout(`${unlocked.label} unlocked`, 'success', 2.5);
+        }
+        this.queueCallout(`Stage ${this.currentRun.stage}`, 'info', 1.8);
+        this.cooldowns.directive = Math.max(this.cooldowns.directive, 3);
+        return this.buildStageConfig();
+    }
+
+    unlockModifier() {
+        if (!this.currentRun) return null;
+        const available = MODIFIER_POOL.filter((mod) => !this.currentRun.modifiers.some((active) => active.id === mod.id));
+        if (!available.length) return null;
+        const chosen = choose(available);
+        if (!chosen) return null;
+        this.currentRun.modifiers.push({ ...chosen, unlockedAt: this.currentRun.stage });
+        return chosen;
+    }
+
+    update(dt, analysis, gameState) {
+        if (!this.currentRun) {
+            return { stage: 1, effects: this.serializeEffects(), persistentModifiers: [], spawnModifiers: {}, events: [] };
+        }
+        this.tickCooldowns(dt);
+        this.tickEffects(dt);
+        this.tickTransientModifiers(dt);
+        this.handleAudioAnalysis(analysis, gameState);
+        const effects = this.serializeEffects();
+        const spawnModifiers = this.computeSpawnModifiers(analysis, effects);
+        if (gameState) {
+            if (spawnModifiers.phaseRegenBonus != null) {
+                gameState.setPhaseRegenBonus?.(spawnModifiers.phaseRegenBonus);
+            }
+            if (effects.glitchLevel > 0) {
+                gameState.applyGlitch?.(effects.glitchLevel, 0.25);
+            }
+            if (effects.reverseControls) {
+                gameState.activateReverseControls?.(0.1);
+            }
+        }
+        return {
+            stage: this.currentRun.stage,
+            runId: this.currentRun.runId,
+            effects,
+            persistentModifiers: this.currentRun.modifiers.slice(),
+            spawnModifiers,
+            events: this.consumeEvents()
+        };
+    }
+
+    handleAudioAnalysis(analysis, gameState) {
+        if (!analysis) return;
+        let directiveTriggered = false;
+        const directiveReady = this.canTriggerDirective(gameState);
+
+        if (analysis.drop && this.cooldowns.drop <= 0) {
+            const intensity = 1 + (this.currentRun.stage - 1) * 0.12;
+            this.activateEffect('glitch', 5, { glitchLevel: 0.9 + intensity * 0.35 });
+            this.cooldowns.drop = 8;
+            const hasDropQuickDraw = this.currentRun.modifiers.some((mod) => mod.effects?.dropQuickDraw);
+            if (hasDropQuickDraw && this.cooldowns.quickdraw <= 0) {
+                this.spawnQuickDraw();
+                this.cooldowns.quickdraw = 10;
+            }
+            if (directiveReady && this.cooldowns.directive <= 0) {
+                const count = Math.min(6, 4 + Math.floor(this.currentRun.stage / 2));
+                this.queueDirective('pulse-blast', {
+                    spawnEvent: {
+                        id: `burst-${Date.now()}`,
+                        eventType: 'burst',
+                        count,
+                        lifespan: 3.2,
+                        timeToImpact: 0.6
+                    }
+                });
+                this.armDirectiveCooldown(6);
+                directiveTriggered = true;
+            }
+        }
+
+        if (analysis.lull && this.cooldowns.lull <= 0) {
+            this.activateEffect('reverse', 6, { invertControls: true });
+            this.cooldowns.lull = 12;
+            if (!directiveTriggered && directiveReady && this.cooldowns.directive <= 0.5) {
+                this.queueDirective('phase-hold');
+                this.armDirectiveCooldown(6);
+                directiveTriggered = true;
+            }
+        }
+
+        if (analysis.silence && this.cooldowns.silence <= 0) {
+            this.spawnQuickDraw();
+            this.cooldowns.silence = 14;
+            if (!directiveTriggered && directiveReady && this.cooldowns.directive <= 0.5) {
+                this.queueDirective('silence-freeze');
+                this.armDirectiveCooldown(7);
+                directiveTriggered = true;
+            }
+        }
+
+        if (!directiveTriggered && directiveReady && this.cooldowns.directive <= 0) {
+            if (analysis.bridge) {
+                this.queueDirective('phase-hold');
+                this.armDirectiveCooldown(6);
+                directiveTriggered = true;
+            } else if (analysis.rhythmShift && this.currentRun.stage >= 2) {
+                this.queueDirective('swipe-sync');
+                this.armDirectiveCooldown(5);
+                directiveTriggered = true;
+            } else if (analysis.vocal) {
+                this.queueDirective('echo-pulse');
+                this.armDirectiveCooldown(5.5);
+                directiveTriggered = true;
+            }
+        }
+
+        if (analysis.flux > 0.3 && this.cooldowns.flux <= 0 && this.currentRun.stage >= 2) {
+            const mult = 1.15 + Math.min(0.25, analysis.flux * 0.8);
+            this.activateEffect('tempo-shift', 5, { tempoMultiplier: mult });
+            this.cooldowns.flux = 10;
+        }
+    }
+
+    canTriggerDirective(gameState) {
+        if (!this.currentRun) return false;
+        if (this.activeDirective) return false;
+        if (this.cooldowns.directive > 0) return false;
+        if (gameState?.hasActiveDirective?.()) return false;
+        return true;
+    }
+
+    queueDirective(id, options = {}) {
+        const def = DIRECTIVE_DEFS[id];
+        if (!def) return;
+        this.activeDirective = id;
+        const shout = options.callout || def.shout || def.label;
+        const variant = options.variant || def.variant || 'info';
+        const calloutDuration = options.calloutDuration || 2.1;
+        if (shout) {
+            this.queueCallout(shout, variant, calloutDuration);
+        }
+        this.eventQueue.push({ type: 'directive', directiveId: id });
+        if (options.spawnEvent) {
+            this.eventQueue.push({ type: 'spawn-event', event: options.spawnEvent });
+        }
+    }
+
+    armDirectiveCooldown(seconds = 5) {
+        this.cooldowns.directive = Math.max(this.cooldowns.directive, seconds);
+    }
+
+    activateEffect(id, duration, data = {}) {
+        const def = EFFECT_DEFS[id];
+        if (!def) return;
+        const effect = {
+            id,
+            label: def.label,
+            variant: def.variant || 'info',
+            duration,
+            data: { ...(def.data || {}), ...data }
+        };
+        this.activeEffects = this.activeEffects.filter((e) => e.id !== id);
+        this.activeEffects.push(effect);
+        this.eventQueue.push({ type: 'effect-start', id, label: def.label, variant: def.variant, duration, data: effect.data });
+    }
+
+    spawnQuickDraw() {
+        if (!this.currentRun) return;
+        const eventId = `quickdraw-${Date.now()}`;
+        const count = Math.min(5, 3 + Math.floor(this.currentRun.stage / 2));
+        this.eventQueue.push({
+            type: 'spawn-event',
+            event: {
+                id: eventId,
+                eventType: 'quickdraw',
+                count,
+                lifespan: 3.8
+            }
+        });
+        this.queueCallout('Quick Draw!', 'alert', 2.5);
+        this.cooldowns.quickdraw = Math.max(this.cooldowns.quickdraw, 10);
+    }
+
+    handleTargetResolved(target, quality) {
+        if (!target?.event) return;
+        if (target.event.type === 'quickdraw') {
+            const message = quality === 'perfect' ? 'Quick Draw Perfect!' : 'Quick Draw Cleared!';
+            this.queueCallout(message, 'success', 1.6);
+            this.activeEffects = this.activeEffects.filter((effect) => effect.data?.eventId !== target.event.id);
+        }
+    }
+
+    handleTargetExpired(target) {
+        if (!target?.event) return;
+        if (target.event.type === 'quickdraw') {
+            this.queueCallout('Missed the Quick Draw!', 'alert', 1.8);
+        }
+    }
+
+    handleSpecialTap(gameState) {
+        if (!gameState) {
+            return null;
+        }
+        if (typeof gameState.spendSpecialCharges === 'function' && gameState.lives <= 1) {
+            const granted = gameState.spendSpecialCharges(2);
+            if (granted) {
+                this.queueCallout('Extra Life Ready!', 'success', 1.6);
+                return { type: 'extra-life' };
+            }
+        }
+        if (!gameState?.spendSpecialCharges?.(1)) {
+            this.queueCallout('No special charge!', 'alert', 1.2);
+            return null;
+        }
+        const duration = 4;
+        const factor = 0.55;
+        this.queueCallout('Slow Motion!', 'success', 1.6);
+        return { type: 'slowmo', duration, factor };
+    }
+
+    completeRun(gameState) {
+        if (!this.currentRun) return null;
+        const baseId = this.currentRun.base?.id || 'rogue';
+        const summary = {
+            baseId,
+            runId: this.currentRun.runId,
+            stage: this.currentRun.stage,
+            score: gameState?.score || 0,
+            maxCombo: gameState?.maxCombo || 0,
+            timestamp: Date.now()
+        };
+        this.currentRun = null;
+        this.activeEffects.length = 0;
+        this.eventQueue.length = 0;
+        this.activeDirective = null;
+        this.transientModifiers = { density: 0, chaos: 0, tempo: 1, remaining: 0, duration: 0 };
+        this.cooldowns.directive = 0;
+        return summary;
+    }
+
+    computeSpawnModifiers(analysis, effects) {
+        const modifiers = {
+            energy: analysis?.energy ?? 0.5,
+            bass: analysis?.bass ?? 0.3,
+            mid: analysis?.mid ?? 0.3,
+            high: analysis?.high ?? 0.3,
+            flux: analysis?.flux ?? 0,
+            tempoMultiplier: effects?.tempoMultiplier ?? 1,
+            glitchLevel: effects?.glitchLevel ?? 0,
+            reverseControls: effects?.reverseControls ?? false,
+            densityBoost: 0,
+            chaosBoost: (effects?.glitchLevel || 0) * 0.25,
+            phaseRegenBonus: 0,
+            flags: this.currentRun?.modifiers?.map((mod) => mod.id) || []
+        };
+        (this.currentRun?.modifiers || []).forEach((mod) => {
+            if (mod.effects?.densityBoost) {
+                modifiers.densityBoost += mod.effects.densityBoost;
+            }
+            if (mod.effects?.clusterBias) {
+                modifiers.clusterBias = (modifiers.clusterBias || 0) + mod.effects.clusterBias;
+            }
+            if (mod.effects?.phaseRegenBonus) {
+                modifiers.phaseRegenBonus = (modifiers.phaseRegenBonus || 0) + mod.effects.phaseRegenBonus;
+            }
+            if (mod.effects?.bassBias) {
+                modifiers.bassBias = (modifiers.bassBias || 0) + mod.effects.bassBias;
+            }
+            if (mod.effects?.dropQuickDraw) {
+                modifiers.dropQuickDraw = true;
+            }
+        });
+        if (this.transientModifiers?.remaining > 0 && this.transientModifiers?.duration > 0) {
+            const ratio = this.transientModifiers.remaining / this.transientModifiers.duration;
+            modifiers.densityBoost += (this.transientModifiers.density || 0) * ratio;
+            modifiers.chaosBoost += (this.transientModifiers.chaos || 0) * ratio;
+            modifiers.tempoMultiplier *= 1 + ((this.transientModifiers.tempo || 1) - 1) * ratio;
+        }
+        return modifiers;
+    }
+
+    serializeEffects() {
+        const state = {
+            glitchLevel: 0,
+            reverseControls: false,
+            tempoMultiplier: 1
+        };
+        this.activeEffects.forEach((effect) => {
+            if (effect.id === 'glitch') {
+                state.glitchLevel = Math.max(state.glitchLevel, effect.data?.glitchLevel ?? 1);
+            }
+            if (effect.id === 'reverse') {
+                state.reverseControls = true;
+            }
+            if (effect.id === 'tempo-shift') {
+                state.tempoMultiplier *= effect.data?.tempoMultiplier ?? 1.15;
+            }
+        });
+        return state;
+    }
+
+    tickCooldowns(dt) {
+        Object.keys(this.cooldowns).forEach((key) => {
+            this.cooldowns[key] = Math.max(0, this.cooldowns[key] - dt);
+        });
+    }
+
+    tickEffects(dt) {
+        const remaining = [];
+        this.activeEffects.forEach((effect) => {
+            effect.duration -= dt;
+            if (effect.duration <= 0) {
+                this.eventQueue.push({ type: 'effect-end', id: effect.id });
+            } else {
+                remaining.push(effect);
+            }
+        });
+        this.activeEffects = remaining;
+    }
+
+    queueCallout(text, variant = 'info', duration = 1.6) {
+        this.eventQueue.push({ type: 'callout', text, variant, duration });
+    }
+
+    consumeEvents() {
+        const queue = this.eventQueue.slice();
+        this.eventQueue.length = 0;
+        return queue;
+    }
+
+    getPersistentModifiers() {
+        return this.currentRun?.modifiers || [];
+    }
+
+    getStage() {
+        return this.currentRun?.stage || 1;
+    }
+
+    hasActiveDirective() {
+        return Boolean(this.activeDirective);
+    }
+
+    tickTransientModifiers(dt) {
+        const mod = this.transientModifiers;
+        if (!mod) return;
+        if (mod.remaining > 0) {
+            mod.remaining = Math.max(0, mod.remaining - dt);
+            if (mod.remaining === 0) {
+                mod.density = 0;
+                mod.chaos = 0;
+                mod.tempo = 1;
+                mod.duration = 0;
+            }
+        }
+    }
+
+    applyTransientBoosts({ densityBoost = 0, chaosBoost = 0, tempoBoost = 0, duration = 4 } = {}) {
+        const mod = this.transientModifiers;
+        if (!mod) return;
+        mod.density = Math.max(mod.density, densityBoost);
+        mod.chaos = Math.max(mod.chaos, chaosBoost);
+        mod.tempo = Math.max(mod.tempo, 1 + tempoBoost);
+        mod.duration = Math.max(mod.duration, duration);
+        mod.remaining = mod.duration;
+    }
+
+    handleDirectiveOutcome(event, gameState) {
+        if (!event) return;
+        const def = DIRECTIVE_DEFS[event.id];
+        this.activeDirective = null;
+        this.armDirectiveCooldown(3.5);
+        if (!def) return;
+        const stageMult = this.currentRun ? 1 + (this.currentRun.stage - 1) * 0.12 : 1;
+
+        if (event.status === 'success') {
+            this.queueCallout(`${def.label} Clear!`, 'success', 1.8);
+            if (def.reward?.score && gameState) {
+                gameState.score += Math.round(def.reward.score * stageMult);
+            }
+            if (def.reward?.charge && gameState) {
+                gameState.gainSpecialCharge(def.reward.charge);
+            }
+            if (def.reward?.life && gameState) {
+                for (let i = 0; i < def.reward.life; i += 1) {
+                    gameState.grantLife?.();
+                }
+            }
+            if (def.reward?.phaseEnergy && gameState) {
+                gameState.phaseEnergy = Math.min(1, gameState.phaseEnergy + def.reward.phaseEnergy);
+            }
+            if (def.reward?.tempoBoost) {
+                this.activateEffect('tempo-shift', def.reward.tempoDuration || 4, {
+                    tempoMultiplier: 1 + def.reward.tempoBoost
+                });
+            }
+            if (def.reward?.densityBoost || def.reward?.chaosBoost) {
+                this.applyTransientBoosts({
+                    densityBoost: def.reward.densityBoost || 0,
+                    chaosBoost: def.reward.chaosBoost || 0,
+                    duration: def.reward.densityDuration || def.reward.chaosDuration || 4
+                });
+            }
+        } else {
+            this.queueCallout(`${def.label} Failed`, 'alert', 1.6);
+            if (def.penalty?.glitch) {
+                this.activateEffect('glitch', 3.5, { glitchLevel: 0.6 + def.penalty.glitch });
+            }
+            if (def.penalty?.chaos) {
+                this.applyTransientBoosts({ chaosBoost: def.penalty.chaos, duration: 4 });
+            }
+            if (def.penalty?.reverse) {
+                this.activateEffect('reverse', 4, { invertControls: true });
+            }
+            if (def.penalty?.drainCharge && gameState?.specialCharges) {
+                const drain = Math.min(gameState.specialCharges, def.penalty.drainCharge);
+                if (drain > 0) {
+                    gameState.spendSpecialCharges?.(drain);
+                }
+            }
+        }
+    }
+
+    getDirectiveDefinition(id) {
+        const def = DIRECTIVE_DEFS[id];
+        return def ? { ...def } : null;
+    }
+}

--- a/src/game/SpawnSystem.js
+++ b/src/game/SpawnSystem.js
@@ -1,0 +1,142 @@
+import { project4DToScreen } from './utils/Math4D.js';
+
+/**
+ * Beat-driven spawn manager. Keeps targets in deterministic order and
+ * computes their projected positions for collision tests.
+ */
+export class SpawnSystem {
+    constructor(geometryController) {
+        this.geometryController = geometryController;
+        this.targets = [];
+        this.newTargets = [];
+        this.expiredTargets = [];
+        this.aspect = 1;
+        this.currentInterval = 0.5;
+        this.difficulty = { density: 1, speed: 1, chaos: 0.2 };
+        this.lastParams = null;
+        this.spawnContext = {};
+        this.audioProfile = {};
+    }
+
+    setDifficulty(difficulty) {
+        this.difficulty = { ...this.difficulty, ...difficulty };
+    }
+
+    handleBeat(beatInfo, audioAnalysis = {}, context = {}) {
+        this.currentInterval = beatInfo.interval;
+        this.audioProfile = audioAnalysis || {};
+        this.spawnContext = { ...this.spawnContext, ...context };
+        const effectiveDifficulty = {
+            ...this.difficulty,
+            density: (this.difficulty.density || 1) * (1 + (context.densityBoost || 0)),
+            chaos: (this.difficulty.chaos || 0.2) * (1 + (context.chaosBoost || 0)),
+            speed: (this.difficulty.speed || 1) * (context.tempoMultiplier || 1)
+        };
+        const spawnDefs = this.geometryController.generateTargets(beatInfo.beat, effectiveDifficulty, audioAnalysis, this.spawnContext);
+        const tempo = context.tempoMultiplier || 1;
+        spawnDefs.forEach((def) => {
+            const beatsAhead = Math.max(1, def.dueBeat - beatInfo.beat);
+            const timeToImpact = (beatsAhead * beatInfo.interval) / tempo;
+            this.targets.push({
+                ...def,
+                state: 'incoming',
+                timer: 0,
+                timeToImpact,
+                lifespan: timeToImpact + beatInfo.interval * 1.25,
+                screenA: null,
+                screenB: null,
+                children: def.children ? def.children.map((child) => ({ ...child, timer: 0 })) : null
+            });
+        });
+    }
+
+    update(dt, params, aspect, context = {}) {
+        this.lastParams = params;
+        this.aspect = aspect;
+        this.spawnContext = { ...this.spawnContext, ...context };
+        this.newTargets.length = 0;
+        this.expiredTargets.length = 0;
+
+        const remaining = [];
+        this.targets.forEach((target) => {
+            target.timer += dt;
+            if (target.children) {
+                target.children.forEach((child) => {
+                    child.timer += dt;
+                    child.screen = project4DToScreen(child.vec4, params, aspect);
+                    child.alpha = Math.min(1, child.timer / target.timeToImpact);
+                });
+            }
+
+            if (target.state === 'incoming' && target.timer > target.timeToImpact * 0.35) {
+                target.state = 'active';
+                this.newTargets.push(target);
+            }
+
+            target.remaining = target.timeToImpact - target.timer;
+            if (target.type === 'lane') {
+                target.screenA = project4DToScreen(target.vec4, params, aspect);
+                target.screenB = project4DToScreen(target.vec4b, params, aspect);
+            } else if (target.type === 'cluster') {
+                // cluster uses children already projected
+            } else {
+                target.screen = project4DToScreen(target.vec4, params, aspect);
+            }
+
+            if (target.timer > target.lifespan) {
+                target.state = 'expired';
+                this.expiredTargets.push(target);
+            } else {
+                remaining.push(target);
+            }
+        });
+        this.targets = remaining;
+        return {
+            newTargets: this.newTargets,
+            expiredTargets: this.expiredTargets
+        };
+    }
+
+    getActiveTargets() {
+        return this.targets.filter((t) => t.state === 'active');
+    }
+
+    removeTarget(id) {
+        const index = this.targets.findIndex((t) => t.id === id);
+        if (index >= 0) {
+            this.targets.splice(index, 1);
+        }
+    }
+
+    reset() {
+        this.targets.length = 0;
+    }
+
+    setSpawnContext(context = {}) {
+        this.spawnContext = { ...this.spawnContext, ...context };
+    }
+
+    injectEventTargets(event, options = {}) {
+        if (!event) return;
+        const tempo = this.spawnContext.tempoMultiplier || 1;
+        const defs = this.geometryController.generateEventTargets(event.eventType, {
+            count: event.count,
+            audio: this.audioProfile,
+            options
+        });
+        const baseTime = Math.max(0.35, (event.timeToImpact || 0.5) / tempo);
+        defs.forEach((def, index) => {
+            this.targets.push({
+                ...def,
+                id: `${event.id}-${index}`,
+                state: 'incoming',
+                timer: 0,
+                timeToImpact: baseTime + index * 0.08,
+                lifespan: event.lifespan || 2.5,
+                screenA: null,
+                screenB: null,
+                event: { type: event.eventType, id: event.id }
+            });
+        });
+    }
+}

--- a/src/game/levels/lvl-01-faceted-torus.json
+++ b/src/game/levels/lvl-01-faceted-torus.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-01-faceted-torus",
+  "system": "faceted",
+  "geometryIndex": 3,
+  "variantIndex": 12,
+  "track": {
+    "id": "suno:track_001",
+    "url": null
+  },
+  "bpm": 128,
+  "seed": 4711,
+  "planes": ["XW", "YW"],
+  "windowMs": 150,
+  "spawn": { "pattern": "belt", "density": 0.85 },
+  "powerups": ["pulse+"],
+  "targetBeats": 64,
+  "difficulty": {
+    "speed": 1.0,
+    "chaos": 0.12,
+    "density": 0.95
+  },
+  "color": {
+    "hue": 210,
+    "intensity": 0.6,
+    "saturation": 0.88
+  }
+}

--- a/src/game/levels/lvl-02-quantum-sphere.json
+++ b/src/game/levels/lvl-02-quantum-sphere.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-02-quantum-sphere",
+  "system": "quantum",
+  "geometryIndex": 2,
+  "variantIndex": 10,
+  "track": {
+    "id": "suno:track_009",
+    "url": null
+  },
+  "bpm": 140,
+  "seed": 9913,
+  "planes": ["XW", "ZW"],
+  "windowMs": 140,
+  "spawn": { "pattern": "orbit", "density": 1.05 },
+  "powerups": ["phase"],
+  "targetBeats": 72,
+  "difficulty": {
+    "speed": 1.15,
+    "chaos": 0.22,
+    "density": 1.1
+  },
+  "color": {
+    "hue": 32,
+    "intensity": 0.7,
+    "saturation": 0.92
+  }
+}

--- a/src/game/levels/lvl-03-holographic-crystal.json
+++ b/src/game/levels/lvl-03-holographic-crystal.json
@@ -1,0 +1,27 @@
+{
+  "id": "lvl-03-holographic-crystal",
+  "system": "holographic",
+  "geometryIndex": 28,
+  "variantIndex": 28,
+  "track": {
+    "id": "suno:track_024",
+    "url": null
+  },
+  "bpm": 110,
+  "seed": 2048,
+  "planes": ["YW", "ZW"],
+  "windowMs": 170,
+  "spawn": { "pattern": "shard", "density": 0.9 },
+  "powerups": ["pulse+", "phase"],
+  "targetBeats": 80,
+  "difficulty": {
+    "speed": 0.95,
+    "chaos": 0.28,
+    "density": 1.0
+  },
+  "color": {
+    "hue": 320,
+    "intensity": 0.65,
+    "saturation": 0.9
+  }
+}

--- a/src/game/persistence/LocalPersistence.js
+++ b/src/game/persistence/LocalPersistence.js
@@ -1,0 +1,88 @@
+const STORAGE_KEY = 'latticePulseProgress';
+
+export class LocalPersistence {
+    constructor() {
+        this.state = {
+            highScores: {},
+            settings: {
+                audio: true,
+                tilt: false
+            },
+            runs: {}
+        };
+        this.load();
+    }
+
+    load() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                this.state = { ...this.state, ...parsed };
+            }
+            if (!this.state.runs) {
+                this.state.runs = {};
+            }
+        } catch (err) {
+            console.warn('LocalPersistence: failed to load state', err);
+        }
+    }
+
+    save() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.state));
+        } catch (err) {
+            console.warn('LocalPersistence: failed to save state', err);
+        }
+    }
+
+    recordScore(levelId, score, combo) {
+        const existing = this.state.highScores[levelId];
+        if (!existing || score > existing.score) {
+            this.state.highScores[levelId] = {
+                score,
+                combo,
+                timestamp: Date.now()
+            };
+            this.save();
+            return true;
+        }
+        return false;
+    }
+
+    getBestScore(levelId) {
+        return this.state.highScores[levelId] || null;
+    }
+
+    recordRunResult(levelId, summary) {
+        if (!levelId || !summary) return false;
+        if (!this.state.runs) {
+            this.state.runs = {};
+        }
+        const existing = this.state.runs[levelId];
+        const isBetter = !existing || summary.stage > existing.stage || (summary.stage === existing.stage && summary.score > existing.score);
+        if (isBetter) {
+            this.state.runs[levelId] = {
+                stage: summary.stage,
+                score: summary.score,
+                combo: summary.maxCombo,
+                timestamp: summary.timestamp || Date.now()
+            };
+            this.save();
+        }
+        return isBetter;
+    }
+
+    getRunRecord(levelId) {
+        return this.state.runs?.[levelId] || null;
+    }
+
+    updateSettings(updates) {
+        this.state.settings = { ...this.state.settings, ...updates };
+        this.save();
+    }
+
+    getSettings() {
+        return this.state.settings;
+    }
+}

--- a/src/game/ui/HUDRenderer.js
+++ b/src/game/ui/HUDRenderer.js
@@ -1,0 +1,202 @@
+/**
+ * Renders the mobile-friendly HUD overlay.
+ */
+export class HUDRenderer {
+    constructor(root, persistence) {
+        this.root = root;
+        this.persistence = persistence;
+        this.build();
+    }
+
+    build() {
+        this.root.innerHTML = `
+            <div class="hud-safe-area">
+                <div class="hud-top">
+                    <div class="hud-level">
+                        <span class="hud-label">LEVEL</span>
+                        <span class="hud-value" id="hud-level-id">--</span>
+                    </div>
+                    <div class="hud-stage">
+                        <span class="hud-label">STAGE</span>
+                        <span class="hud-value" id="hud-stage">1</span>
+                    </div>
+                    <div class="hud-score">
+                        <span class="hud-label">SCORE</span>
+                        <span class="hud-value" id="hud-score">0</span>
+                    </div>
+                    <div class="hud-combo">
+                        <span class="hud-label">COMBO</span>
+                        <span class="hud-value" id="hud-combo">0</span>
+                    </div>
+                </div>
+                <div class="hud-bars">
+                    <div class="hud-bar hud-health">
+                        <div class="hud-bar-fill" id="hud-health-fill"></div>
+                    </div>
+                    <div class="hud-bar hud-phase">
+                        <div class="hud-bar-fill" id="hud-phase-fill"></div>
+                    </div>
+                    <div class="hud-charges" id="hud-charges"></div>
+                </div>
+                <div class="hud-bottom">
+                    <div class="hud-status" id="hud-status">Tap the beat to pulse.</div>
+                    <div class="hud-modifiers" id="hud-modifiers"></div>
+                    <div class="hud-best" id="hud-best"></div>
+                </div>
+            </div>
+            <div class="hud-overlay-callout" id="hud-callout-overlay"></div>
+            <div class="hud-directive" id="hud-directive" data-state="idle">
+                <div class="hud-directive-text">
+                    <span class="hud-directive-label" id="hud-directive-label"></span>
+                    <span class="hud-directive-count" id="hud-directive-count"></span>
+                </div>
+                <div class="hud-directive-timer">
+                    <div class="hud-directive-timer-fill" id="hud-directive-timer"></div>
+                </div>
+            </div>
+        `;
+        this.levelEl = this.root.querySelector('#hud-level-id');
+        this.stageEl = this.root.querySelector('#hud-stage');
+        this.scoreEl = this.root.querySelector('#hud-score');
+        this.comboEl = this.root.querySelector('#hud-combo');
+        this.healthFill = this.root.querySelector('#hud-health-fill');
+        this.phaseFill = this.root.querySelector('#hud-phase-fill');
+        this.statusEl = this.root.querySelector('#hud-status');
+        this.bestEl = this.root.querySelector('#hud-best');
+        this.chargesEl = this.root.querySelector('#hud-charges');
+        this.modifiersEl = this.root.querySelector('#hud-modifiers');
+        this.calloutEl = this.root.querySelector('#hud-callout-overlay');
+        this.directiveEl = this.root.querySelector('#hud-directive');
+        this.directiveLabelEl = this.root.querySelector('#hud-directive-label');
+        this.directiveCountEl = this.root.querySelector('#hud-directive-count');
+        this.directiveTimerEl = this.root.querySelector('#hud-directive-timer');
+        this.currentDirective = null;
+    }
+
+    setLevel(level, meta = {}) {
+        this.levelEl.textContent = level?.id?.toUpperCase() || '--';
+        const best = this.persistence.getBestScore(level.id);
+        const runRecord = this.persistence.getRunRecord(level.baseId || level.id);
+        if (best) {
+            this.bestEl.textContent = `BEST ${best.score} • MAX COMBO ${best.combo}`;
+        }
+        if (runRecord) {
+            this.bestEl.textContent = `RUN ${runRecord.stage} • ${runRecord.score} pts • x${runRecord.combo}`;
+        }
+        if (!best && !runRecord) {
+            this.bestEl.textContent = '';
+        }
+        if (meta.stage) {
+            this.stageEl.textContent = meta.stage;
+        }
+        if (meta.modifiers?.length) {
+            this.modifiersEl.textContent = meta.modifiers.map((mod) => mod.label || mod.id).join(' • ');
+        } else {
+            this.modifiersEl.textContent = '';
+        }
+    }
+
+    update(state, meta = {}) {
+        this.scoreEl.textContent = state.score.toLocaleString();
+        this.comboEl.textContent = state.combo ? `x${state.combo}` : '0';
+        this.healthFill.style.transform = `scaleX(${Math.max(0, state.health)})`;
+        this.phaseFill.style.transform = `scaleX(${Math.max(0, state.phaseEnergy)})`;
+        if (meta.stage) {
+            this.stageEl.textContent = meta.stage;
+        } else if (state.stage) {
+            this.stageEl.textContent = state.stage;
+        }
+        const charges = meta.charges || state.getChargeState?.() || { current: 0, max: 0 };
+        if (this.chargesEl) {
+            const filled = '●'.repeat(Math.max(0, charges.current || 0));
+            const empty = '○'.repeat(Math.max(0, (charges.max || 0) - (charges.current || 0)));
+            this.chargesEl.textContent = charges.max ? `SLOW • ${filled}${empty}` : '';
+        }
+        if (meta.modifiers) {
+            this.modifiersEl.textContent = meta.modifiers.length ? meta.modifiers.map((mod) => mod.label || mod.id).join(' • ') : '';
+        }
+        this.setDirectiveState(meta.directive);
+    }
+
+    setStatus(text, variant = 'info') {
+        this.statusEl.textContent = text;
+        this.statusEl.dataset.variant = variant;
+    }
+
+    flash(text) {
+        this.setStatus(text, 'pulse');
+        this.statusEl.classList.add('flash');
+        setTimeout(() => this.statusEl.classList.remove('flash'), 600);
+    }
+
+    showCallout(text, variant = 'info', duration = 1.6) {
+        if (!this.calloutEl) return;
+        this.calloutEl.textContent = text;
+        this.calloutEl.dataset.variant = variant;
+        this.calloutEl.classList.add('show');
+        if (this.calloutTimeout) {
+            clearTimeout(this.calloutTimeout);
+        }
+        this.calloutTimeout = setTimeout(() => {
+            this.calloutEl.classList.remove('show');
+        }, duration * 1000);
+    }
+
+    showRunSummary(summary, improved) {
+        if (!summary) return;
+        const text = `STAGE ${summary.stage} • ${summary.score.toLocaleString()} pts • x${summary.maxCombo}`;
+        this.bestEl.textContent = improved ? `NEW BEST • ${text}` : `LAST RUN • ${text}`;
+    }
+
+    announceDirective(directive) {
+        if (!directive) return;
+        this.setDirectiveState(directive);
+        this.flash(directive.label || 'Directive!');
+    }
+
+    finishDirective(status, event) {
+        if (status === 'success') {
+            this.flash(event?.label ? `${event.label} Clear!` : 'Directive Clear!');
+        } else {
+            this.setStatus(event?.label ? `${event.label} Failed` : 'Directive Failed', 'alert');
+        }
+        this.setDirectiveState(null);
+    }
+
+    setDirectiveState(state) {
+        if (!this.directiveEl) return;
+        if (!state) {
+            this.directiveEl.dataset.state = 'idle';
+            this.directiveEl.dataset.variant = '';
+            if (this.directiveLabelEl) this.directiveLabelEl.textContent = '';
+            if (this.directiveCountEl) this.directiveCountEl.textContent = '';
+            if (this.directiveTimerEl) this.directiveTimerEl.style.transform = 'scaleX(0)';
+            this.currentDirective = null;
+            return;
+        }
+        this.currentDirective = state;
+        this.directiveEl.dataset.state = 'active';
+        this.directiveEl.dataset.variant = state.variant || 'info';
+        if (this.directiveLabelEl) {
+            this.directiveLabelEl.textContent = state.label || state.id || 'Directive';
+        }
+        if (this.directiveCountEl) {
+            if (state.requirement === 'phase-hold') {
+                const remaining = Math.max(0, (state.goal || 0) - (state.progress || 0));
+                this.directiveCountEl.textContent = `${remaining.toFixed(1)}s`;
+            } else if (state.requirement === 'no-pulse') {
+                this.directiveCountEl.textContent = 'HOLD';
+            } else if (typeof state.goal === 'number') {
+                this.directiveCountEl.textContent = `${Math.floor(state.progress || 0)}/${state.goal}`;
+            } else {
+                this.directiveCountEl.textContent = '';
+            }
+        }
+        if (this.directiveTimerEl) {
+            const duration = state.duration || 1;
+            const remaining = Math.max(0, state.remaining ?? duration);
+            const ratio = duration > 0 ? Math.max(0, Math.min(1, remaining / duration)) : 0;
+            this.directiveTimerEl.style.transform = `scaleX(${ratio})`;
+        }
+    }
+}

--- a/src/game/utils/Math4D.js
+++ b/src/game/utils/Math4D.js
@@ -1,0 +1,103 @@
+/**
+ * Minimal 4D math helpers for projecting game geometry to screen space.
+ */
+
+/**
+ * Apply 4D rotations in XW, YW, ZW planes.
+ * @param {{x:number,y:number,z:number,w:number}} vec
+ * @param {{rot4dXW:number,rot4dYW:number,rot4dZW:number}} angles
+ */
+export function rotate4D(vec, angles) {
+    let { x, y, z, w } = vec;
+
+    if (angles.rot4dXW) {
+        const cos = Math.cos(angles.rot4dXW);
+        const sin = Math.sin(angles.rot4dXW);
+        const nx = x * cos - w * sin;
+        const nw = x * sin + w * cos;
+        x = nx;
+        w = nw;
+    }
+
+    if (angles.rot4dYW) {
+        const cos = Math.cos(angles.rot4dYW);
+        const sin = Math.sin(angles.rot4dYW);
+        const ny = y * cos - w * sin;
+        const nw = y * sin + w * cos;
+        y = ny;
+        w = nw;
+    }
+
+    if (angles.rot4dZW) {
+        const cos = Math.cos(angles.rot4dZW);
+        const sin = Math.sin(angles.rot4dZW);
+        const nz = z * cos - w * sin;
+        const nw = z * sin + w * cos;
+        z = nz;
+        w = nw;
+    }
+
+    return { x, y, z, w };
+}
+
+/**
+ * Simple 4D → 3D projection that blends W into scale.
+ * @param {{x:number,y:number,z:number,w:number}} vec
+ * @param {number} dimension - effective dimensionality (3-4)
+ */
+export function project4Dto3D(vec, dimension) {
+    const depth = Math.max(0.5, dimension);
+    const scale = 1 / (depth + 1 - vec.w * 0.5);
+    return {
+        x: vec.x * scale,
+        y: vec.y * scale,
+        z: vec.z * scale
+    };
+}
+
+/**
+ * Project 3D coordinates to 2D normalized screen space (0..1).
+ * @param {{x:number,y:number,z:number}} vec3
+ * @param {number} aspect
+ */
+export function project3DtoScreen(vec3, aspect = 1) {
+    const perspective = 1 / (1 + Math.max(-0.8, Math.min(0.8, vec3.z)));
+    const x = 0.5 + vec3.x * perspective * 0.45 * aspect;
+    const y = 0.5 - vec3.y * perspective * 0.45;
+    return { x, y };
+}
+
+/**
+ * Combined helper: rotate + project to screen.
+ * @param {object} vec4
+ * @param {object} params - expects rot4dXW/YW/ZW and dimension.
+ * @param {number} aspect
+ */
+export function project4DToScreen(vec4, params, aspect = 1) {
+    const rotated = rotate4D(vec4, params);
+    const vec3 = project4Dto3D(rotated, params.dimension || 3.5);
+    return project3DtoScreen(vec3, aspect);
+}
+
+/**
+ * Compute squared distance between two points in normalized screen space.
+ */
+export function distanceSq(a, b) {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    return dx * dx + dy * dy;
+}
+
+/**
+ * Linear interpolation.
+ */
+export function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+/**
+ * Exponential decay helper.
+ */
+export function damp(value, target, lambda, dt) {
+    return lerp(value, target, 1 - Math.exp(-lambda * dt));
+}

--- a/src/game/utils/Random.js
+++ b/src/game/utils/Random.js
@@ -1,0 +1,58 @@
+/**
+ * Deterministic random utilities for seeded gameplay.
+ * Provides simple Mulberry32 implementation and helpers.
+ */
+
+/**
+ * Mulberry32 RNG implementation.
+ * @param {number} seed - unsigned 32-bit seed
+ * @returns {() => number} function returning floats in [0, 1)
+ */
+export function mulberry32(seed) {
+    let t = seed >>> 0;
+    return function () {
+        t += 0x6D2B79F5;
+        let r = Math.imul(t ^ (t >>> 15), t | 1);
+        r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+        return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/**
+ * Creates a RNG helper with common convenience methods.
+ * @param {number} seed
+ */
+export function createSeededRNG(seed) {
+    const rand = mulberry32(seed);
+    return {
+        nextFloat: () => rand(),
+        nextRange: (min, max) => min + (max - min) * rand(),
+        nextInt: (min, max) => Math.floor(min + (max - min + 1) * rand()),
+        choose: (array) => array[Math.floor(rand() * array.length)],
+        shuffle(array) {
+            const copy = array.slice();
+            for (let i = copy.length - 1; i > 0; i--) {
+                const j = Math.floor(rand() * (i + 1));
+                [copy[i], copy[j]] = [copy[j], copy[i]];
+            }
+            return copy;
+        }
+    };
+}
+
+/**
+ * Hash string into a numeric seed for deterministic RNG.
+ * @param {string} str
+ */
+export function hashStringToSeed(str) {
+    let h1 = 0xdeadbeef ^ str.length;
+    let h2 = 0x41c6ce57 ^ str.length;
+    for (let i = 0, ch; i < str.length; i++) {
+        ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return (h1 >>> 0) ^ (h2 >>> 0);
+}

--- a/styles/lattice-pulse.css
+++ b/styles/lattice-pulse.css
@@ -1,0 +1,362 @@
+:root {
+  --bg-color: radial-gradient(circle at 20% 20%, #0d1b2a, #020407 70%);
+  --accent: #6fffe9;
+  --danger: #ff4d6d;
+  --text-primary: #e0fbfc;
+  --text-muted: rgba(224, 251, 252, 0.7);
+  --hud-bg: rgba(10, 15, 25, 0.7);
+  --hud-border: rgba(111, 255, 233, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-color);
+  font-family: 'Orbitron', 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  overscroll-behavior: none;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+#lp-app {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+#lp-canvas-root {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.lp-mode-stage {
+  position: absolute;
+  inset: 0;
+  transition: opacity 0.45s ease;
+}
+
+.lp-mode-stage:not(.active) {
+  pointer-events: none;
+}
+
+.lp-canvas-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  pointer-events: none;
+}
+
+#lp-input-layer {
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+#lp-hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hud-safe-area {
+  width: min(92vw, 420px);
+  height: 100%;
+  padding: 1.75rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hud-top {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.hud-label {
+  display: block;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.hud-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.hud-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hud-bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hud-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), #60efff);
+  transform-origin: left center;
+  transform: scaleX(1);
+  transition: transform 0.15s ease;
+}
+
+.hud-bar.hud-phase .hud-bar-fill {
+  background: linear-gradient(90deg, #ff9f1c, #ffbf69);
+}
+
+.hud-charges {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(224, 251, 252, 0.75);
+}
+
+.hud-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.hud-status {
+  font-size: 0.8rem;
+  min-height: 1.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hud-status[data-variant='alert'] {
+  color: var(--danger);
+}
+
+.hud-status.flash {
+  animation: hudFlash 0.4s ease;
+}
+
+@keyframes hudFlash {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.7; }
+}
+
+.hud-best {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(224, 251, 252, 0.6);
+}
+
+.hud-modifiers {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(224, 251, 252, 0.55);
+  min-height: 0.9rem;
+}
+
+.hud-overlay-callout {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1.8rem, 8vw, 3rem);
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(111, 255, 233, 0.85);
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.hud-overlay-callout[data-variant='alert'] {
+  color: rgba(255, 77, 109, 0.9);
+}
+
+.hud-overlay-callout[data-variant='success'] {
+  color: rgba(144, 255, 185, 0.9);
+}
+
+.hud-overlay-callout.show {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.hud-directive {
+  position: absolute;
+  bottom: 18%;
+  left: 50%;
+  transform: translate(-50%, 16px);
+  padding: 0.75rem 1.2rem;
+  background: rgba(10, 18, 30, 0.75);
+  border: 1px solid rgba(111, 255, 233, 0.4);
+  border-radius: 18px;
+  min-width: clamp(220px, 60vw, 320px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(224, 251, 252, 0.85);
+}
+
+.hud-directive[data-state='active'] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.hud-directive[data-variant='alert'] {
+  border-color: rgba(255, 77, 109, 0.6);
+  color: rgba(255, 199, 217, 0.9);
+}
+
+.hud-directive[data-variant='success'] {
+  border-color: rgba(144, 255, 185, 0.6);
+  color: rgba(200, 255, 229, 0.95);
+}
+
+.hud-directive-text {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  gap: 0.5rem;
+}
+
+.hud-directive-label {
+  font-weight: 700;
+  color: rgba(224, 251, 252, 0.9);
+}
+
+.hud-directive-count {
+  font-size: 0.7rem;
+  color: rgba(224, 251, 252, 0.7);
+}
+
+.hud-directive-timer {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.hud-directive-timer-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(111, 255, 233, 0.9), rgba(144, 202, 249, 0.9));
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 0.2s ease;
+}
+
+#lp-start-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(2, 4, 7, 0.86);
+  z-index: 30;
+  backdrop-filter: blur(12px);
+  text-align: center;
+  padding: 2rem;
+  transition: opacity 0.35s ease;
+}
+
+#lp-start-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lp-start-title {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.lp-start-subtitle {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  max-width: 320px;
+}
+
+#lp-start-button {
+  padding: 0.9rem 2.4rem;
+  background: linear-gradient(90deg, var(--accent), #64dfdf);
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #020407;
+  cursor: pointer;
+  box-shadow: 0 10px 35px rgba(100, 223, 223, 0.35);
+}
+
+#lp-start-button:active {
+  transform: scale(0.97);
+}
+
+@media (max-width: 640px) {
+  .hud-safe-area {
+    width: min(94vw, 360px);
+    padding: 1.25rem 1rem;
+  }
+  .hud-top {
+    gap: 0.5rem;
+  }
+  .hud-value {
+    font-size: 1.2rem;
+  }
+  .hud-overlay-callout {
+    font-size: clamp(1.6rem, 11vw, 2.6rem);
+  }
+  .hud-directive {
+    bottom: 12%;
+    min-width: clamp(200px, 80vw, 280px);
+  }
+}

--- a/sw-lattice-pulse.js
+++ b/sw-lattice-pulse.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'lattice-pulse-v3';
+const PRECACHE = [
+  './lattice-pulse.html',
+  './styles/lattice-pulse.css',
+  './src/game/LatticePulseGame.js',
+  './src/game/GameLoop.js',
+  './src/game/AudioService.js',
+  './src/game/ModeController.js',
+  './src/game/GeometryController.js',
+  './src/game/RogueLiteManager.js',
+  './src/game/SpawnSystem.js',
+  './src/game/CollisionSystem.js',
+  './src/game/InputMapping.js',
+  './src/game/EffectsManager.js',
+  './src/game/PerformanceController.js',
+  './src/game/LevelManager.js',
+  './src/game/GameState.js',
+  './src/game/utils/Random.js',
+  './src/game/utils/Math4D.js',
+  './src/game/persistence/LocalPersistence.js',
+  './src/game/ui/HUDRenderer.js',
+  './src/game/levels/lvl-01-faceted-torus.json',
+  './src/game/levels/lvl-02-quantum-sphere.json',
+  './src/game/levels/lvl-03-holographic-crystal.json',
+  './icons/lattice-192.svg',
+  './icons/lattice-512.svg',
+  './lattice-pulse-manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.map((key) => {
+      if (key !== CACHE_NAME) {
+        return caches.delete(key);
+      }
+    }))).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      }).catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a RogueLite manager and integrate stage-scaling runs, audio-triggered events, and special gesture handling into Lattice Pulse
- extend the game state, spawn logic, audio analysis, effects, and HUD styling to support quick draw challenges, glitches, reverse flow, and charge tracking
- refresh documentation and service worker precache entries to describe and ship the new rogue-lite experience

## Testing
- npm test *(fails: Playwright binary is not executable in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4a3bd81c83298af0624151c20b75