### PR TITLE
Simplify directive pause handling and HUD overlay

### DIFF
--- a/src/game/AudioReactivityEngine.js
+++ b/src/game/AudioReactivityEngine.js
@@ -1,0 +1,524 @@
+/**
+ * AudioReactivityEngine analyses audio input from either the microphone or
+ * media elements and produces normalized feature frames that other systems can
+ * consume to drive gameplay. The class wraps the Web Audio API but gracefully
+ * degrades when running in non-browser environments.
+ */
+export class AudioReactivityEngine {
+    constructor(options = {}) {
+        const {
+            audioContext = null,
+            fftSize = 2048,
+            smoothing = 0.75,
+            minDecibels = -90,
+            maxDecibels = -16,
+            minBeatInterval = 0.32,
+            beatSensitivity = 1.35,
+            difficulty = {},
+            fallbackGenerator = null,
+        } = options;
+
+        this.audioContext = audioContext || this.createContext();
+        this.analyser = null;
+        this.gainNode = null;
+        this.sourceNode = null;
+
+        this.fftSize = fftSize;
+        this.smoothingTimeConstant = smoothing;
+        this.minDecibels = minDecibels;
+        this.maxDecibels = maxDecibels;
+        this.minBeatInterval = Math.max(0.12, minBeatInterval);
+        this.beatSensitivity = beatSensitivity;
+
+        this.fallbackGenerator = typeof fallbackGenerator === 'function'
+            ? fallbackGenerator
+            : null;
+
+        this.frequencyData = null;
+        this.timeDomainData = null;
+
+        this.energyHistory = [];
+        this.beatHistory = [];
+        this.lastBeatTime = 0;
+        this.lastFrame = null;
+
+        this.peakEnergy = 0.0001;
+        this.smoothedEnergy = 0;
+
+        this.difficultyConfig = {
+            min: 0.85,
+            max: 3.6,
+            smoothing: 0.06,
+            exponent: 0.65,
+            baseline: 1.05,
+            ...difficulty,
+        };
+        this.difficultyLevel = this.difficultyConfig.baseline;
+
+        this.manualFrameGenerator = null;
+    }
+
+    createContext() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) {
+            return null;
+        }
+
+        try {
+            return new AudioContextClass();
+        } catch (error) {
+            return null;
+        }
+    }
+
+    getContext() {
+        return this.audioContext;
+    }
+
+    ensureAnalyser(context = this.audioContext) {
+        if (!context || typeof context.createAnalyser !== 'function') {
+            return null;
+        }
+
+        if (!this.analyser) {
+            this.analyser = context.createAnalyser();
+            this.analyser.fftSize = this.fftSize;
+            this.analyser.minDecibels = this.minDecibels;
+            this.analyser.maxDecibels = this.maxDecibels;
+            this.analyser.smoothingTimeConstant = this.smoothingTimeConstant;
+            this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
+            this.timeDomainData = new Uint8Array(this.analyser.fftSize);
+        }
+
+        return this.analyser;
+    }
+
+    connectSource(sourceNode) {
+        if (!sourceNode) {
+            return null;
+        }
+
+        const context = sourceNode.context || this.audioContext || this.createContext();
+        if (!context) {
+            return null;
+        }
+
+        this.audioContext = context;
+        const analyser = this.ensureAnalyser(context);
+        if (!analyser) {
+            return null;
+        }
+
+        if (this.gainNode) {
+            try {
+                this.gainNode.disconnect();
+            } catch (error) {
+                // Ignore disconnect failures when the graph is already detached.
+            }
+        }
+
+        if (typeof context.createGain === 'function') {
+            this.gainNode = context.createGain();
+            this.gainNode.gain.value = 1;
+            sourceNode.connect(this.gainNode);
+            this.gainNode.connect(analyser);
+        } else {
+            sourceNode.connect(analyser);
+            this.gainNode = null;
+        }
+
+        this.sourceNode = sourceNode;
+        return analyser;
+    }
+
+    connectToMediaElement(element) {
+        if (!element) {
+            return null;
+        }
+
+        const context = this.audioContext || this.createContext();
+        if (!context || typeof context.createMediaElementSource !== 'function') {
+            return null;
+        }
+
+        const sourceNode = context.createMediaElementSource(element);
+        this.connectSource(sourceNode);
+        return sourceNode;
+    }
+
+    connectToStream(stream) {
+        if (!stream) {
+            return null;
+        }
+
+        const context = this.audioContext || this.createContext();
+        if (!context || typeof context.createMediaStreamSource !== 'function') {
+            return null;
+        }
+
+        const sourceNode = context.createMediaStreamSource(stream);
+        this.connectSource(sourceNode);
+        return sourceNode;
+    }
+
+    async connectToMic(constraints = { audio: true }) {
+        if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+            throw new Error('Microphone access is not available in this environment.');
+        }
+
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        this.connectToStream(stream);
+        return stream;
+    }
+
+    setManualFrameGenerator(generator) {
+        this.manualFrameGenerator = typeof generator === 'function' ? generator : null;
+    }
+
+    setFallbackGenerator(generator) {
+        this.fallbackGenerator = typeof generator === 'function' ? generator : null;
+    }
+
+    resume() {
+        if (!this.audioContext) {
+            return Promise.resolve();
+        }
+
+        if (this.audioContext.state === 'suspended' && typeof this.audioContext.resume === 'function') {
+            return this.audioContext.resume();
+        }
+
+        return Promise.resolve();
+    }
+
+    suspend() {
+        if (!this.audioContext) {
+            return Promise.resolve();
+        }
+
+        if (typeof this.audioContext.suspend === 'function') {
+            return this.audioContext.suspend();
+        }
+
+        return Promise.resolve();
+    }
+
+    now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+
+    update(now = this.now()) {
+        if (this.manualFrameGenerator) {
+            const manualFrame = this.manualFrameGenerator(now);
+            if (manualFrame) {
+                this.lastFrame = this.normalizeFrame(manualFrame, now);
+                return this.lastFrame;
+            }
+        }
+
+        if (!this.analyser || !this.frequencyData || !this.timeDomainData) {
+            if (this.fallbackGenerator) {
+                const fallback = this.fallbackGenerator(now);
+                if (fallback) {
+                    this.lastFrame = this.normalizeFrame(fallback, now);
+                    return this.lastFrame;
+                }
+            }
+            return this.generateSilentFrame(now);
+        }
+
+        this.analyser.getByteFrequencyData(this.frequencyData);
+        if (typeof this.analyser.getByteTimeDomainData === 'function') {
+            this.analyser.getByteTimeDomainData(this.timeDomainData);
+        } else if (typeof this.analyser.getFloatTimeDomainData === 'function') {
+            const floatData = new Float32Array(this.analyser.fftSize);
+            this.analyser.getFloatTimeDomainData(floatData);
+            for (let i = 0; i < floatData.length; i += 1) {
+                this.timeDomainData[i] = Math.round((floatData[i] + 1) * 127.5);
+            }
+        } else {
+            // Fallback: approximate time domain data from frequency magnitudes.
+            for (let i = 0; i < this.timeDomainData.length; i += 1) {
+                this.timeDomainData[i] = 128 + (this.frequencyData[i % this.frequencyData.length] - 128);
+            }
+        }
+
+        const frame = this.extractFeatures(now);
+        this.lastFrame = frame;
+        return frame;
+    }
+
+    extractFeatures(now) {
+        const energy = this.computeRmsEnergy();
+        this.peakEnergy = Math.max(energy, this.peakEnergy * 0.995);
+        const normalizedEnergy = this.peakEnergy ? energy / this.peakEnergy : energy;
+
+        this.energyHistory.push({ time: now, energy: normalizedEnergy });
+        while (this.energyHistory.length > 0 && (now - this.energyHistory[0].time) > 4000) {
+            this.energyHistory.shift();
+        }
+
+        const averages = this.computeEnergyAverages();
+        const beatData = this.detectBeat(normalizedEnergy, now, averages.averageEnergy);
+
+        const bands = this.computeBands();
+        const centroid = this.computeSpectralCentroid();
+        const zeroCrossingRate = this.computeZeroCrossingRate();
+
+        const difficulty = this.deriveDifficultyLevel({
+            energy: normalizedEnergy,
+            beatStrength: beatData.beatStrength,
+            centroid,
+        });
+
+        const trend = this.computeEnergyTrend(normalizedEnergy);
+
+        return {
+            time: now,
+            rawEnergy: energy,
+            energy: normalizedEnergy,
+            energyAverages: averages,
+            beat: beatData.isBeat,
+            beatStrength: beatData.beatStrength,
+            bpm: beatData.bpm,
+            tempoConfidence: beatData.tempoConfidence,
+            bass: bands.bass,
+            mid: bands.mid,
+            treble: bands.treble,
+            spectralCentroid: centroid,
+            zeroCrossingRate,
+            difficulty,
+            trend,
+            silent: false,
+        };
+    }
+
+    computeRmsEnergy() {
+        if (!this.timeDomainData?.length) {
+            return 0;
+        }
+
+        let sumSquares = 0;
+        for (let i = 0; i < this.timeDomainData.length; i += 1) {
+            const sample = (this.timeDomainData[i] - 128) / 128;
+            sumSquares += sample * sample;
+        }
+
+        return Math.sqrt(sumSquares / this.timeDomainData.length);
+    }
+
+    computeEnergyAverages() {
+        if (!this.energyHistory.length) {
+            return {
+                averageEnergy: 0,
+                variance: 0,
+            };
+        }
+
+        const count = this.energyHistory.length;
+        let sum = 0;
+        for (const entry of this.energyHistory) {
+            sum += entry.energy;
+        }
+        const averageEnergy = sum / count;
+
+        let varianceSum = 0;
+        for (const entry of this.energyHistory) {
+            const delta = entry.energy - averageEnergy;
+            varianceSum += delta * delta;
+        }
+
+        return {
+            averageEnergy,
+            variance: varianceSum / count,
+        };
+    }
+
+    detectBeat(energy, now, averageEnergy) {
+        const epsilon = 0.00001;
+        const thresholdBase = (averageEnergy || epsilon) * this.beatSensitivity;
+        const dynamicThreshold = thresholdBase + 0.05;
+        const isBeat = energy > dynamicThreshold && (now - this.lastBeatTime) > (this.minBeatInterval * 1000);
+
+        let beatStrength = 0;
+        if (averageEnergy > epsilon) {
+            beatStrength = energy / averageEnergy;
+        }
+
+        let bpm = this.lastFrame?.bpm ?? 0;
+        let tempoConfidence = this.lastFrame?.tempoConfidence ?? 0;
+
+        if (isBeat) {
+            this.lastBeatTime = now;
+            this.beatHistory.push(now);
+            while (this.beatHistory.length > 0 && (now - this.beatHistory[0]) > 12000) {
+                this.beatHistory.shift();
+            }
+
+            if (this.beatHistory.length >= 2) {
+                const intervals = [];
+                for (let i = 1; i < this.beatHistory.length; i += 1) {
+                    intervals.push(this.beatHistory[i] - this.beatHistory[i - 1]);
+                }
+                const avgInterval = intervals.reduce((sum, interval) => sum + interval, 0) / intervals.length;
+                if (avgInterval > 0) {
+                    bpm = 60000 / avgInterval;
+                    tempoConfidence = Math.min(1, intervals.length / 12);
+                }
+            }
+        }
+
+        return { isBeat, beatStrength, bpm, tempoConfidence };
+    }
+
+    computeBands() {
+        if (!this.frequencyData?.length || !this.analyser) {
+            return { bass: 0, mid: 0, treble: 0 };
+        }
+
+        const nyquist = (this.audioContext?.sampleRate || 44100) / 2;
+        const band = (minFreq, maxFreq) => {
+            const start = Math.max(0, Math.floor((minFreq / nyquist) * this.frequencyData.length));
+            const end = Math.min(this.frequencyData.length - 1, Math.ceil((maxFreq / nyquist) * this.frequencyData.length));
+            if (end <= start) {
+                return 0;
+            }
+
+            let sum = 0;
+            for (let i = start; i <= end; i += 1) {
+                sum += this.frequencyData[i];
+            }
+            const average = sum / (end - start + 1);
+            return Math.min(1, average / 255);
+        };
+
+        return {
+            bass: band(20, 160),
+            mid: band(160, 2000),
+            treble: band(2000, 8000),
+        };
+    }
+
+    computeSpectralCentroid() {
+        if (!this.frequencyData?.length || !this.analyser) {
+            return 0;
+        }
+
+        const sampleRate = this.audioContext?.sampleRate || 44100;
+        const nyquist = sampleRate / 2;
+        let weightedSum = 0;
+        let total = 0;
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.frequencyData[i];
+            total += magnitude;
+            const frequency = (i / this.frequencyData.length) * nyquist;
+            weightedSum += frequency * magnitude;
+        }
+
+        if (total <= 0) {
+            return 0;
+        }
+
+        return weightedSum / total / nyquist;
+    }
+
+    computeZeroCrossingRate() {
+        if (!this.timeDomainData?.length) {
+            return 0;
+        }
+
+        let crossings = 0;
+        for (let i = 1; i < this.timeDomainData.length; i += 1) {
+            const prev = this.timeDomainData[i - 1] - 128;
+            const curr = this.timeDomainData[i] - 128;
+            if ((prev >= 0 && curr < 0) || (prev < 0 && curr >= 0)) {
+                crossings += 1;
+            }
+        }
+
+        return crossings / this.timeDomainData.length;
+    }
+
+    deriveDifficultyLevel(features) {
+        const { min, max, smoothing, exponent, baseline } = this.difficultyConfig;
+        const energy = Math.max(0, Math.min(1, features.energy ?? 0));
+        const beatStrength = Math.max(0, Math.min(2.5, features.beatStrength ?? 0));
+        const centroid = Math.max(0, Math.min(1, features.centroid ?? 0));
+
+        const combined = (energy ** exponent) * 0.6
+            + Math.min(1, beatStrength / 1.8) * 0.25
+            + centroid * 0.15;
+        const target = min + combined * (max - min);
+
+        this.difficultyLevel = (this.difficultyLevel * (1 - smoothing)) + (target * smoothing);
+        return {
+            level: this.difficultyLevel,
+            normalized: (this.difficultyLevel - min) / Math.max(0.001, max - min),
+            baseline,
+        };
+    }
+
+    computeEnergyTrend(currentEnergy) {
+        const smoothing = 0.12;
+        this.smoothedEnergy = (this.smoothedEnergy * (1 - smoothing)) + (currentEnergy * smoothing);
+        if (!this.lastFrame) {
+            return 0;
+        }
+
+        return currentEnergy - (this.lastFrame.energy ?? currentEnergy);
+    }
+
+    normalizeFrame(frame, now) {
+        return {
+            time: frame.time ?? now,
+            rawEnergy: frame.rawEnergy ?? frame.energy ?? 0,
+            energy: Math.max(0, Math.min(1, frame.energy ?? 0)),
+            energyAverages: frame.energyAverages || { averageEnergy: frame.energy ?? 0, variance: 0 },
+            beat: Boolean(frame.beat),
+            beatStrength: frame.beatStrength ?? 0,
+            bpm: frame.bpm ?? 0,
+            tempoConfidence: frame.tempoConfidence ?? 0,
+            bass: Math.max(0, Math.min(1, frame.bass ?? frame.low ?? 0)),
+            mid: Math.max(0, Math.min(1, frame.mid ?? frame.midrange ?? 0)),
+            treble: Math.max(0, Math.min(1, frame.treble ?? frame.high ?? 0)),
+            spectralCentroid: Math.max(0, Math.min(1, frame.spectralCentroid ?? 0)),
+            zeroCrossingRate: Math.max(0, frame.zeroCrossingRate ?? 0),
+            difficulty: frame.difficulty || this.deriveDifficultyLevel({
+                energy: frame.energy ?? 0,
+                beatStrength: frame.beatStrength ?? 0,
+                centroid: frame.spectralCentroid ?? 0,
+            }),
+            trend: frame.trend ?? 0,
+            silent: Boolean(frame.silent),
+        };
+    }
+
+    generateSilentFrame(now) {
+        const difficulty = this.deriveDifficultyLevel({ energy: 0, beatStrength: 0, centroid: 0 });
+        return {
+            time: now,
+            rawEnergy: 0,
+            energy: 0,
+            energyAverages: { averageEnergy: 0, variance: 0 },
+            beat: false,
+            beatStrength: 0,
+            bpm: this.lastFrame?.bpm ?? 0,
+            tempoConfidence: 0,
+            bass: 0,
+            mid: 0,
+            treble: 0,
+            spectralCentroid: 0,
+            zeroCrossingRate: 0,
+            difficulty,
+            trend: -this.smoothedEnergy,
+            silent: true,
+        };
+    }
+}

--- a/src/game/EffectsManager.js
+++ b/src/game/EffectsManager.js
@@ -1,0 +1,107 @@
+const DEFAULT_COLORS = {
+    gestureDirective: '#45ffe7',
+    quickDraw: '#ff3a73',
+    resolve: '#6ea8ff',
+    default: '#ffffff',
+};
+
+export class EffectsManager {
+    constructor(options = {}) {
+        const {
+            shaderHooks = null,
+            targetHighlighter = null,
+            colors = {},
+        } = options;
+
+        this.shaderHooks = shaderHooks;
+        this.targetHighlighter = targetHighlighter;
+        this.colors = { ...DEFAULT_COLORS, ...colors };
+    }
+
+    handleDirectiveStart(directive) {
+        if (!directive) {
+            return;
+        }
+        const color = this.resolveColor(directive.type);
+        this.applyShaderEvent('directive-start', directive, color);
+        this.applyTargetTint(color, directive);
+    }
+
+    handleDirectiveComplete(payload = {}) {
+        const directive = payload.directive;
+        const color = this.colors.resolve;
+        this.applyShaderEvent('directive-complete', directive, color);
+        this.clearTargetTint(payload);
+    }
+
+    resolveColor(type) {
+        return this.colors[type] || this.colors.default;
+    }
+
+    applyShaderEvent(eventName, directive, color) {
+        if (!this.shaderHooks) {
+            return;
+        }
+
+        if (typeof this.shaderHooks.onDirectiveEvent === 'function') {
+            this.shaderHooks.onDirectiveEvent(eventName, { directive, color });
+            return;
+        }
+
+        if (eventName === 'directive-start') {
+            if (typeof this.shaderHooks.flash === 'function') {
+                this.shaderHooks.flash({ color, duration: 0.4 });
+            } else if (typeof this.shaderHooks.setUniform === 'function') {
+                try {
+                    this.shaderHooks.setUniform('uDirectiveFlashColor', color);
+                    this.shaderHooks.setUniform('uDirectiveFlashStrength', 1);
+                } catch (error) {
+                    // Ignore controllers without uniform setters.
+                }
+            }
+            return;
+        }
+
+        if (eventName === 'directive-complete') {
+            if (typeof this.shaderHooks.flash === 'function') {
+                this.shaderHooks.flash({ color, duration: 0.25 });
+            } else if (typeof this.shaderHooks.setUniform === 'function') {
+                try {
+                    this.shaderHooks.setUniform('uDirectiveFlashStrength', 0);
+                } catch (error) {
+                    // Ignore controllers without uniform setters.
+                }
+            }
+        }
+    }
+
+    applyTargetTint(color, directive) {
+        if (!this.targetHighlighter) {
+            return;
+        }
+
+        if (typeof this.targetHighlighter.setDirectiveTint === 'function') {
+            this.targetHighlighter.setDirectiveTint(color, directive);
+            return;
+        }
+
+        if (typeof this.targetHighlighter === 'function') {
+            this.targetHighlighter(color, directive);
+        }
+    }
+
+    clearTargetTint(payload = {}) {
+        if (!this.targetHighlighter) {
+            return;
+        }
+
+        if (typeof this.targetHighlighter.clearDirectiveTint === 'function') {
+            this.targetHighlighter.clearDirectiveTint(payload);
+            return;
+        }
+
+        if (typeof this.targetHighlighter === 'function') {
+            this.targetHighlighter(null, payload.directive);
+        }
+    }
+}

--- a/src/game/EventDirector.js
+++ b/src/game/EventDirector.js
@@ -1,0 +1,218 @@
+const DEFAULT_DIRECTIVE_DURATIONS = {
+    gestureDirective: 4500,
+    quickDraw: 2500,
+};
+
+const PRIORITY_ORDER = ['gestureDirective', 'quickDraw'];
+
+function createClock(clock) {
+    if (typeof clock === 'function') {
+        return clock;
+    }
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        return () => performance.now();
+    }
+    return () => Date.now();
+}
+
+function cloneDirective(directive) {
+    return directive ? { ...directive } : null;
+}
+
+export class EventDirector {
+    constructor(options = {}) {
+        const {
+            clock,
+            directiveDurations = {},
+        } = options;
+
+        this._clock = createClock(clock);
+        this.directiveDurations = {
+            ...DEFAULT_DIRECTIVE_DURATIONS,
+            ...directiveDurations,
+        };
+
+        this.activeDirectives = new Map();
+        this.lastSpawnDirective = { density: 1, paused: false };
+    }
+
+    now() {
+        return this._clock();
+    }
+
+    activateDirective(type, config = {}) {
+        if (!type) {
+            return null;
+        }
+
+        const startedAt = this.now();
+        const duration = config.duration ?? this.directiveDurations[type] ?? null;
+        const countdownSeconds = config.countdownSeconds
+            ?? (typeof duration === 'number' ? Math.ceil(duration / 1000) : null);
+        const endsAt = duration != null ? startedAt + duration : null;
+
+        const directive = {
+            id: config.id ?? `${type}-${Math.round(startedAt)}`,
+            type,
+            label: config.label ?? this.defaultLabel(type),
+            prompt: config.prompt ?? config.message ?? '',
+            description: config.description ?? '',
+            annotation: config.annotation ?? '',
+            startedAt,
+            duration,
+            endsAt,
+            countdownSeconds,
+            pauseSpawns: config.pauseSpawns ?? true,
+            color: config.color ?? null,
+            colorPalette: config.colorPalette ?? null,
+            pattern: config.pattern ?? null,
+            difficultyLabel: config.difficultyLabel ?? null,
+            metadata: { ...config.metadata },
+        };
+
+        this.activeDirectives.set(type, directive);
+        return cloneDirective(directive);
+    }
+
+    resolveDirective(type, result = {}) {
+        if (!type || !this.activeDirectives.has(type)) {
+            return null;
+        }
+
+        const directive = this.activeDirectives.get(type);
+        this.activeDirectives.delete(type);
+
+        return {
+            ...directive,
+            completedAt: this.now(),
+            result,
+        };
+    }
+
+    clearDirective(type) {
+        if (type) {
+            this.activeDirectives.delete(type);
+        }
+    }
+
+    clearAllDirectives() {
+        this.activeDirectives.clear();
+    }
+
+    isDirectiveActive(type) {
+        if (!type) {
+            return this.activeDirectives.size > 0;
+        }
+        return this.activeDirectives.has(type);
+    }
+
+    update(now = this.now()) {
+        const expired = [];
+        for (const [type, directive] of this.activeDirectives.entries()) {
+            if (directive.endsAt != null && now >= directive.endsAt) {
+                this.activeDirectives.delete(type);
+                expired.push({
+                    ...directive,
+                    expiredAt: now,
+                    result: { success: false, reason: 'timeout' },
+                });
+            }
+        }
+        return { activated: [], expired };
+    }
+
+    getDirectiveState(type, now = this.now()) {
+        const directive = this.activeDirectives.get(type);
+        if (!directive) {
+            return null;
+        }
+
+        const remaining = directive.endsAt != null
+            ? Math.max(0, directive.endsAt - now)
+            : null;
+        const progress = directive.duration
+            ? Math.min(1, Math.max(0, 1 - (remaining ?? 0) / directive.duration))
+            : null;
+
+        return {
+            ...directive,
+            remaining,
+            progress,
+        };
+    }
+
+    getPrimaryDirective(now = this.now()) {
+        for (const type of PRIORITY_ORDER) {
+            const state = this.getDirectiveState(type, now);
+            if (state && this.shouldPauseSpawns(state)) {
+                return state;
+            }
+        }
+
+        for (const [type] of this.activeDirectives.entries()) {
+            if (PRIORITY_ORDER.includes(type)) {
+                continue;
+            }
+            const state = this.getDirectiveState(type, now);
+            if (state && this.shouldPauseSpawns(state)) {
+                return state;
+            }
+        }
+
+        return null;
+    }
+
+    shouldPauseSpawns(directive) {
+        if (!directive) {
+            return false;
+        }
+        return directive.pauseSpawns !== false;
+    }
+
+    getSpawnDirectives(baseDirective = {}) {
+        const blocking = this.getPrimaryDirective();
+        if (blocking) {
+            const pausedDirective = {
+                ...baseDirective,
+                paused: true,
+                density: 0,
+                directive: blocking,
+                reason: blocking.type,
+            };
+            this.lastSpawnDirective = pausedDirective;
+            return pausedDirective;
+        }
+
+        const density = typeof baseDirective.density === 'number'
+            ? baseDirective.density
+            : 1;
+        const directive = {
+            ...baseDirective,
+            paused: false,
+            density,
+        };
+        this.lastSpawnDirective = directive;
+        return directive;
+    }
+
+    getLastSpawnDirective() {
+        return cloneDirective(this.lastSpawnDirective);
+    }
+
+    describeActiveDirectives(now = this.now()) {
+        return Array.from(this.activeDirectives.keys()).map(
+            (type) => this.getDirectiveState(type, now),
+        ).filter(Boolean);
+    }
+
+    defaultLabel(type) {
+        switch (type) {
+        case 'gestureDirective':
+            return 'Gesture Directive';
+        case 'quickDraw':
+            return 'Quick Draw';
+        default:
+            return String(type).replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()).trim();
+        }
+    }
+}

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -1,0 +1,226 @@
+import { EventDirector } from './EventDirector.js';
+import { SpawnSystem } from './SpawnSystem.js';
+import { EffectsManager } from './EffectsManager.js';
+import { HUDRenderer } from './ui/HUDRenderer.js';
+
+function createClock(clock) {
+    if (typeof clock === 'function') {
+        return clock;
+    }
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        return () => performance.now();
+    }
+    return () => Date.now();
+}
+
+function toSeconds(deltaMs) {
+    if (!Number.isFinite(deltaMs) || deltaMs < 0) {
+        return 0;
+    }
+    return deltaMs / 1000;
+}
+
+export class LatticePulseGame {
+    constructor(options = {}) {
+        const {
+            clock,
+            eventDirector,
+            spawnSystem,
+            effectsManager,
+            hudRenderer,
+            hudRoot,
+            hudOptions,
+            effectsOptions,
+        } = options;
+
+        this.clock = createClock(clock);
+
+        this.eventDirector = eventDirector || new EventDirector({ clock: () => this.clock() });
+        this.spawnSystem = spawnSystem || new SpawnSystem();
+        this.effectsManager = effectsManager || new EffectsManager(effectsOptions);
+        this.hudRenderer = hudRenderer || new HUDRenderer(hudRoot, hudOptions);
+
+        this.isRunning = false;
+        this.lastUpdate = null;
+        this.loopHandle = null;
+        this.isSpawnPaused = false;
+
+        this.bindSpawnHooks();
+    }
+
+    bindSpawnHooks() {
+        if (!this.spawnSystem) {
+            return;
+        }
+
+        const originalPause = this.spawnSystem.onPause;
+        const originalResume = this.spawnSystem.onResume;
+
+        this.spawnSystem.onPause = (directive) => {
+            if (typeof originalPause === 'function') {
+                originalPause(directive);
+            }
+            this.handleSpawnPause(directive);
+        };
+
+        this.spawnSystem.onResume = (directive) => {
+            if (typeof originalResume === 'function') {
+                originalResume(directive);
+            }
+            this.handleSpawnResume(directive);
+        };
+    }
+
+    start() {
+        if (this.isRunning) {
+            return;
+        }
+        this.isRunning = true;
+        this.lastUpdate = this.clock();
+
+        if (typeof requestAnimationFrame === 'function') {
+            this.loopHandle = requestAnimationFrame(() => this.loop());
+        }
+    }
+
+    stop() {
+        if (!this.isRunning) {
+            return;
+        }
+        this.isRunning = false;
+        if (typeof cancelAnimationFrame === 'function' && this.loopHandle) {
+            cancelAnimationFrame(this.loopHandle);
+        }
+        this.loopHandle = null;
+        this.lastUpdate = null;
+    }
+
+    loop() {
+        if (!this.isRunning) {
+            return;
+        }
+
+        const now = this.clock();
+        const delta = this.lastUpdate != null ? now - this.lastUpdate : 0;
+        this.lastUpdate = now;
+
+        this.tick(delta);
+
+        if (typeof requestAnimationFrame === 'function') {
+            this.loopHandle = requestAnimationFrame(() => this.loop());
+        }
+    }
+
+    tick(deltaMs = 0) {
+        const now = this.clock();
+        const updateResult = this.eventDirector.update(now);
+        const expired = updateResult?.expired ?? [];
+
+        expired.forEach((directive) => this.handleDirectiveExpired(directive));
+
+        const spawnDirective = this.eventDirector.getSpawnDirectives();
+        this.spawnSystem.update(toSeconds(deltaMs), spawnDirective);
+
+        this.syncDirectiveOverlay(now);
+    }
+
+    startGestureDirective(config = {}) {
+        return this.startDirective('gestureDirective', config);
+    }
+
+    startQuickDraw(config = {}) {
+        return this.startDirective('quickDraw', config);
+    }
+
+    completeGesture(result = {}) {
+        return this.resolveDirective('gestureDirective', { success: true, ...result });
+    }
+
+    resolveQuickDraw(result = {}) {
+        return this.resolveDirective('quickDraw', { success: true, ...result });
+    }
+
+    startDirective(type, config = {}) {
+        const directive = this.eventDirector.activateDirective(type, config);
+        if (!directive) {
+            return null;
+        }
+
+        const state = this.eventDirector.getDirectiveState(type);
+        if (state) {
+            this.announceDirectiveStart(state);
+        }
+        return state ?? directive;
+    }
+
+    resolveDirective(type, result = {}) {
+        const directive = this.eventDirector.resolveDirective(type, result);
+        if (!directive) {
+            return null;
+        }
+
+        this.effectsManager.handleDirectiveComplete({ directive, result });
+        const hudActive = this.hudRenderer.getActiveDirective();
+        if (hudActive && hudActive.id === directive.id) {
+            this.hudRenderer.hideDirectiveOverlay();
+        }
+        this.syncDirectiveOverlay();
+        return directive;
+    }
+
+    handleDirectiveExpired(directive) {
+        if (!directive) {
+            return;
+        }
+
+        const hudActive = this.hudRenderer.getActiveDirective();
+        if (hudActive && hudActive.id === directive.id) {
+            this.hudRenderer.hideDirectiveOverlay();
+        }
+
+        this.effectsManager.handleDirectiveComplete({
+            directive,
+            result: directive.result,
+        });
+        this.syncDirectiveOverlay();
+    }
+
+    announceDirectiveStart(directive) {
+        if (!directive) {
+            return;
+        }
+
+        this.hudRenderer.showDirectiveOverlay(directive);
+        this.effectsManager.handleDirectiveStart(directive);
+    }
+
+    syncDirectiveOverlay(now = this.clock()) {
+        const directiveState = this.eventDirector.getPrimaryDirective(now);
+        const hudActive = this.hudRenderer.getActiveDirective();
+
+        if (!directiveState) {
+            if (hudActive) {
+                this.hudRenderer.hideDirectiveOverlay();
+            }
+            return;
+        }
+
+        if (!hudActive || hudActive.id !== directiveState.id) {
+            this.hudRenderer.showDirectiveOverlay(directiveState);
+        } else {
+            this.hudRenderer.updateDirectiveCountdown(directiveState);
+        }
+    }
+
+    handleSpawnPause(directive) {
+        this.isSpawnPaused = true;
+        if (directive?.directive) {
+            this.hudRenderer.showDirectiveOverlay(directive.directive);
+        }
+    }
+
+    handleSpawnResume() {
+        this.isSpawnPaused = false;
+        this.syncDirectiveOverlay();
+    }
+}

--- a/src/game/SpawnSystem.js
+++ b/src/game/SpawnSystem.js
@@ -1,0 +1,122 @@
+const DEFAULT_BEAT_INTERVAL = 0.6;
+
+function clampDensity(value, fallback) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return fallback;
+    }
+    return Math.max(0, value);
+}
+
+export class SpawnSystem {
+    constructor(options = {}) {
+        const {
+            beatInterval = DEFAULT_BEAT_INTERVAL,
+            baseDensity = 1,
+            spawnHandler = null,
+            onPause = null,
+            onResume = null,
+            random = Math.random,
+        } = options;
+
+        this.beatInterval = beatInterval;
+        this.baseDensity = baseDensity;
+        this.spawnHandler = typeof spawnHandler === 'function' ? spawnHandler : null;
+        this.onPause = typeof onPause === 'function' ? onPause : null;
+        this.onResume = typeof onResume === 'function' ? onResume : null;
+        this.random = typeof random === 'function' ? random : Math.random;
+
+        this.timeAccumulator = 0;
+        this.isPaused = false;
+        this.lastDirective = null;
+    }
+
+    update(deltaSeconds, directive = {}) {
+        if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+            return;
+        }
+
+        this.lastDirective = directive || null;
+
+        if (directive?.paused) {
+            if (!this.isPaused) {
+                this.isPaused = true;
+                this.timeAccumulator = 0;
+                if (this.onPause) {
+                    this.onPause(directive);
+                }
+            }
+            return;
+        }
+
+        if (this.isPaused) {
+            this.isPaused = false;
+            if (this.onResume) {
+                this.onResume(directive);
+            }
+        }
+
+        const interval = this.resolveBeatInterval(directive);
+        if (!Number.isFinite(interval) || interval <= 0) {
+            return;
+        }
+
+        this.timeAccumulator += deltaSeconds;
+        while (this.timeAccumulator >= interval) {
+            this.timeAccumulator -= interval;
+            this.injectBeatTargets(directive);
+        }
+    }
+
+    resolveBeatInterval(directive = {}) {
+        const tempo = directive?.tempo;
+        if (typeof tempo === 'number' && tempo > 0) {
+            return 60 / tempo;
+        }
+        return this.beatInterval;
+    }
+
+    injectBeatTargets(directive = {}) {
+        const density = clampDensity(directive?.density, this.baseDensity);
+        let spawnCount = Math.floor(density);
+        const fractional = density - spawnCount;
+        if (fractional > 0 && this.random() < fractional) {
+            spawnCount += 1;
+        }
+
+        const targets = [];
+        for (let i = 0; i < spawnCount; i += 1) {
+            const target = this.createTarget(directive, i);
+            if (target) {
+                targets.push(target);
+            }
+        }
+
+        if (this.spawnHandler) {
+            this.spawnHandler(targets, {
+                directive,
+                density,
+                paused: false,
+            });
+        }
+
+        return targets;
+    }
+
+    createTarget(directive, index) {
+        return {
+            id: `directive-target-${Date.now()}-${index}`,
+            directive,
+            index,
+            color: directive?.color || directive?.colorPalette?.primary || '#ffffff',
+            pattern: directive?.pattern || null,
+        };
+    }
+
+    flush() {
+        this.timeAccumulator = 0;
+    }
+
+    getLastDirective() {
+        return this.lastDirective;
+    }
+}

--- a/src/game/ui/HUDRenderer.js
+++ b/src/game/ui/HUDRenderer.js
@@ -1,0 +1,193 @@
+function resolveRoot(rootElement) {
+    if (rootElement) {
+        return rootElement;
+    }
+    if (typeof document !== 'undefined') {
+        return document.body;
+    }
+    return null;
+}
+
+function now() {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        return performance.now();
+    }
+    return Date.now();
+}
+
+function formatCountdown(remainingMs) {
+    if (remainingMs == null) {
+        return '';
+    }
+    const seconds = Math.ceil(Math.max(remainingMs, 0) / 1000);
+    return seconds > 0 ? String(seconds) : '0';
+}
+
+export class HUDRenderer {
+    constructor(rootElement = null, options = {}) {
+        this.rootElement = resolveRoot(rootElement);
+        this.options = {
+            overlayId: 'directive-overlay',
+            ...options,
+        };
+
+        this.overlay = null;
+        this.activeDirective = null;
+        this.countdownEnd = null;
+        this.countdownStartRemaining = null;
+        this.countdownHandle = null;
+
+        if (this.rootElement) {
+            this.overlay = this.buildOverlay();
+        }
+    }
+
+    buildOverlay() {
+        if (typeof document === 'undefined') {
+            return null;
+        }
+
+        const overlay = document.createElement('div');
+        overlay.className = 'directive-overlay';
+        overlay.id = this.options.overlayId;
+        overlay.setAttribute('aria-live', 'assertive');
+
+        const panel = document.createElement('div');
+        panel.className = 'directive-overlay__panel';
+
+        const label = document.createElement('div');
+        label.className = 'directive-overlay__label';
+
+        const prompt = document.createElement('div');
+        prompt.className = 'directive-overlay__prompt';
+
+        const annotation = document.createElement('div');
+        annotation.className = 'directive-overlay__annotation';
+
+        const countdown = document.createElement('div');
+        countdown.className = 'directive-overlay__countdown';
+
+        const countdownNumber = document.createElement('span');
+        countdownNumber.className = 'directive-overlay__countdown-number';
+        countdown.appendChild(countdownNumber);
+
+        panel.appendChild(label);
+        panel.appendChild(prompt);
+        panel.appendChild(annotation);
+        panel.appendChild(countdown);
+        overlay.appendChild(panel);
+
+        this.rootElement.appendChild(overlay);
+
+        return {
+            root: overlay,
+            panel,
+            label,
+            prompt,
+            annotation,
+            countdown,
+            countdownNumber,
+        };
+    }
+
+    getActiveDirective() {
+        return this.activeDirective;
+    }
+
+    showDirectiveOverlay(directive = {}) {
+        if (!this.overlay?.root) {
+            this.activeDirective = directive;
+            return;
+        }
+
+        this.activeDirective = { ...directive };
+        this.overlay.root.classList.add('is-visible');
+        this.overlay.root.dataset.type = directive.type || '';
+
+        this.overlay.label.textContent = (directive.label || 'Directive').toUpperCase();
+        this.overlay.prompt.textContent = directive.prompt || directive.description || '';
+        this.overlay.annotation.textContent = directive.annotation || directive.difficultyLabel || '';
+
+        const accent = directive.color || directive.colorPalette?.primary;
+        if (accent) {
+            this.overlay.root.style.setProperty('--directive-accent', accent);
+        } else {
+            this.overlay.root.style.removeProperty('--directive-accent');
+        }
+
+        this.beginCountdown(directive);
+    }
+
+    updateDirectiveCountdown(directive = {}) {
+        if (!this.overlay?.root || !this.activeDirective) {
+            return;
+        }
+
+        this.activeDirective = { ...this.activeDirective, ...directive };
+        this.beginCountdown(this.activeDirective, true);
+    }
+
+    hideDirectiveOverlay() {
+        if (!this.overlay?.root) {
+            this.activeDirective = null;
+            return;
+        }
+
+        this.activeDirective = null;
+        this.overlay.root.classList.remove('is-visible');
+        this.overlay.root.style.removeProperty('--directive-accent');
+        this.cancelCountdown();
+        this.overlay.countdownNumber.textContent = '';
+    }
+
+    beginCountdown(directive, preserveStart = false) {
+        this.cancelCountdown();
+
+        const remaining = directive.remaining ?? (directive.countdownSeconds != null
+            ? directive.countdownSeconds * 1000
+            : null);
+
+        if (remaining == null) {
+            this.overlay.countdownNumber.textContent = '';
+            this.countdownEnd = null;
+            this.countdownStartRemaining = null;
+            return;
+        }
+
+        const reference = preserveStart && this.countdownEnd
+            ? this.countdownEnd - now()
+            : remaining;
+
+        this.countdownStartRemaining = reference;
+        this.countdownEnd = now() + reference;
+        this.overlay.countdownNumber.textContent = formatCountdown(reference);
+
+        const tick = () => {
+            const remainingMs = Math.max(0, this.countdownEnd - now());
+            this.overlay.countdownNumber.textContent = formatCountdown(remainingMs);
+            if (remainingMs > 0 && this.activeDirective) {
+                this.countdownHandle = this.requestFrame(tick);
+            }
+        };
+
+        this.countdownHandle = this.requestFrame(tick);
+    }
+
+    cancelCountdown() {
+        if (this.countdownHandle != null) {
+            if (typeof cancelAnimationFrame === 'function') {
+                cancelAnimationFrame(this.countdownHandle);
+            } else {
+                clearTimeout(this.countdownHandle);
+            }
+        }
+        this.countdownHandle = null;
+    }
+
+    requestFrame(callback) {
+        if (typeof requestAnimationFrame === 'function') {
+            return requestAnimationFrame(callback);
+        }
+        return setTimeout(callback, 50);
+    }
+}

--- a/styles/lattice-pulse.css
+++ b/styles/lattice-pulse.css
@@ -1,0 +1,85 @@
+.directive-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(16px) scale(0.96);
+    transition: opacity 180ms ease, transform 240ms ease;
+    font-family: 'Orbitron', 'Rajdhani', 'Montserrat', sans-serif;
+    --directive-accent: #6ea8ff;
+    z-index: 20;
+}
+
+.directive-overlay.is-visible {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.directive-overlay__panel {
+    padding: clamp(24px, 6vw, 48px);
+    border-radius: 24px;
+    background: rgba(6, 10, 18, 0.86);
+    box-shadow:
+        0 24px 48px rgba(0, 0, 0, 0.4),
+        0 0 60px rgba(0, 0, 0, 0.25);
+    min-width: min(420px, 90vw);
+    text-align: center;
+    backdrop-filter: blur(16px);
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    pointer-events: none;
+}
+
+.directive-overlay__label {
+    font-size: clamp(0.8rem, 1.8vw, 1.1rem);
+    letter-spacing: 0.5em;
+    text-transform: uppercase;
+    color: var(--directive-accent);
+    opacity: 0.85;
+}
+
+.directive-overlay__prompt {
+    margin-top: clamp(12px, 2.4vw, 20px);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #f5f8ff;
+}
+
+.directive-overlay__annotation {
+    margin-top: clamp(8px, 1.8vw, 14px);
+    font-size: clamp(0.75rem, 1.4vw, 0.95rem);
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.directive-overlay__countdown {
+    margin: clamp(20px, 3vw, 28px) auto 0;
+    width: clamp(120px, 22vw, 160px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    border: 4px solid rgba(255, 255, 255, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    box-shadow: 0 0 40px rgba(30, 120, 255, 0.15);
+}
+
+.directive-overlay__countdown-number {
+    font-size: clamp(2.5rem, 6vw, 4rem);
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    color: var(--directive-accent);
+}
+
+.directive-overlay[data-type='gestureDirective'] {
+    --directive-accent: #45ffe7;
+}
+
+.directive-overlay[data-type='quickDraw'] {
+    --directive-accent: #ff3a73;
+}


### PR DESCRIPTION
## Summary
- rebuild the event director to prioritise gesture and quick draw directives and emit paused spawn directives when they are active
- update the lattice pulse game, spawn system, HUD renderer and effects manager so directive events pause beat injections, display an overlay and trigger shader/target tint cues
- refresh the lattice pulse stylesheet with a focused directive overlay presentation

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf7a956b00832986e5dd8ae406b616