### PR TITLE
Add audio-driven gameplay orchestration with microphone fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1035,13 +1035,22 @@
                         // Update panel header
                         const headers = {
                             faceted: 'FACETED SYSTEM',
-                            quantum: 'QUANTUM SYSTEM', 
+                            quantum: 'QUANTUM SYSTEM',
                             holographic: 'HOLOGRAPHIC SYSTEM',
                             polychora: 'POLYCHORA SYSTEM'
                         };
                         const panelHeader = document.getElementById('panelHeader');
                         if (panelHeader) panelHeader.textContent = headers[system] || 'VIB34D SYSTEM';
-                        
+
+                        if (window.audioDirector) {
+                            window.audioDirector.attachEngines({
+                                engine: window.engine,
+                                quantumEngine: window.quantumEngine,
+                                holographicSystem: window.holographicSystem,
+                                polychoraSystem: window.polychoraSystem
+                            });
+                        }
+
                         console.log(`✅ Switched to ${system} system successfully`);
                         return; // Success - exit early
                     } else if (system === 'polychora') {
@@ -1569,6 +1578,7 @@
         import { CanvasManager } from './src/core/CanvasManager.js';
         import { TradingCardGenerator } from './src/export/TradingCardGenerator.js';
         import { ReactivityManager } from './src/core/ReactivityManager.js';
+        import AudioGameplayDirector from './src/core/AudioGameplayDirector.js';
         // Universal reactivity system removed - implementing modular reactivity system
         
         // Global state - CRITICAL FIX: Check for gallery preview data FIRST
@@ -1620,18 +1630,18 @@
             window.geometries = geometries;
             window.initializePolychora = initializePolychora;
             window.updateParameter = updateParameter;
-            
+
             // Initialize ReactivityManager
             reactivityManager = new ReactivityManager();
             window.reactivityManager = reactivityManager;
-            
+
             // Disable built-in reactivity now that ReactivityManager is active
             if (window.engine) window.engine.useBuiltInReactivity = false;
             if (window.quantumEngine) window.quantumEngine.useBuiltInReactivity = false;
             if (window.holographicSystem) window.holographicSystem.useBuiltInReactivity = false;
-            
+
             console.log('⚡ Built-in system reactivity DISABLED - ReactivityManager taking control');
-            
+
             // Connect ReactivityManager to global interactivity toggle
             if (window.toggleInteractivity) {
                 const originalToggle = window.toggleInteractivity;
@@ -1642,7 +1652,23 @@
                     }
                 };
             }
-            
+
+            if (success) {
+                const audioDirector = new AudioGameplayDirector({
+                    audioEngine: window.audioEngine,
+                    statusManager: engine?.statusManager,
+                    reactivityManager
+                });
+                audioDirector.attachEngines({
+                    engine,
+                    quantumEngine,
+                    holographicSystem,
+                    polychoraSystem
+                });
+                audioDirector.start();
+                window.audioDirector = audioDirector;
+            }
+
             console.log('🚀 VIB34D Clean Interface Ready - All systems + modular reactivity initialized');
         });
         
@@ -2082,14 +2108,22 @@
                 }
                 
                 const success = polychoraSystem.initialize();
-                
+
                 // Hide again if it was hidden
                 if (wasHidden) {
                     polychoraLayers.style.display = 'none';
                 }
-                
+
                 if (success) {
                     console.log('✅ Polychora System initialized');
+                    if (window.audioDirector) {
+                        window.audioDirector.attachEngines({
+                            engine,
+                            quantumEngine,
+                            holographicSystem,
+                            polychoraSystem
+                        });
+                    }
                     return true;
                 } else {
                     console.error('❌ Polychora System initialization failed');
@@ -2217,33 +2251,61 @@
         }
         
         window.toggleAudio = async function() {
-            audioEnabled = !audioEnabled;
-            window.audioEnabled = audioEnabled; // Update global flag
-            
-            // Update button visual state
-            const audioBtn = document.querySelector('[onclick="toggleAudio()"]');
-            if (audioBtn) {
-                audioBtn.style.background = audioEnabled ? 
-                    'rgba(0, 255, 0, 0.3)' : 'rgba(255, 0, 255, 0.1)';
-                audioBtn.style.borderColor = audioEnabled ? '#00ff00' : 'rgba(255, 0, 255, 0.3)';
-                audioBtn.title = `Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`;
+            if (!window.audioEngine) {
+                console.warn('⚠️ Audio engine not initialized');
+                return;
             }
-            
-            // ✅ NEW: CONNECT TO AUDIO ENGINE
-            if (audioEnabled && window.audioEngine) {
+
+            const audioBtn = document.querySelector('[onclick="toggleAudio()"]');
+
+            if (!window.audioEngine.isActive) {
                 const success = await window.audioEngine.init();
-                if (!success) {
-                    audioEnabled = false;
-                    window.audioEnabled = false;
+                audioEnabled = success || window.audioEngine.mode === 'fallback';
+                window.audioEnabled = audioEnabled;
+
+                if (audioBtn) {
+                    if (window.audioEngine.mode === 'fallback') {
+                        audioBtn.style.background = 'linear-gradient(45deg, rgba(255, 140, 0, 0.2), rgba(255, 99, 71, 0.4))';
+                        audioBtn.style.borderColor = '#ff8c00';
+                        audioBtn.title = 'Audio Reactivity: Fallback';
+                    } else if (audioEnabled) {
+                        audioBtn.style.background = 'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))';
+                        audioBtn.style.borderColor = '#00ff00';
+                        audioBtn.title = 'Audio Reactivity: ON';
+                    }
+                }
+
+                if (!success && window.audioEngine.mode !== 'fallback') {
                     console.warn('🎵 Audio initialization failed');
                 }
-            } else if (!audioEnabled && window.audioEngine) {
-                // Properly disable audio engine
-                window.audioEngine.isActive = false;
-                console.log('🎵 Audio engine disabled');
+            } else {
+                audioEnabled = !window.audioEnabled;
+                window.audioEnabled = audioEnabled;
+
+                if (!audioEnabled) {
+                    window.audioEngine.stop();
+                } else {
+                    await window.audioEngine.init();
+                }
+
+                if (audioBtn) {
+                    if (!audioEnabled) {
+                        audioBtn.style.background = 'linear-gradient(45deg, rgba(255, 0, 255, 0.1), rgba(255, 0, 255, 0.3))';
+                        audioBtn.style.borderColor = 'rgba(255, 0, 255, 0.3)';
+                        audioBtn.title = 'Audio Reactivity: OFF';
+                    } else if (window.audioEngine.mode === 'fallback') {
+                        audioBtn.style.background = 'linear-gradient(45deg, rgba(255, 140, 0, 0.2), rgba(255, 99, 71, 0.4))';
+                        audioBtn.style.borderColor = '#ff8c00';
+                        audioBtn.title = 'Audio Reactivity: Fallback';
+                    } else {
+                        audioBtn.style.background = 'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))';
+                        audioBtn.style.borderColor = '#00ff00';
+                        audioBtn.title = 'Audio Reactivity: ON';
+                    }
+                }
             }
-            
-            console.log(`🎵 Audio: ${audioEnabled ? 'ENABLED' : 'DISABLED'}`);
+
+            console.log(`🎵 Audio Reactivity: ${window.audioEnabled ? 'ENABLED' : 'DISABLED'} (${window.audioEngine.mode})`);
         }
         
         window.showLLMInterface = async function() {
@@ -2511,95 +2573,308 @@
                 this.analyser = null;
                 this.dataArray = null;
                 this.isActive = false;
-                
-                // Mobile-safe: Initialize with defaults
+                this.mode = 'idle';
+                this.sourceNode = null;
+                this.currentStream = null;
+                this.trackElement = null;
+                this.trackUrl = null;
+                this.processing = false;
+                this.modeListeners = new Set();
+                this.fallbackTempo = 110;
+                this.fallbackPhase = 0;
+                this.fallbackLastTime = performance.now();
+
                 window.audioReactive = {
                     bass: 0,
-                    mid: 0, 
+                    mid: 0,
                     high: 0,
-                    energy: 0
+                    energy: 0,
+                    mode: 'idle',
+                    bpm: 0
                 };
             }
-            
-            async init() {
-                if (this.isActive) return true;
-                
-                try {
-                    console.log('🎵 Simple Audio Engine: Starting...');
-                    
-                    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                    this.context = new (window.AudioContext || window.webkitAudioContext)();
-                    
-                    if (this.context.state === 'suspended') {
-                        await this.context.resume();
+
+            async init(options = {}) {
+                const { trackUrl = null, fallbackTempo = null, autoplay = true } = options;
+
+                await this.ensureContext();
+                await this.setupAnalyser();
+
+                if (this.isActive) {
+                    if (trackUrl && trackUrl !== this.trackUrl) {
+                        return this.useTrack(trackUrl, { autoplay });
                     }
-                    
-                    this.analyser = this.context.createAnalyser();
-                    this.analyser.fftSize = 256;
-                    this.analyser.smoothingTimeConstant = 0.8;
-                    
-                    const source = this.context.createMediaStreamSource(stream);
-                    source.connect(this.analyser);
-                    
-                    this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+                    if (!trackUrl && this.mode === 'track') {
+                        return this.useMicrophone();
+                    }
+                    return true;
+                }
+
+                try {
+                    if (trackUrl) {
+                        await this.connectTrack(trackUrl, { autoplay });
+                    } else {
+                        await this.connectMicrophone();
+                    }
+
                     this.isActive = true;
-                    
-                    // CRITICAL FIX: Enable global audio flag so visualizers will use the data
                     window.audioEnabled = true;
-                    
                     this.startProcessing();
                     console.log('✅ Audio Engine: Active - window.audioEnabled = true');
                     return true;
-                    
                 } catch (error) {
-                    console.log('⚠️ Audio denied - silent mode');
-                    window.audioEnabled = false; // Keep audio disabled if permission denied
+                    console.warn('⚠️ Audio init failed, switching to fallback metronome:', error);
+                    await this.enableFallback(fallbackTempo || this.fallbackTempo);
+                    this.isActive = true;
+                    window.audioEnabled = true;
+                    this.startProcessing();
                     return false;
                 }
             }
-            
+
+            async ensureContext() {
+                if (!this.context) {
+                    this.context = new (window.AudioContext || window.webkitAudioContext)();
+                }
+                if (this.context.state === 'suspended') {
+                    await this.context.resume();
+                }
+                return this.context;
+            }
+
+            async setupAnalyser() {
+                if (!this.analyser && this.context) {
+                    this.analyser = this.context.createAnalyser();
+                    this.analyser.fftSize = 512;
+                    this.analyser.smoothingTimeConstant = 0.75;
+                    this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+                }
+            }
+
+            disconnectSources() {
+                if (this.sourceNode) {
+                    try { this.sourceNode.disconnect(); } catch (error) { console.warn('Audio source disconnect issue:', error); }
+                    this.sourceNode = null;
+                }
+                if (this.currentStream) {
+                    try {
+                        this.currentStream.getTracks().forEach(track => track.stop());
+                    } catch (error) {
+                        console.warn('Audio stream stop issue:', error);
+                    }
+                    this.currentStream = null;
+                }
+                if (this.trackElement) {
+                    try { this.trackElement.pause(); } catch (error) { console.warn('Audio track pause issue:', error); }
+                    this.trackElement.src = '';
+                    this.trackElement = null;
+                }
+                this.trackUrl = null;
+            }
+
+            async connectMicrophone() {
+                this.disconnectSources();
+                if (!navigator.mediaDevices?.getUserMedia) {
+                    throw new Error('Microphone access not supported');
+                }
+                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                this.currentStream = stream;
+                this.sourceNode = this.context.createMediaStreamSource(stream);
+                this.sourceNode.connect(this.analyser);
+                this.setMode('microphone');
+            }
+
+            async connectTrack(trackUrl, options = {}) {
+                this.disconnectSources();
+                const { autoplay = true, loop = true } = options;
+                const audioElement = new Audio();
+                audioElement.crossOrigin = 'anonymous';
+                audioElement.src = trackUrl;
+                audioElement.loop = loop;
+
+                if (autoplay) {
+                    try {
+                        await audioElement.play();
+                    } catch (error) {
+                        console.warn('Auto-play blocked, waiting for interaction:', error.message);
+                    }
+                }
+
+                this.trackElement = audioElement;
+                this.sourceNode = this.context.createMediaElementSource(audioElement);
+                this.sourceNode.connect(this.analyser);
+                this.sourceNode.connect(this.context.destination);
+                this.trackUrl = trackUrl;
+                this.setMode('track');
+            }
+
+            async useMicrophone() {
+                try {
+                    await this.connectMicrophone();
+                    this.isActive = true;
+                    this.startProcessing();
+                    return true;
+                } catch (error) {
+                    console.warn('Microphone activation failed, keeping fallback:', error.message);
+                    await this.enableFallback(this.fallbackTempo);
+                    this.startProcessing();
+                    return false;
+                }
+            }
+
+            async useTrack(trackUrl, options = {}) {
+                await this.ensureContext();
+                await this.setupAnalyser();
+                if (!trackUrl) {
+                    return this.useMicrophone();
+                }
+                try {
+                    await this.connectTrack(trackUrl, options);
+                    this.isActive = true;
+                    this.startProcessing();
+                    return true;
+                } catch (error) {
+                    console.error('Failed to load external track:', error);
+                    return false;
+                }
+            }
+
+            async enableFallback(tempo = 110) {
+                await this.ensureContext();
+                this.disconnectSources();
+                this.fallbackTempo = tempo;
+                this.fallbackPhase = 0;
+                this.fallbackLastTime = performance.now();
+                this.setMode('fallback');
+            }
+
+            onModeChange(listener) {
+                if (typeof listener === 'function') {
+                    this.modeListeners.add(listener);
+                    return () => this.modeListeners.delete(listener);
+                }
+                return () => {};
+            }
+
+            setMode(mode, reason = '') {
+                if (this.mode === mode) return;
+                this.mode = mode;
+                if (window.audioReactive) {
+                    window.audioReactive.mode = mode;
+                }
+                this.modeListeners.forEach(listener => {
+                    try {
+                        listener(mode, reason);
+                    } catch (error) {
+                        console.warn('Audio mode listener error:', error);
+                    }
+                });
+            }
+
             startProcessing() {
+                if (this.processing) return;
+                this.processing = true;
+
                 const process = () => {
-                    if (!this.isActive || !this.analyser) {
+                    if (!this.processing) return;
+
+                    if (!this.isActive) {
                         requestAnimationFrame(process);
                         return;
                     }
-                    
-                    this.analyser.getByteFrequencyData(this.dataArray);
-                    
-                    // Simple frequency analysis
-                    const len = this.dataArray.length;
-                    const bassRange = Math.floor(len * 0.1);
-                    const midRange = Math.floor(len * 0.3);
-                    
-                    let bass = 0, mid = 0, high = 0;
-                    
-                    for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
-                    for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
-                    for (let i = midRange; i < len; i++) high += this.dataArray[i];
-                    
-                    bass = (bass / bassRange) / 255;
-                    mid = (mid / (midRange - bassRange)) / 255;
-                    high = (high / (len - midRange)) / 255;
-                    
-                    const smoothing = 0.7;
-                    window.audioReactive.bass = bass * smoothing + window.audioReactive.bass * (1 - smoothing);
-                    window.audioReactive.mid = mid * smoothing + window.audioReactive.mid * (1 - smoothing);
-                    window.audioReactive.high = high * smoothing + window.audioReactive.high * (1 - smoothing);
-                    window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
-                    
-                    // Debug logging every 5 seconds to verify audio processing
-                    if (Date.now() % 5000 < 16) {
-                        console.log(`🎵 Audio levels: Bass=${window.audioReactive.bass.toFixed(2)} Mid=${window.audioReactive.mid.toFixed(2)} High=${window.audioReactive.high.toFixed(2)} Energy=${window.audioReactive.energy.toFixed(2)}`);
+
+                    if (this.mode === 'fallback') {
+                        this.updateFallbackReactive();
+                    } else if (this.analyser && this.dataArray) {
+                        this.analyser.getByteFrequencyData(this.dataArray);
+
+                        const len = this.dataArray.length;
+                        const bassRange = Math.max(1, Math.floor(len * 0.1));
+                        const midRange = Math.max(bassRange + 1, Math.floor(len * 0.35));
+
+                        let bass = 0, mid = 0, high = 0;
+
+                        for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
+                        for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
+                        for (let i = midRange; i < len; i++) high += this.dataArray[i];
+
+                        bass = (bass / bassRange) / 255;
+                        mid = (mid / (midRange - bassRange)) / 255;
+                        high = (high / (len - midRange)) / 255;
+
+                        this.applySmoothing({ bass, mid, high }, 0.7);
                     }
-                    
+
                     requestAnimationFrame(process);
                 };
-                
-                process();
+
+                requestAnimationFrame(process);
+            }
+
+            applySmoothing(levels, smoothing = 0.7) {
+                if (!window.audioReactive) return;
+                window.audioReactive.bass = levels.bass * smoothing + (window.audioReactive.bass || 0) * (1 - smoothing);
+                window.audioReactive.mid = levels.mid * smoothing + (window.audioReactive.mid || 0) * (1 - smoothing);
+                window.audioReactive.high = levels.high * smoothing + (window.audioReactive.high || 0) * (1 - smoothing);
+                window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
+                window.audioReactive.mode = this.mode;
+            }
+
+            updateFallbackReactive() {
+                const now = performance.now();
+                const dt = (now - this.fallbackLastTime) / 1000;
+                this.fallbackLastTime = now;
+
+                const beatFrequency = (this.fallbackTempo || 110) / 60;
+                this.fallbackPhase = (this.fallbackPhase + dt * beatFrequency) % 1;
+
+                const bass = Math.max(0, Math.sin(this.fallbackPhase * Math.PI));
+                const mid = Math.max(0, Math.sin(((this.fallbackPhase + 0.33) % 1) * Math.PI));
+                const high = Math.max(0, Math.sin(((this.fallbackPhase + 0.66) % 1) * Math.PI));
+
+                this.applySmoothing({
+                    bass: bass * 0.95 + Math.random() * 0.05,
+                    mid: mid * 0.9 + Math.random() * 0.04,
+                    high: high * 0.85 + Math.random() * 0.03
+                }, 0.6);
+            }
+
+            isAudioActive() {
+                return this.isActive && this.mode !== 'idle';
+            }
+
+            stop() {
+                this.processing = false;
+                this.isActive = false;
+                window.audioEnabled = false;
+                this.setMode('idle');
+
+                if (this.context) {
+                    try {
+                        this.context.close();
+                    } catch (error) {
+                        console.warn('Audio context close issue:', error);
+                    }
+                    this.context = null;
+                }
+
+                this.disconnectSources();
+                this.analyser = null;
+                this.dataArray = null;
+
+                window.audioReactive = {
+                    bass: 0,
+                    mid: 0,
+                    high: 0,
+                    energy: 0,
+                    mode: 'idle',
+                    bpm: 0
+                };
+
+                console.log('🎵 Audio Engine: Stopped');
             }
         }
-        
+
         // Create the simple, mobile-safe audio engine
         window.audioEngine = new SimpleAudioEngine();
         

--- a/js/audio/audio-engine.js
+++ b/js/audio/audio-engine.js
@@ -17,122 +17,355 @@ export class SimpleAudioEngine {
         this.analyser = null;
         this.dataArray = null;
         this.isActive = false;
-        
+        this.mode = 'idle'; // 'idle' | 'microphone' | 'track' | 'fallback'
+        this.sourceNode = null;
+        this.currentStream = null;
+        this.trackElement = null;
+        this.trackUrl = null;
+        this.processing = false;
+        this.modeListeners = new Set();
+        this.fallbackTempo = 110;
+        this.fallbackPhase = 0;
+        this.fallbackLastTime = performance.now();
+
         // Mobile-safe: Initialize with defaults
         window.audioReactive = {
             bass: 0,
-            mid: 0, 
+            mid: 0,
             high: 0,
-            energy: 0
+            energy: 0,
+            mode: 'idle',
+            bpm: 0
         };
-        
+
         console.log('🎵 Audio Engine: Initialized with default values');
     }
-    
-    async init() {
-        if (this.isActive) return true;
-        
-        try {
-            console.log('🎵 Simple Audio Engine: Starting...');
-            
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            this.context = new (window.AudioContext || window.webkitAudioContext)();
-            
-            if (this.context.state === 'suspended') {
-                await this.context.resume();
+
+    /**
+     * Initialize the audio engine with microphone or optional track input
+     */
+    async init(options = {}) {
+        const { trackUrl = null, fallbackTempo = null, autoplay = true } = options;
+
+        // Resume context if already active
+        await this.ensureContext();
+        await this.setupAnalyser();
+
+        if (this.isActive) {
+            if (trackUrl && trackUrl !== this.trackUrl) {
+                return this.useTrack(trackUrl, { autoplay });
             }
-            
-            this.analyser = this.context.createAnalyser();
-            this.analyser.fftSize = 256;
-            this.analyser.smoothingTimeConstant = 0.8;
-            
-            const source = this.context.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
-            this.isActive = true;
-            
-            // CRITICAL FIX: Enable global audio flag so visualizers will use the data
-            window.audioEnabled = true;
-            
-            this.startProcessing();
-            console.log('✅ Audio Engine: Active - window.audioEnabled = true');
+            if (!trackUrl && this.mode === 'track') {
+                return this.useMicrophone();
+            }
             return true;
-            
+        }
+
+        try {
+            if (trackUrl) {
+                await this.connectTrack(trackUrl, { autoplay });
+            } else {
+                await this.connectMicrophone();
+            }
+
+            this.isActive = true;
+            window.audioEnabled = true;
+            this.startProcessing();
+            return true;
         } catch (error) {
-            console.log('⚠️ Audio denied - silent mode');
-            window.audioEnabled = false; // Keep audio disabled if permission denied
+            console.warn('⚠️ Audio init failed, switching to fallback metronome:', error);
+            await this.enableFallback(fallbackTempo || this.fallbackTempo);
+            this.isActive = true;
+            window.audioEnabled = true;
+            this.startProcessing();
             return false;
         }
     }
-    
+
+    /**
+     * Ensure audio context exists and is running
+     */
+    async ensureContext() {
+        if (!this.context) {
+            this.context = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        if (this.context.state === 'suspended') {
+            await this.context.resume();
+        }
+        return this.context;
+    }
+
+    /**
+     * Configure analyser node
+     */
+    async setupAnalyser() {
+        if (!this.analyser && this.context) {
+            this.analyser = this.context.createAnalyser();
+            this.analyser.fftSize = 512;
+            this.analyser.smoothingTimeConstant = 0.75;
+            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+        }
+    }
+
+    /**
+     * Disconnect any active audio sources
+     */
+    disconnectSources() {
+        if (this.sourceNode) {
+            try { this.sourceNode.disconnect(); } catch (e) { console.warn('Audio source disconnect issue:', e); }
+            this.sourceNode = null;
+        }
+        if (this.currentStream) {
+            try {
+                this.currentStream.getTracks().forEach(track => track.stop());
+            } catch (e) {
+                console.warn('Audio stream stop issue:', e);
+            }
+            this.currentStream = null;
+        }
+        if (this.trackElement) {
+            try {
+                this.trackElement.pause();
+            } catch (e) {
+                console.warn('Audio track pause issue:', e);
+            }
+            this.trackElement.src = '';
+            this.trackElement = null;
+        }
+        this.trackUrl = null;
+    }
+
+    /**
+     * Connect microphone input
+     */
+    async connectMicrophone() {
+        this.disconnectSources();
+        if (!navigator.mediaDevices?.getUserMedia) {
+            throw new Error('Microphone access not supported');
+        }
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        this.currentStream = stream;
+        this.sourceNode = this.context.createMediaStreamSource(stream);
+        this.sourceNode.connect(this.analyser);
+        this.setMode('microphone');
+    }
+
+    /**
+     * Connect an audio track
+     */
+    async connectTrack(trackUrl, options = {}) {
+        this.disconnectSources();
+        const { autoplay = true, loop = true } = options;
+        const audioElement = new Audio();
+        audioElement.crossOrigin = 'anonymous';
+        audioElement.src = trackUrl;
+        audioElement.loop = loop;
+
+        if (autoplay) {
+            try {
+                await audioElement.play();
+            } catch (error) {
+                console.warn('Auto-play blocked, waiting for user interaction:', error.message);
+            }
+        }
+
+        this.trackElement = audioElement;
+        this.sourceNode = this.context.createMediaElementSource(audioElement);
+        this.sourceNode.connect(this.analyser);
+        this.sourceNode.connect(this.context.destination);
+        this.trackUrl = trackUrl;
+        this.setMode('track');
+    }
+
+    /**
+     * Public helper to switch back to microphone mode
+     */
+    async useMicrophone() {
+        try {
+            await this.connectMicrophone();
+            this.isActive = true;
+            this.startProcessing();
+            return true;
+        } catch (error) {
+            console.warn('Microphone activation failed, keeping fallback:', error.message);
+            await this.enableFallback(this.fallbackTempo);
+            this.startProcessing();
+            return false;
+        }
+    }
+
+    /**
+     * Public helper to switch to an external track
+     */
+    async useTrack(trackUrl, options = {}) {
+        await this.ensureContext();
+        await this.setupAnalyser();
+        if (!trackUrl) {
+            return this.useMicrophone();
+        }
+        try {
+            await this.connectTrack(trackUrl, options);
+            this.isActive = true;
+            this.startProcessing();
+            return true;
+        } catch (error) {
+            console.error('Failed to load external track:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Enable fallback metronome mode
+     */
+    async enableFallback(tempo = 110) {
+        await this.ensureContext();
+        this.disconnectSources();
+        this.fallbackTempo = tempo;
+        this.fallbackPhase = 0;
+        this.fallbackLastTime = performance.now();
+        this.setMode('fallback');
+    }
+
+    /**
+     * Register a listener for mode changes
+     */
+    onModeChange(listener) {
+        if (typeof listener === 'function') {
+            this.modeListeners.add(listener);
+            return () => this.modeListeners.delete(listener);
+        }
+        return () => {};
+    }
+
+    setMode(mode, reason = '') {
+        if (this.mode === mode) return;
+        this.mode = mode;
+        window.audioReactive.mode = mode;
+        this.modeListeners.forEach(listener => {
+            try {
+                listener(mode, reason);
+            } catch (error) {
+                console.warn('Audio mode listener error:', error);
+            }
+        });
+    }
+
+    /**
+     * Start processing loop
+     */
     startProcessing() {
+        if (this.processing) return;
+        this.processing = true;
+
         const process = () => {
-            if (!this.isActive || !this.analyser) {
+            if (!this.processing) return;
+
+            if (!this.isActive) {
                 requestAnimationFrame(process);
                 return;
             }
-            
-            this.analyser.getByteFrequencyData(this.dataArray);
-            
-            // Simple frequency analysis
-            const len = this.dataArray.length;
-            const bassRange = Math.floor(len * 0.1);
-            const midRange = Math.floor(len * 0.3);
-            
-            let bass = 0, mid = 0, high = 0;
-            
-            for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
-            for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
-            for (let i = midRange; i < len; i++) high += this.dataArray[i];
-            
-            bass = (bass / bassRange) / 255;
-            mid = (mid / (midRange - bassRange)) / 255;
-            high = (high / (len - midRange)) / 255;
-            
-            const smoothing = 0.7;
-            window.audioReactive.bass = bass * smoothing + window.audioReactive.bass * (1 - smoothing);
-            window.audioReactive.mid = mid * smoothing + window.audioReactive.mid * (1 - smoothing);
-            window.audioReactive.high = high * smoothing + window.audioReactive.high * (1 - smoothing);
-            window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
-            
-            // Debug logging every 5 seconds to verify audio processing
-            if (Date.now() % 5000 < 16) {
-                console.log(`🎵 Audio levels: Bass=${window.audioReactive.bass.toFixed(2)} Mid=${window.audioReactive.mid.toFixed(2)} High=${window.audioReactive.high.toFixed(2)} Energy=${window.audioReactive.energy.toFixed(2)}`);
+
+            if (this.mode === 'fallback') {
+                this.updateFallbackReactive();
+            } else if (this.analyser && this.dataArray) {
+                this.analyser.getByteFrequencyData(this.dataArray);
+
+                const len = this.dataArray.length;
+                const bassRange = Math.max(1, Math.floor(len * 0.1));
+                const midRange = Math.max(bassRange + 1, Math.floor(len * 0.35));
+
+                let bass = 0, mid = 0, high = 0;
+
+                for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
+                for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
+                for (let i = midRange; i < len; i++) high += this.dataArray[i];
+
+                bass = (bass / bassRange) / 255;
+                mid = (mid / (midRange - bassRange)) / 255;
+                high = (high / (len - midRange)) / 255;
+
+                this.applySmoothing({ bass, mid, high }, 0.7);
             }
-            
+
             requestAnimationFrame(process);
         };
-        
-        process();
+
+        requestAnimationFrame(process);
     }
-    
+
     /**
-     * Check if audio is currently active and processing
+     * Apply smoothing to global audioReactive object
+     */
+    applySmoothing(levels, smoothing = 0.7) {
+        const reactive = window.audioReactive || {};
+        reactive.bass = levels.bass * smoothing + (reactive.bass || 0) * (1 - smoothing);
+        reactive.mid = levels.mid * smoothing + (reactive.mid || 0) * (1 - smoothing);
+        reactive.high = levels.high * smoothing + (reactive.high || 0) * (1 - smoothing);
+        reactive.energy = (reactive.bass + reactive.mid + reactive.high) / 3;
+        reactive.mode = this.mode;
+        window.audioReactive = reactive;
+    }
+
+    /**
+     * Generate synthetic audio levels when running without real audio
+     */
+    updateFallbackReactive() {
+        const now = performance.now();
+        const dt = (now - this.fallbackLastTime) / 1000;
+        this.fallbackLastTime = now;
+
+        const beatFrequency = (this.fallbackTempo || 110) / 60;
+        this.fallbackPhase = (this.fallbackPhase + dt * beatFrequency) % 1;
+
+        const bass = Math.max(0, Math.sin(this.fallbackPhase * Math.PI));
+        const mid = Math.max(0, Math.sin(((this.fallbackPhase + 0.33) % 1) * Math.PI));
+        const high = Math.max(0, Math.sin(((this.fallbackPhase + 0.66) % 1) * Math.PI));
+
+        this.applySmoothing({
+            bass: bass * 0.95 + Math.random() * 0.05,
+            mid: mid * 0.9 + Math.random() * 0.04,
+            high: high * 0.85 + Math.random() * 0.03
+        }, 0.6);
+    }
+
+    /**
+     * Check if audio processing is active
      */
     isAudioActive() {
-        return this.isActive && window.audioEnabled;
+        return this.isActive && this.mode !== 'idle';
     }
-    
-    /**
-     * Get current audio reactive values
-     */
-    getAudioLevels() {
-        return window.audioReactive;
-    }
-    
+
     /**
      * Stop audio processing and clean up resources
      */
     stop() {
+        this.processing = false;
         this.isActive = false;
         window.audioEnabled = false;
-        
+        this.setMode('idle');
+
         if (this.context) {
-            this.context.close();
+            try {
+                this.context.close();
+            } catch (error) {
+                console.warn('Audio context close issue:', error);
+            }
             this.context = null;
         }
-        
+
+        this.disconnectSources();
+        this.analyser = null;
+        this.dataArray = null;
+
+        window.audioReactive = {
+            bass: 0,
+            mid: 0,
+            high: 0,
+            energy: 0,
+            mode: 'idle',
+            bpm: 0
+        };
+
         console.log('🎵 Audio Engine: Stopped');
     }
 }
@@ -142,46 +375,45 @@ export class SimpleAudioEngine {
  * Toggles audio reactivity and updates UI state
  */
 export function setupAudioToggle() {
-    window.toggleAudio = function() {
+    window.toggleAudio = async function() {
         const audioBtn = document.querySelector('[onclick="toggleAudio()"]');
-        
+
         if (!window.audioEngine.isActive) {
-            // Try to start audio
-            window.audioEngine.init().then(success => {
-                if (success) {
-                    if (audioBtn) {
-                        audioBtn.style.background = 'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))';
-                        audioBtn.style.borderColor = '#00ff00';
-                        audioBtn.title = 'Audio Reactivity: ON';
-                    }
-                    console.log('🎵 Audio Reactivity: ON');
-                } else {
-                    console.log('⚠️ Audio permission denied or not available');
+            const success = await window.audioEngine.init();
+            if (success) {
+                window.audioEnabled = true;
+                if (audioBtn) {
+                    audioBtn.style.background = 'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))';
+                    audioBtn.style.borderColor = '#00ff00';
+                    audioBtn.title = 'Audio Reactivity: ON';
                 }
-            });
+                console.log('🎵 Audio Reactivity: ON');
+            } else {
+                console.log('⚠️ Audio permission denied or not available - fallback metronome active');
+                if (audioBtn) {
+                    audioBtn.style.background = 'linear-gradient(45deg, rgba(255, 140, 0, 0.2), rgba(255, 99, 71, 0.4))';
+                    audioBtn.style.borderColor = '#ff8c00';
+                    audioBtn.title = 'Audio Reactivity: Fallback';
+                }
+            }
         } else {
-            // Toggle audio processing
-            let audioEnabled = !window.audioEnabled;
-            window.audioEnabled = audioEnabled; // Update global flag
-            
+            const audioEnabled = !window.audioEnabled;
+            window.audioEnabled = audioEnabled;
+
+            if (!audioEnabled) {
+                window.audioEngine.stop();
+            } else {
+                await window.audioEngine.init();
+            }
+
             if (audioBtn) {
-                // Update button visual state
-                audioBtn.style.background = audioEnabled ? 
-                    'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))' : 
-                    'linear-gradient(45deg, rgba(255, 0, 255, 0.1), rgba(255, 0, 255, 0.3))';
+                audioBtn.style.background = audioEnabled
+                    ? 'linear-gradient(45deg, rgba(0, 255, 0, 0.3), rgba(0, 255, 0, 0.6))'
+                    : 'linear-gradient(45deg, rgba(255, 0, 255, 0.1), rgba(255, 0, 255, 0.3))';
                 audioBtn.style.borderColor = audioEnabled ? '#00ff00' : 'rgba(255, 0, 255, 0.3)';
                 audioBtn.title = `Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`;
             }
-            
-            // Audio permission check for mobile
-            if (audioEnabled) {
-                navigator.mediaDevices.getUserMedia({ audio: true }).catch(e => {
-                    audioEnabled = false;
-                    window.audioEnabled = false;
-                    console.log('⚠️ Audio permission denied:', e.message);
-                });
-            }
-            
+
             console.log(`🎵 Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`);
         }
     };

--- a/src/core/AudioGameplayDirector.js
+++ b/src/core/AudioGameplayDirector.js
@@ -1,0 +1,579 @@
+/**
+ * AudioGameplayDirector
+ * Centralizes beat detection and audio-driven gameplay logic across all visualizer systems.
+ * Ensures every geometry, variation, and event is spawned in relation to microphone or track audio input.
+ */
+export class AudioGameplayDirector {
+    constructor(options = {}) {
+        this.audioEngine = options.audioEngine || window.audioEngine || null;
+        this.statusManager = options.statusManager || window.statusManager || null;
+        this.reactivityManager = options.reactivityManager || window.reactivityManager || null;
+
+        this.engines = {
+            faceted: null,
+            quantum: null,
+            holographic: null,
+            polychora: null
+        };
+
+        this.energyHistory = new Array(options.historySize || 96).fill(0);
+        this.energyCursor = 0;
+        this.energyTotal = 0;
+        this.prevEnergy = 0;
+        this.lastBeatTime = 0;
+        this.currentBpm = 0;
+        this.minBeatInterval = options.minBeatInterval || 180; // milliseconds
+        this.beatSensitivity = options.beatSensitivity || 1.6;
+        this.silenceCounter = 0;
+        this.silenceThreshold = options.silenceFrames || 240;
+        this.mode = this.audioEngine?.mode || 'idle';
+        this.syntheticTempo = options.syntheticTempo || 110;
+        this.nextSyntheticBeat = performance.now();
+        this.running = false;
+        this.manualTrackUrl = options.trackUrl || null;
+        this.bootstrapped = false;
+        this.modeSubscription = null;
+        this.lastStatusMessage = null;
+
+        this.lastGeometryChange = {
+            faceted: 0,
+            quantum: 0,
+            holographic: 0,
+            polychora: 0
+        };
+
+        this.geometryDirections = {
+            faceted: 1,
+            quantum: 1,
+            polychora: 1
+        };
+
+        this.levelState = {
+            faceted: 0.3,
+            quantum: 0.4,
+            holographic: 0.5,
+            polychora: 0.4
+        };
+
+        this.fallbackProfiles = this.buildFallbackProfiles();
+    }
+
+    attachEngines({ engine, quantumEngine, holographicSystem, polychoraSystem }) {
+        if (engine) this.engines.faceted = engine;
+        if (quantumEngine) this.engines.quantum = quantumEngine;
+        if (holographicSystem) this.engines.holographic = holographicSystem;
+        if (polychoraSystem) this.engines.polychora = polychoraSystem;
+    }
+
+    start(options = {}) {
+        if (this.running) return;
+        if (options.audioEngine) {
+            this.audioEngine = options.audioEngine;
+        }
+        if (options.trackUrl) {
+            this.manualTrackUrl = options.trackUrl;
+        }
+
+        this.running = true;
+        this.installModeSubscription();
+        this.installInteractionBootstrap();
+        this.loop();
+    }
+
+    stop() {
+        this.running = false;
+        if (this.modeSubscription) {
+            this.modeSubscription();
+            this.modeSubscription = null;
+        }
+    }
+
+    installModeSubscription() {
+        if (!this.audioEngine || typeof this.audioEngine.onModeChange !== 'function' || this.modeSubscription) {
+            return;
+        }
+
+        this.modeSubscription = this.audioEngine.onModeChange((mode, reason) => {
+            this.mode = mode;
+            this.silenceCounter = 0;
+            if (mode === 'microphone') {
+                this.notifyStatus('Microphone audio linked. Reactive gameplay engaged.', 'success');
+            } else if (mode === 'track') {
+                this.notifyStatus('External track linked. Visualizers following track audio.', 'info');
+            } else if (mode === 'fallback') {
+                this.notifyStatus('Audio input unavailable – fallback metronome active.', 'warning');
+            } else if (mode === 'idle') {
+                this.notifyStatus('Audio reactivity paused.', 'info');
+            }
+        });
+    }
+
+    installInteractionBootstrap() {
+        if (this.bootstrapped) return;
+
+        const handler = async () => {
+            await this.ensureAudioEngineActive();
+        };
+
+        window.addEventListener('pointerdown', handler, { once: true });
+        window.addEventListener('keydown', handler, { once: true });
+        this.bootstrapped = true;
+    }
+
+    async ensureAudioEngineActive() {
+        if (!this.audioEngine) return;
+        if (!this.audioEngine.isActive) {
+            const options = this.manualTrackUrl ? { trackUrl: this.manualTrackUrl } : {};
+            await this.audioEngine.init(options);
+        }
+    }
+
+    loop() {
+        if (!this.running) return;
+        this.update();
+        requestAnimationFrame(() => this.loop());
+    }
+
+    update() {
+        const reactive = window.audioReactive || { bass: 0, mid: 0, high: 0, energy: 0 };
+        const rawEnergy = typeof reactive.energy === 'number'
+            ? reactive.energy
+            : (this.clamp(reactive.bass) + this.clamp(reactive.mid) + this.clamp(reactive.high)) / 3;
+
+        this.energyTotal -= this.energyHistory[this.energyCursor];
+        this.energyHistory[this.energyCursor] = rawEnergy;
+        this.energyTotal += rawEnergy;
+        this.energyCursor = (this.energyCursor + 1) % this.energyHistory.length;
+
+        const average = this.energyTotal / this.energyHistory.length;
+        const threshold = Math.max(average * this.beatSensitivity, average + 0.05);
+        const now = performance.now();
+
+        const deltaEnergy = rawEnergy - this.prevEnergy;
+        const mode = this.audioEngine?.mode || reactive.mode || 'idle';
+        const audioEnabled = window.audioEnabled !== false;
+
+        if (mode !== 'fallback' && audioEnabled && rawEnergy > threshold && deltaEnergy > 0.02 && (now - this.lastBeatTime) > this.minBeatInterval) {
+            this.registerBeat('audio', {
+                energy: this.clamp(rawEnergy),
+                bass: this.clamp(reactive.bass),
+                mid: this.clamp(reactive.mid),
+                high: this.clamp(reactive.high)
+            }, now);
+            this.silenceCounter = 0;
+        } else {
+            if (rawEnergy < Math.max(average * 0.6, 0.02) || !audioEnabled) {
+                this.silenceCounter += 1;
+            } else {
+                this.silenceCounter = Math.max(0, this.silenceCounter - 2);
+            }
+        }
+
+        this.prevEnergy = rawEnergy;
+
+        if (this.silenceCounter > this.silenceThreshold) {
+            if (this.audioEngine && typeof this.audioEngine.enableFallback === 'function' && this.audioEngine.mode !== 'fallback') {
+                this.audioEngine.enableFallback(this.syntheticTempo);
+            }
+            this.silenceCounter = this.silenceThreshold;
+        }
+
+        if (this.audioEngine?.mode === 'fallback' || mode === 'fallback') {
+            const system = this.getCurrentSystem();
+            const geometry = this.getActiveGeometryIndex(system);
+            const profile = this.getFallbackProfile(system, geometry);
+            const tempo = profile?.tempo || this.syntheticTempo;
+            const period = 60000 / tempo;
+            if (now >= this.nextSyntheticBeat) {
+                const syntheticLevels = this.generateSyntheticLevels(profile);
+                this.registerBeat('fallback', syntheticLevels, now, profile);
+                this.nextSyntheticBeat = now + period;
+            }
+        } else if (this.currentBpm > 0) {
+            this.syntheticTempo = this.currentBpm;
+            this.nextSyntheticBeat = now + 60000 / this.syntheticTempo;
+        }
+    }
+
+    registerBeat(source, levels, now, profile) {
+        const delta = now - this.lastBeatTime;
+        if (this.lastBeatTime > 0 && delta > 0) {
+            const bpm = 60000 / delta;
+            this.currentBpm = this.currentBpm ? (this.currentBpm * 0.75 + bpm * 0.25) : bpm;
+        }
+        this.lastBeatTime = now;
+
+        if (window.audioReactive) {
+            window.audioReactive.bpm = Math.round(this.currentBpm || 0);
+        }
+
+        const beatData = {
+            timestamp: now,
+            bpm: this.currentBpm,
+            energy: this.clamp(levels.energy),
+            bass: this.clamp(levels.bass),
+            mid: this.clamp(levels.mid),
+            high: this.clamp(levels.high),
+            source,
+            mode: this.audioEngine?.mode || source,
+            profile: profile || null
+        };
+
+        this.handleBeat(beatData);
+    }
+
+    handleBeat(beatData) {
+        const system = this.getCurrentSystem();
+        switch (system) {
+            case 'quantum':
+                this.handleQuantumBeat(beatData);
+                break;
+            case 'holographic':
+                this.handleHolographicBeat(beatData);
+                break;
+            case 'polychora':
+                this.handlePolychoraBeat(beatData);
+                break;
+            case 'faceted':
+            default:
+                this.handleFacetedBeat(beatData);
+                break;
+        }
+    }
+
+    handleFacetedBeat(beatData) {
+        const geometry = this.getActiveGeometryIndex('faceted');
+        const profile = beatData.profile || this.getFallbackProfile('faceted', geometry);
+        const now = performance.now();
+
+        const density = this.lerp(profile.densityRange[0], profile.densityRange[1], Math.min(1, beatData.energy + beatData.bass * 0.4));
+        const morph = this.lerp(profile.morphRange[0], profile.morphRange[1], Math.min(1, beatData.mid + 0.2));
+        const chaos = this.lerp(profile.chaosRange[0], profile.chaosRange[1], Math.min(1, beatData.energy + Math.random() * 0.3));
+        const speed = this.lerp(profile.speedRange[0], profile.speedRange[1], Math.min(1, beatData.high + 0.2));
+        const hue = this.wrapHue(this.lerp(profile.hueRange[0], profile.hueRange[1], Math.min(1, beatData.bass * 0.5 + beatData.high * 0.5)));
+        const intensity = this.clamp(0.4 + beatData.energy * 0.5, 0.3, 1.0);
+
+        this.applyParameter('gridDensity', density);
+        this.applyParameter('morphFactor', morph);
+        this.applyParameter('chaos', chaos);
+        this.applyParameter('speed', speed);
+        this.applyParameter('hue', hue);
+        this.applyParameter('intensity', intensity);
+
+        this.levelState.faceted = this.levelState.faceted * 0.7 + beatData.energy * 0.3;
+
+        if ((beatData.bass > 0.65 || beatData.energy > 0.75) && (now - this.lastGeometryChange.faceted) > 600) {
+            const nextGeometry = this.resolveGeometryFlow('faceted', geometry, profile.geometryFlow, 8);
+            this.applyGeometry('faceted', nextGeometry);
+            this.lastGeometryChange.faceted = now;
+        }
+    }
+
+    handleQuantumBeat(beatData) {
+        const geometry = this.getActiveGeometryIndex('quantum');
+        const profile = beatData.profile || this.getFallbackProfile('quantum', geometry);
+        const now = performance.now();
+
+        const density = this.lerp(profile.densityRange[0], profile.densityRange[1], Math.min(1, beatData.energy + beatData.mid * 0.3));
+        const morph = this.lerp(profile.morphRange[0], profile.morphRange[1], Math.min(1, beatData.mid + beatData.high * 0.2));
+        const chaos = this.lerp(profile.chaosRange[0], profile.chaosRange[1], Math.min(1, beatData.energy + beatData.high));
+        const speed = this.lerp(profile.speedRange[0], profile.speedRange[1], Math.min(1, beatData.high + 0.15));
+        const hue = this.wrapHue(this.lerp(profile.hueRange[0], profile.hueRange[1], Math.min(1, beatData.bass * 0.4 + beatData.high * 0.6)));
+
+        this.applyParameter('gridDensity', density);
+        this.applyParameter('morphFactor', morph);
+        this.applyParameter('chaos', chaos);
+        this.applyParameter('speed', speed);
+        this.applyParameter('hue', hue);
+
+        this.levelState.quantum = this.levelState.quantum * 0.65 + beatData.energy * 0.35;
+
+        if ((beatData.high > 0.6 || beatData.energy > 0.8) && (now - this.lastGeometryChange.quantum) > 800) {
+            const nextGeometry = this.resolveGeometryFlow('quantum', geometry, profile.geometryFlow, 8);
+            this.applyGeometry('quantum', nextGeometry);
+            this.lastGeometryChange.quantum = now;
+        }
+    }
+
+    handleHolographicBeat(beatData) {
+        const geometry = this.getActiveGeometryIndex('holographic');
+        const profile = beatData.profile || this.getFallbackProfile('holographic', geometry);
+        const now = performance.now();
+
+        const baseVariant = geometry * profile.variantSpread;
+        const variantOffset = Math.floor(this.clamp(beatData.bass * 0.6 + beatData.mid * 0.6, 0, 1) * profile.variantSpread) % profile.variantSpread;
+        const variant = this.clamp(baseVariant + variantOffset, 0, this.getHolographicVariantCount() - 1);
+
+        this.setHolographicVariant(variant);
+
+        const intensity = this.lerp(profile.intensityRange[0], profile.intensityRange[1], Math.min(1, beatData.energy + beatData.bass * 0.3));
+        const saturation = this.lerp(profile.saturationRange[0], profile.saturationRange[1], Math.min(1, beatData.mid + 0.1));
+        const chaos = this.lerp(profile.chaosRange[0], profile.chaosRange[1], Math.min(1, beatData.energy + beatData.high * 0.4));
+        const speed = this.lerp(profile.speedRange[0], profile.speedRange[1], Math.min(1, beatData.high + 0.15));
+        const hue = this.wrapHue(this.lerp(profile.colorShift[0], profile.colorShift[1], Math.min(1, beatData.bass * 0.5 + beatData.high * 0.5)));
+
+        this.applyParameter('intensity', intensity);
+        this.applyParameter('saturation', saturation);
+        this.applyParameter('chaos', chaos);
+        this.applyParameter('speed', speed);
+        this.applyParameter('hue', hue);
+
+        this.levelState.holographic = this.levelState.holographic * 0.7 + beatData.energy * 0.3;
+
+        if ((beatData.energy > 0.82 || beatData.high > 0.7) && (now - this.lastGeometryChange.holographic) > 900) {
+            const randomVariant = this.clamp(baseVariant + Math.floor(Math.random() * profile.variantSpread), 0, this.getHolographicVariantCount() - 1);
+            this.setHolographicVariant(randomVariant);
+            this.lastGeometryChange.holographic = now;
+        }
+    }
+
+    handlePolychoraBeat(beatData) {
+        const geometry = this.getActiveGeometryIndex('polychora');
+        const profile = beatData.profile || this.getFallbackProfile('polychora', geometry);
+        const now = performance.now();
+
+        const rotation = this.lerp(profile.rotationRange[0], profile.rotationRange[1], Math.min(1, beatData.bass + beatData.mid * 0.5));
+        const morph = this.lerp(profile.morphRange[0], profile.morphRange[1], Math.min(1, beatData.mid + 0.2));
+        const dimension = this.lerp(profile.dimensionRange[0], profile.dimensionRange[1], Math.min(1, beatData.energy + 0.2));
+        const hue = this.wrapHue(this.lerp(profile.hueRange[0], profile.hueRange[1], Math.min(1, beatData.high + beatData.mid * 0.3)));
+
+        this.applyParameter('rot4dXW', rotation);
+        this.applyParameter('rot4dYW', rotation * 0.85);
+        this.applyParameter('rot4dZW', rotation * 0.7);
+        this.applyParameter('morphFactor', morph);
+        this.applyParameter('dimension', dimension);
+        this.applyParameter('hue', hue);
+
+        this.levelState.polychora = this.levelState.polychora * 0.65 + beatData.energy * 0.35;
+
+        if ((beatData.energy > 0.75 || beatData.bass > 0.7) && (now - this.lastGeometryChange.polychora) > 1200) {
+            const nextGeometry = this.resolveGeometryFlow('polychora', geometry, profile.geometryFlow, 6);
+            this.applyGeometry('polychora', nextGeometry);
+            this.lastGeometryChange.polychora = now;
+        }
+    }
+
+    async useTrack(trackUrl, options = {}) {
+        this.manualTrackUrl = trackUrl;
+        if (this.audioEngine && typeof this.audioEngine.useTrack === 'function') {
+            return this.audioEngine.useTrack(trackUrl, options);
+        }
+        return false;
+    }
+
+    applyParameter(param, value) {
+        const numericValue = typeof value === 'number' ? value : parseFloat(value);
+        if (typeof window.updateParameter === 'function') {
+            window.updateParameter(param, numericValue);
+            return;
+        }
+
+        const system = this.getCurrentSystem();
+        const engine = this.engines[system];
+        if (engine?.updateParameter) {
+            engine.updateParameter(param, numericValue);
+        } else if (engine?.parameters?.setParameter) {
+            engine.parameters.setParameter(param, numericValue);
+        }
+    }
+
+    applyGeometry(system, index) {
+        const clampedIndex = system === 'polychora'
+            ? Math.max(0, Math.min(5, Math.round(index)))
+            : Math.max(0, Math.min(7, Math.round(index)));
+
+        if (system === 'faceted') {
+            if (typeof window.selectGeometry === 'function') {
+                window.selectGeometry(clampedIndex);
+            } else {
+                this.applyParameter('geometry', clampedIndex);
+            }
+        } else if (system === 'quantum') {
+            this.applyParameter('geometry', clampedIndex);
+        } else if (system === 'polychora') {
+            this.applyParameter('geometry', clampedIndex);
+        }
+    }
+
+    setHolographicVariant(variant) {
+        const system = this.engines.holographic;
+        if (!system) return;
+        if (typeof system.updateVariant === 'function') {
+            system.updateVariant(variant);
+        } else if (typeof system.setVariant === 'function') {
+            system.setVariant(variant);
+        }
+    }
+
+    getCurrentSystem() {
+        return window.currentSystem || 'faceted';
+    }
+
+    getActiveGeometryIndex(system) {
+        if (system === 'holographic') {
+            const holo = this.engines.holographic;
+            if (holo?.currentVariant !== undefined) {
+                return Math.floor(holo.currentVariant / 4);
+            }
+            return 0;
+        }
+
+        if (system === 'polychora') {
+            const poly = this.engines.polychora;
+            if (poly?.parameters?.getParameter) {
+                return Math.round(poly.parameters.getParameter('geometry') || 0);
+            }
+            return Math.round(window.userParameterState?.geometry || 0);
+        }
+
+        if (system === 'quantum') {
+            const quantum = this.engines.quantum;
+            if (quantum?.parameters?.getParameter) {
+                return Math.round(quantum.parameters.getParameter('geometry') || 0);
+            }
+        }
+
+        const stored = window.userParameterState?.geometry;
+        if (typeof stored === 'number') {
+            return Math.round(stored);
+        }
+
+        const engine = this.engines[system];
+        if (engine?.parameterManager?.getParameter) {
+            return Math.round(engine.parameterManager.getParameter('geometry') || 0);
+        }
+
+        return 0;
+    }
+
+    getFallbackProfile(system, geometryIndex = 0) {
+        const profiles = this.fallbackProfiles[system];
+        if (!profiles || profiles.length === 0) return null;
+        const index = Math.max(0, Math.min(profiles.length - 1, Math.round(geometryIndex)));
+        return profiles[index];
+    }
+
+    getHolographicVariantCount() {
+        return this.engines.holographic?.totalVariants || 30;
+    }
+
+    resolveGeometryFlow(system, current, mode, total) {
+        const geometryCount = total || 8;
+        const normalized = Math.max(0, Math.min(geometryCount - 1, Math.round(current)));
+        const flow = mode || 'forward';
+
+        if (flow === 'shuffle') {
+            let next = normalized;
+            while (next === normalized) {
+                next = Math.floor(Math.random() * geometryCount);
+            }
+            return next;
+        }
+
+        if (flow === 'pendulum') {
+            const direction = this.geometryDirections[system] || 1;
+            let next = normalized + direction;
+            if (next >= geometryCount || next < 0) {
+                this.geometryDirections[system] = -direction;
+                next = normalized - direction;
+            }
+            return Math.max(0, Math.min(geometryCount - 1, next));
+        }
+
+        if (flow === 'burst') {
+            const jump = Math.max(1, Math.floor(Math.random() * 3));
+            return (normalized + jump) % geometryCount;
+        }
+
+        // forward/default
+        return (normalized + 1) % geometryCount;
+    }
+
+    buildFallbackProfiles() {
+        return {
+            faceted: [
+                { tempo: 92, densityRange: [12, 24], morphRange: [0.25, 0.6], chaosRange: [0.05, 0.22], speedRange: [0.9, 1.4], hueRange: [180, 240], geometryFlow: 'forward' },
+                { tempo: 128, densityRange: [16, 34], morphRange: [0.1, 0.45], chaosRange: [0.1, 0.28], speedRange: [1.1, 1.8], hueRange: [220, 280], geometryFlow: 'shuffle' },
+                { tempo: 78, densityRange: [10, 20], morphRange: [0.4, 0.85], chaosRange: [0.05, 0.18], speedRange: [0.8, 1.2], hueRange: [150, 210], geometryFlow: 'pendulum' },
+                { tempo: 140, densityRange: [18, 36], morphRange: [0.2, 0.55], chaosRange: [0.1, 0.3], speedRange: [1.2, 2.1], hueRange: [260, 320], geometryFlow: 'burst' },
+                { tempo: 118, densityRange: [14, 30], morphRange: [0.3, 0.7], chaosRange: [0.08, 0.26], speedRange: [1.0, 1.6], hueRange: [190, 260], geometryFlow: 'forward' },
+                { tempo: 104, densityRange: [12, 28], morphRange: [0.35, 0.75], chaosRange: [0.12, 0.32], speedRange: [0.9, 1.5], hueRange: [170, 230], geometryFlow: 'shuffle' },
+                { tempo: 132, densityRange: [20, 42], morphRange: [0.25, 0.6], chaosRange: [0.15, 0.38], speedRange: [1.3, 2.4], hueRange: [200, 300], geometryFlow: 'forward' },
+                { tempo: 86, densityRange: [10, 22], morphRange: [0.45, 0.9], chaosRange: [0.05, 0.2], speedRange: [0.7, 1.2], hueRange: [140, 200], geometryFlow: 'pendulum' }
+            ],
+            quantum: [
+                { tempo: 110, densityRange: [18, 30], morphRange: [0.9, 1.4], chaosRange: [0.18, 0.35], speedRange: [0.9, 1.6], hueRange: [240, 320], geometryFlow: 'forward' },
+                { tempo: 136, densityRange: [22, 36], morphRange: [0.8, 1.3], chaosRange: [0.22, 0.4], speedRange: [1.2, 2.0], hueRange: [200, 280], geometryFlow: 'shuffle' },
+                { tempo: 96, densityRange: [16, 28], morphRange: [1.0, 1.6], chaosRange: [0.16, 0.32], speedRange: [0.8, 1.4], hueRange: [220, 300], geometryFlow: 'pendulum' },
+                { tempo: 148, densityRange: [24, 42], morphRange: [0.7, 1.2], chaosRange: [0.28, 0.45], speedRange: [1.4, 2.3], hueRange: [260, 340], geometryFlow: 'burst' },
+                { tempo: 124, densityRange: [20, 34], morphRange: [0.95, 1.5], chaosRange: [0.2, 0.36], speedRange: [1.0, 1.8], hueRange: [210, 290], geometryFlow: 'forward' },
+                { tempo: 102, densityRange: [18, 30], morphRange: [1.1, 1.7], chaosRange: [0.18, 0.34], speedRange: [0.85, 1.5], hueRange: [230, 310], geometryFlow: 'shuffle' },
+                { tempo: 140, densityRange: [26, 44], morphRange: [0.9, 1.4], chaosRange: [0.26, 0.48], speedRange: [1.3, 2.4], hueRange: [250, 330], geometryFlow: 'forward' },
+                { tempo: 90, densityRange: [16, 26], morphRange: [1.2, 1.8], chaosRange: [0.14, 0.3], speedRange: [0.7, 1.3], hueRange: [200, 280], geometryFlow: 'pendulum' }
+            ],
+            holographic: [
+                { tempo: 96, variantSpread: 4, intensityRange: [0.45, 0.8], saturationRange: [0.6, 0.95], chaosRange: [0.1, 0.25], speedRange: [0.9, 1.4], colorShift: [180, 240], geometryFlow: 'forward' },
+                { tempo: 128, variantSpread: 4, intensityRange: [0.5, 0.85], saturationRange: [0.7, 0.98], chaosRange: [0.12, 0.3], speedRange: [1.0, 1.6], colorShift: [220, 280], geometryFlow: 'shuffle' },
+                { tempo: 88, variantSpread: 4, intensityRange: [0.55, 0.9], saturationRange: [0.65, 1.0], chaosRange: [0.1, 0.28], speedRange: [0.8, 1.3], colorShift: [160, 220], geometryFlow: 'pendulum' },
+                { tempo: 144, variantSpread: 4, intensityRange: [0.5, 0.88], saturationRange: [0.7, 1.0], chaosRange: [0.18, 0.36], speedRange: [1.2, 2.0], colorShift: [240, 320], geometryFlow: 'burst' },
+                { tempo: 118, variantSpread: 4, intensityRange: [0.48, 0.86], saturationRange: [0.68, 0.96], chaosRange: [0.15, 0.32], speedRange: [0.95, 1.6], colorShift: [200, 280], geometryFlow: 'forward' },
+                { tempo: 106, variantSpread: 3, intensityRange: [0.52, 0.88], saturationRange: [0.7, 1.0], chaosRange: [0.12, 0.3], speedRange: [0.85, 1.5], colorShift: [190, 270], geometryFlow: 'shuffle' },
+                { tempo: 134, variantSpread: 3, intensityRange: [0.55, 0.9], saturationRange: [0.72, 1.0], chaosRange: [0.18, 0.34], speedRange: [1.1, 1.9], colorShift: [220, 300], geometryFlow: 'forward' },
+                { tempo: 92, variantSpread: 3, intensityRange: [0.5, 0.85], saturationRange: [0.65, 0.96], chaosRange: [0.1, 0.26], speedRange: [0.8, 1.35], colorShift: [170, 250], geometryFlow: 'pendulum' }
+            ],
+            polychora: [
+                { tempo: 88, rotationRange: [0.4, 0.9], morphRange: [0.3, 0.6], dimensionRange: [3.2, 3.8], hueRange: [260, 320], geometryFlow: 'forward' },
+                { tempo: 120, rotationRange: [0.5, 1.1], morphRange: [0.25, 0.55], dimensionRange: [3.1, 3.9], hueRange: [240, 300], geometryFlow: 'shuffle' },
+                { tempo: 102, rotationRange: [0.45, 0.95], morphRange: [0.35, 0.65], dimensionRange: [3.3, 3.95], hueRange: [250, 310], geometryFlow: 'pendulum' },
+                { tempo: 138, rotationRange: [0.55, 1.2], morphRange: [0.3, 0.6], dimensionRange: [3.4, 4.0], hueRange: [270, 330], geometryFlow: 'burst' },
+                { tempo: 112, rotationRange: [0.5, 1.05], morphRange: [0.32, 0.62], dimensionRange: [3.25, 3.9], hueRange: [255, 315], geometryFlow: 'forward' },
+                { tempo: 98, rotationRange: [0.42, 0.9], morphRange: [0.28, 0.58], dimensionRange: [3.2, 3.85], hueRange: [245, 305], geometryFlow: 'pendulum' }
+            ]
+        };
+    }
+
+    generateSyntheticLevels(profile) {
+        const tempo = profile?.tempo || this.syntheticTempo;
+        const t = (performance.now() / 1000) * tempo / 60;
+        const phase = t % 1;
+        const bass = Math.max(0, Math.sin(Math.PI * phase));
+        const mid = Math.max(0, Math.sin(Math.PI * ((phase + 0.35) % 1)));
+        const high = Math.max(0, Math.sin(Math.PI * ((phase + 0.67) % 1)));
+        const energy = (bass + mid + high) / 3;
+
+        return {
+            bass: this.clamp(bass + Math.random() * 0.1),
+            mid: this.clamp(mid + Math.random() * 0.08),
+            high: this.clamp(high + Math.random() * 0.05),
+            energy: this.clamp(energy + Math.random() * 0.05)
+        };
+    }
+
+    notifyStatus(message, level = 'info') {
+        if (!this.statusManager || !message || this.lastStatusMessage === message) return;
+        try {
+            this.statusManager.setStatus(message, level);
+            this.lastStatusMessage = message;
+        } catch (error) {
+            console.warn('Status update failed:', error);
+        }
+    }
+
+    lerp(a, b, t) {
+        return a + (b - a) * this.clamp(t, 0, 1);
+    }
+
+    clamp(value, min = 0, max = 1) {
+        if (Number.isNaN(value)) return min;
+        return Math.min(max, Math.max(min, value));
+    }
+
+    wrapHue(value) {
+        if (Number.isNaN(value)) return 0;
+        let hue = value % 360;
+        if (hue < 0) hue += 360;
+        return hue;
+    }
+}
+
+export default AudioGameplayDirector;


### PR DESCRIPTION
## Summary
- extend the shared SimpleAudioEngine so it can switch between microphone capture, external track playback, and a synthesized fallback metronome while reporting mode changes
- introduce an AudioGameplayDirector that detects beats/tempo from the analyser (or fallback) and drives geometry, variation, and parameter updates across systems so visuals always stem from sound
- wire the new director into the index bootstrap, refresh audio controls, and keep the director in sync when systems are switched or lazily initialized

## Testing
- `npm test` *(fails: sh: 1: playwright: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7cb146c0832990cc2f973a860407