### PR TITLE
Enable Lattice Pulse auto-start and ECT tuning

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,10 +86,51 @@
             font-size: 1rem;
             transition: all 0.3s;
         }
-        
+
         .action-btn:hover {
             background: rgba(255, 0, 255, 0.3);
             box-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+        }
+
+        .action-btn[data-game-state="running"] {
+            background: linear-gradient(135deg, rgba(0, 200, 255, 0.3), rgba(0, 255, 200, 0.25));
+            border-color: rgba(0, 200, 255, 0.65);
+            box-shadow: 0 0 15px rgba(0, 200, 255, 0.4);
+            color: #00f5ff;
+        }
+
+        .action-btn[data-game-state="running"][data-auto-start="1"] {
+            background: linear-gradient(135deg, rgba(0, 220, 255, 0.38), rgba(0, 255, 200, 0.32));
+            border-color: rgba(0, 235, 255, 0.85);
+            box-shadow: 0 0 20px rgba(0, 230, 255, 0.6);
+            color: #c8faff;
+        }
+
+        .action-btn[data-auto-start="1"] {
+            position: relative;
+        }
+
+        .action-btn[data-auto-start="1"]::after {
+            content: 'AUTO';
+            position: absolute;
+            top: -6px;
+            right: -6px;
+            font-size: 0.45rem;
+            letter-spacing: 0.16em;
+            color: rgba(210, 255, 255, 0.85);
+            text-shadow: 0 0 6px rgba(0, 220, 255, 0.55);
+        }
+
+        .action-btn[data-game-state="start-screen"] {
+            background: rgba(255, 150, 0, 0.2);
+            border-color: rgba(255, 150, 0, 0.5);
+            color: #ffba4a;
+        }
+
+        .action-btn[data-game-state="paused"] {
+            background: rgba(255, 255, 255, 0.08);
+            border-color: rgba(200, 200, 200, 0.25);
+            color: #e0e0e0;
         }
         
         @keyframes fadeInOut {
@@ -565,6 +606,10 @@
         </div>
         
         <div class="action-buttons">
+            <button class="action-btn" data-action="lattice-game" data-game-state="idle"
+                    onclick="openLatticePulse()"
+                    title="Lattice Pulse Game"
+                    aria-label="Open the Lattice Pulse audio game">🎮</button>
             <button class="action-btn" onclick="openGallery()" title="Gallery">🖼️</button>
             <button class="action-btn" onclick="toggleAudio()" title="Audio">🎵</button>
             <button class="action-btn" onclick="showLLMInterface()" title="AI Parameters">🤖</button>
@@ -1007,7 +1052,7 @@
                         
                         // Update global state and UI
                         window.currentSystem = system;
-                        
+
                         // Update ReactivityManager with new active system
                         if (window.reactivityManager) {
                             window.reactivityManager.setActiveSystem(system, newEngine);
@@ -1041,7 +1086,15 @@
                         };
                         const panelHeader = document.getElementById('panelHeader');
                         if (panelHeader) panelHeader.textContent = headers[system] || 'VIB34D SYSTEM';
-                        
+
+                        if (!window.isGalleryPreview) {
+                            if (system === 'faceted' && typeof window.setupLatticePulseGame === 'function') {
+                                window.setupLatticePulseGame(newEngine);
+                            } else if (window.latticePulseGame && typeof window.latticePulseGame.handleSystemChange === 'function') {
+                                window.latticePulseGame.handleSystemChange(system, newEngine);
+                            }
+                        }
+
                         console.log(`✅ Switched to ${system} system successfully`);
                         return; // Success - exit early
                     } else if (system === 'polychora') {
@@ -1569,6 +1622,7 @@
         import { CanvasManager } from './src/core/CanvasManager.js';
         import { TradingCardGenerator } from './src/export/TradingCardGenerator.js';
         import { ReactivityManager } from './src/core/ReactivityManager.js';
+        import { LatticePulseGame } from './src/game/LatticePulseGame.js';
         // Universal reactivity system removed - implementing modular reactivity system
         
         // Global state - CRITICAL FIX: Check for gallery preview data FIRST
@@ -1586,6 +1640,221 @@
         let parameterMapper = null;
         let savedVariationsCount = 0;
         let reactivityManager = null;
+        let latticePulseGame = null;
+
+        const LATTICE_PULSE_STORAGE = {
+            introSeen: 'latticePulseIntroSeen',
+            autoStart: 'latticePulseAutoStart'
+        };
+
+        function readLatticePulsePreference(key) {
+            if (typeof window === 'undefined') return null;
+            try {
+                if (window.localStorage) {
+                    return window.localStorage.getItem(key);
+                }
+            } catch (error) {
+                console.warn('🎮 Unable to read Lattice Pulse preference:', error);
+            }
+            return null;
+        }
+
+        function shouldAutoLaunchLatticePulse() {
+            if (window.isGalleryPreview) return false;
+            const host = window.location?.hostname || '';
+            const protocol = window.location?.protocol || '';
+            const isLocal = protocol === 'file:' || host === 'localhost' || host === '127.0.0.1' || host.endsWith('.local');
+            if (isLocal) return false;
+            if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
+            const stored = readLatticePulsePreference(LATTICE_PULSE_STORAGE.autoStart);
+            if (stored === '0') return false;
+            return true;
+        }
+
+        function maybeAutoStartLatticePulse(gameInstance, reason = 'pages-auto') {
+            if (!gameInstance || typeof gameInstance.autoStartSignature !== 'function') {
+                return false;
+            }
+
+            if (!shouldAutoLaunchLatticePulse()) {
+                return false;
+            }
+
+            try {
+                const started = gameInstance.autoStartSignature(reason);
+                if (started) {
+                    console.log('🎮 Lattice Pulse auto-started using signature rhythm.');
+                }
+                return started;
+            } catch (error) {
+                console.warn('🎮 Failed to auto-start Lattice Pulse:', error);
+                return false;
+            }
+        }
+
+        function updateGameButtonState(state, detail = {}) {
+            const gameBtn = document.querySelector('[data-action="lattice-game"]');
+            if (!gameBtn) return;
+
+            const normalizedState = state || 'idle';
+            const isAuto = !!(detail.autoStart || detail.startReason === 'auto' || detail.startReason === 'pages-auto' || detail.startReason === 'deploy-auto' || detail.autoStartEnabled);
+            gameBtn.dataset.gameState = normalizedState;
+            if (isAuto) {
+                gameBtn.dataset.autoStart = '1';
+            } else {
+                gameBtn.removeAttribute('data-auto-start');
+            }
+
+            if (detail.mode) {
+                gameBtn.dataset.mode = detail.mode;
+            } else {
+                gameBtn.removeAttribute('data-mode');
+            }
+
+            const titles = {
+                running: 'Lattice Pulse: Running (click to adjust audio)',
+                'running-auto': 'Lattice Pulse: Auto-running signature rhythm (tap to link audio)',
+                'start-screen': 'Lattice Pulse: Choose an audio source',
+                paused: 'Lattice Pulse: Paused while exploring other systems',
+                idle: 'Lattice Pulse: Launch the audio-driven game',
+                'idle-auto': 'Lattice Pulse: Auto-start ready (tap to preview or configure)',
+                stopped: 'Lattice Pulse: Stopped'
+            };
+
+            const titleKey = (() => {
+                if (normalizedState === 'running') {
+                    return isAuto ? 'running-auto' : 'running';
+                }
+                if (normalizedState === 'idle' && (isAuto || detail.autoStartEnabled)) {
+                    return 'idle-auto';
+                }
+                return normalizedState;
+            })();
+            const title = titles[titleKey] || titles.idle;
+            gameBtn.title = title;
+            gameBtn.setAttribute('aria-label', title);
+        }
+
+        function setupLatticePulseGame(engineInstance) {
+            if (window.isGalleryPreview) {
+                console.log('🎮 Lattice Pulse skipped in gallery preview mode.');
+                return null;
+            }
+
+            if (!engineInstance) {
+                console.warn('🎮 Lattice Pulse requires a faceted engine instance.');
+                return null;
+            }
+
+            const host = document.getElementById('canvasContainer') || document.body;
+            let autoStarted = false;
+
+            if (!latticePulseGame) {
+                try {
+                    latticePulseGame = new LatticePulseGame(engineInstance, {
+                        container: host,
+                        energySmoothing: 0.78,
+                        storageKeys: LATTICE_PULSE_STORAGE
+                    });
+                    window.latticePulseGame = latticePulseGame;
+                    console.log('🎮 Lattice Pulse game initialized.');
+                } catch (error) {
+                    console.error('❌ Failed to initialize Lattice Pulse game:', error);
+                    latticePulseGame = null;
+                    return null;
+                }
+
+                latticePulseGame.init();
+
+                if (typeof latticePulseGame.minimizeStartScreen === 'function') {
+                    latticePulseGame.minimizeStartScreen();
+                }
+
+                const introSeen = readLatticePulsePreference(LATTICE_PULSE_STORAGE.introSeen) === '1';
+                if (!introSeen) {
+                    autoStarted = maybeAutoStartLatticePulse(latticePulseGame, 'deploy-auto');
+                    if (!autoStarted) {
+                        latticePulseGame.showStartScreen('Choose how you want to feed the visuals.', 'info');
+                        updateGameButtonState('start-screen', {
+                            autoStartEnabled: latticePulseGame.getAutoStartPreference?.(),
+                            mode: latticePulseGame.mode
+                        });
+                    }
+                    try {
+                        if (window.localStorage) {
+                            window.localStorage.setItem(LATTICE_PULSE_STORAGE.introSeen, '1');
+                        }
+                    } catch (error) {
+                        console.warn('🎮 Failed to persist Lattice Pulse intro flag:', error);
+                    }
+                } else {
+                    autoStarted = maybeAutoStartLatticePulse(latticePulseGame);
+                }
+            } else {
+                latticePulseGame.attachEngine(engineInstance);
+                autoStarted = maybeAutoStartLatticePulse(latticePulseGame);
+            }
+
+            if (typeof latticePulseGame?.handleSystemChange === 'function') {
+                latticePulseGame.handleSystemChange('faceted', engineInstance);
+            }
+
+            const currentState = latticePulseGame?.state || (autoStarted ? 'running' : 'idle');
+            updateGameButtonState(currentState, {
+                autoStart: autoStarted,
+                autoStartEnabled: latticePulseGame?.getAutoStartPreference?.(),
+                mode: latticePulseGame?.mode
+            });
+
+            return latticePulseGame;
+        }
+
+        window.addEventListener('latticepulse:state', (event) => {
+            if (!event || !event.detail) return;
+            updateGameButtonState(event.detail.state, event.detail);
+        });
+
+        window.addEventListener('latticepulse:autostart-preference', (event) => {
+            const enabled = event?.detail?.enabled;
+            if (!latticePulseGame) return;
+            updateGameButtonState(latticePulseGame.state || 'idle', {
+                autoStartEnabled: enabled,
+                mode: latticePulseGame.mode
+            });
+        });
+
+        window.openLatticePulse = async function() {
+            if (window.isGalleryPreview) {
+                console.warn('🎮 Lattice Pulse is disabled in gallery preview mode.');
+                return;
+            }
+
+            if (window.currentSystem !== 'faceted' && typeof window.switchSystem === 'function') {
+                console.log('🎮 Switching to faceted system for Lattice Pulse.');
+                await window.switchSystem('faceted');
+            }
+
+            if (!latticePulseGame) {
+                if (window.engine) {
+                    setupLatticePulseGame(window.engine);
+                } else {
+                    console.warn('🎮 Lattice Pulse game not ready yet.');
+                    return;
+                }
+            }
+
+            try {
+                latticePulseGame.showStartScreen('Choose how you want to feed the visuals.', 'info');
+                updateGameButtonState('start-screen', {
+                    autoStartEnabled: latticePulseGame.getAutoStartPreference?.(),
+                    mode: latticePulseGame.mode
+                });
+            } catch (error) {
+                console.error('❌ Unable to open Lattice Pulse start screen:', error);
+            }
+        };
+
+        window.setupLatticePulseGame = setupLatticePulseGame;
         
         // Geometry configurations
         const geometries = {
@@ -1609,7 +1878,7 @@
         document.addEventListener('DOMContentLoaded', async () => {
             setupGeometry('faceted');
             const success = await initializeEngine();
-            
+
             // Make engines globally accessible for switchSystem function
             window.engine = engine;
             window.quantumEngine = quantumEngine;
@@ -1620,7 +1889,13 @@
             window.geometries = geometries;
             window.initializePolychora = initializePolychora;
             window.updateParameter = updateParameter;
-            
+
+            if (success && engine && !window.isGalleryPreview) {
+                setupLatticePulseGame(engine);
+            } else if (window.isGalleryPreview) {
+                updateGameButtonState('paused');
+            }
+
             // Initialize ReactivityManager
             reactivityManager = new ReactivityManager();
             window.reactivityManager = reactivityManager;

--- a/index.html
+++ b/index.html
@@ -282,7 +282,56 @@
             margin-bottom: 10px;
             text-transform: uppercase;
         }
-        
+
+        .hud-summary {
+            display: grid;
+            gap: 8px;
+            font-size: 0.75rem;
+            color: rgba(200, 255, 255, 0.72);
+            line-height: 1.45;
+        }
+
+        .hud-summary p {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .hud-chip {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            font-size: 0.68rem;
+            text-transform: uppercase;
+            letter-spacing: 0.16em;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: rgba(0, 255, 255, 0.12);
+            border: 1px solid rgba(0, 255, 255, 0.28);
+            color: #c8ffff;
+            white-space: nowrap;
+        }
+
+        .hud-chip.energy {
+            background: rgba(255, 120, 180, 0.14);
+            border-color: rgba(255, 120, 180, 0.32);
+            color: rgba(255, 210, 230, 0.9);
+        }
+
+        .hud-chip.ect {
+            background: rgba(120, 200, 255, 0.14);
+            border-color: rgba(120, 200, 255, 0.32);
+            color: rgba(210, 235, 255, 0.92);
+        }
+
+        .hud-chip.combo {
+            background: rgba(255, 180, 120, 0.14);
+            border-color: rgba(255, 180, 120, 0.32);
+            color: rgba(255, 232, 210, 0.92);
+        }
+
         /* Geometry Grid */
         .geometry-grid {
             display: grid;
@@ -638,7 +687,16 @@
         <div class="panel-header" id="panelHeader">
             <span>FACETED SYSTEM</span>
         </div>
-        
+
+        <div class="control-section" id="feedbackSection">
+            <div class="section-title">HUD FEEDBACK MAP</div>
+            <div class="hud-summary">
+                <p><span class="hud-chip energy">Band Flares</span>Follow bass, mid, and treble surges to see which spectrum is steering each geometry shift.</p>
+                <p><span class="hud-chip ect">ECT Reactor</span>Watch coherence rise and fall so you know when visuals are stabilizing or about to bloom.</p>
+                <p><span class="hud-chip combo">Combo Chain</span>Track streaks and timeline callouts to anticipate signature bursts and rescue moments.</p>
+            </div>
+        </div>
+
         <!-- GEOMETRY SECTION (Faceted & Polychora) -->
         <div class="control-section" id="geometrySection">
             <div class="section-title">GEOMETRY</div>

--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
         
         /* ========== CONTROL PANEL ========== */
         .control-panel {
+            --panel-handle: 56px;
             position: fixed;
             top: 50px;
             right: 0;
@@ -174,37 +175,134 @@
             background: rgba(0, 0, 0, 0.95);
             border-left: 2px solid #00ffff;
             padding: 20px;
-            overflow-y: auto;
+            overflow: hidden;
             backdrop-filter: blur(10px);
             z-index: 100;
-            transition: transform 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            transition: none;
+        }
+
+        .panel-ready .control-panel {
+            transition: transform 0.35s ease;
+        }
+
+        .control-panel.collapsed {
+            transform: translateX(calc(100% - var(--panel-handle)));
+        }
+
+        .control-panel.collapsed .panel-header {
+            pointer-events: auto;
+        }
+
+        .control-panel.collapsed .panel-body {
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.2s ease, visibility 0s linear 0.2s;
+            overflow: hidden;
+        }
+
+        .panel-body {
+            flex: 1;
+            display: block;
+            overflow-y: auto;
+            transition: opacity 0.3s ease;
+            padding-right: 4px;
+            overscroll-behavior: contain;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .panel-body[aria-hidden="true"] {
+            pointer-events: none;
+        }
+
+        .control-panel:not(.collapsed) .panel-body {
+            opacity: 1;
+            visibility: visible;
+            transition-delay: 0s;
+        }
+
+        .hud-dock {
+            margin-bottom: 20px;
+        }
+
+        .hud-dock:empty {
+            display: none;
+        }
+
+        .hud-dock.is-active {
+            margin-bottom: 24px;
+        }
+
+        body.panel-collapsed .canvas-container {
+            right: 0;
+        }
+
+        body.panel-open .canvas-container {
+            right: 300px;
         }
         
         @media (max-width: 768px) {
+            body {
+                --panel-height-mobile: min(55vh, 460px);
+            }
+
             .control-panel {
+                --panel-handle: 52px;
                 width: 100vw;
-                height: 40vh;
+                height: var(--panel-height-mobile);
                 top: auto;
                 bottom: 0;
                 right: 0;
                 left: 0;
                 border-left: none;
                 border-top: 2px solid #00ffff;
+                transform: translateY(0);
             }
-            
+
+            .control-panel.collapsed {
+                transform: translateY(calc(100% - var(--panel-handle)));
+            }
+
+            .control-panel.collapsed .panel-body {
+                transition: opacity 0.2s ease, visibility 0s linear 0.2s;
+            }
+
             .canvas-container {
                 right: 0;
-                bottom: 60px;
+                bottom: 0;
+                top: 0;
             }
-            
+
+            body.panel-open .canvas-container {
+                right: 0;
+                bottom: var(--panel-height-mobile);
+            }
+
+            body.panel-collapsed .canvas-container {
+                right: 0;
+                bottom: 0;
+            }
+
             .system-selector {
                 flex-wrap: wrap;
                 gap: 5px;
+            }
+
+            .panel-body {
+                padding-right: 0;
             }
             
             .system-btn {
                 font-size: 0.8rem;
                 padding: 6px 12px;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .control-panel,
+            .panel-body {
+                transition: none !important;
             }
         }
         
@@ -217,21 +315,40 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            gap: 12px;
+        }
+
+        .panel-title {
+            flex: 1;
+            text-align: left;
         }
         
         .mobile-collapse-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 38px;
+            height: 38px;
             background: rgba(255, 0, 255, 0.2);
             border: 1px solid #ff00ff;
             color: #ff00ff;
-            padding: 8px 12px;
             cursor: pointer;
-            font-size: 1.2rem;
-            border-radius: 5px;
+            font-size: 1rem;
+            border-radius: 8px;
             transition: all 0.3s ease;
         }
-        
+
+        .mobile-collapse-btn span {
+            pointer-events: none;
+        }
+
         .mobile-collapse-btn:hover {
             background: rgba(255, 0, 255, 0.4);
+        }
+
+        .mobile-collapse-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(255, 0, 255, 0.35);
         }
         
         @media (max-width: 768px) {
@@ -685,10 +802,16 @@
     <!-- Control Panel -->
     <div class="control-panel" id="controlPanel">
         <div class="panel-header" id="panelHeader">
-            <span>FACETED SYSTEM</span>
+            <span class="panel-title" id="panelTitle">FACETED SYSTEM</span>
+            <button class="mobile-collapse-btn" id="mobileCollapseBtn" type="button" aria-controls="controlPanel" aria-expanded="true" aria-label="Collapse control panel">
+                <span aria-hidden="true">▼</span>
+            </button>
         </div>
 
-        <div class="control-section" id="feedbackSection">
+        <div class="panel-body" id="panelBody" aria-hidden="false">
+            <div class="hud-dock" id="hudDock" aria-live="polite"></div>
+
+            <div class="control-section" id="feedbackSection">
             <div class="section-title">HUD FEEDBACK MAP</div>
             <div class="hud-summary">
                 <p><span class="hud-chip energy">Band Flares</span>Follow bass, mid, and treble surges to see which spectrum is steering each geometry shift.</p>
@@ -976,6 +1099,7 @@
             <button class="panel-btn" onclick="createTradingCard('classic')" style="background: rgba(255, 150, 0, 0.1); border-color: rgba(255, 150, 0, 0.3); color: #ff9600;">🎴 Trading Card</button>
             <button class="panel-btn" onclick="createTradingCard('social')" style="background: rgba(255, 100, 255, 0.1); border-color: rgba(255, 100, 255, 0.3); color: #ff64ff;">📱 Social Card</button>
         </div>
+        </div>
     </div>
     
     <!-- CRITICAL BUG FIX: Move switchSystem function outside ES6 module for global access -->
@@ -1142,8 +1266,8 @@
                             holographic: 'HOLOGRAPHIC SYSTEM',
                             polychora: 'POLYCHORA SYSTEM'
                         };
-                        const panelHeader = document.getElementById('panelHeader');
-                        if (panelHeader) panelHeader.textContent = headers[system] || 'VIB34D SYSTEM';
+                        const panelTitle = document.getElementById('panelTitle');
+                        if (panelTitle) panelTitle.textContent = headers[system] || 'VIB34D SYSTEM';
 
                         if (!window.isGalleryPreview) {
                             if (system === 'faceted' && typeof window.setupLatticePulseGame === 'function') {
@@ -1635,7 +1759,7 @@
         window.updateAllParameterDisplays = function(uiState) {
             const displayMappings = {
                 rot4dXW: 'xwValue',
-                rot4dYW: 'ywValue', 
+                rot4dYW: 'ywValue',
                 rot4dZW: 'zwValue',
                 gridDensity: 'densityValue',
                 morphFactor: 'morphValue',
@@ -1662,10 +1786,94 @@
             }
         }
 
+        // Control panel responsiveness
+        const controlPanelEl = document.getElementById('controlPanel');
+        const panelBody = document.getElementById('panelBody');
+        const collapseBtn = document.getElementById('mobileCollapseBtn');
+        const panelState = {
+            collapsed: false
+        };
+
+        function emitPanelToggle(collapsed, reason) {
+            try {
+                window.dispatchEvent(new CustomEvent('control-panel:toggle', {
+                    detail: { collapsed, reason }
+                }));
+            } catch (error) {
+                console.warn('⚠️ Unable to dispatch control panel toggle event', error);
+            }
+        }
+
+        function setPanelCollapsed(collapsed, { reason = 'manual', silent = false } = {}) {
+            if (!controlPanelEl) return;
+
+            const nextState = !!collapsed;
+            const changed = panelState.collapsed !== nextState;
+            panelState.collapsed = nextState;
+
+            controlPanelEl.classList.toggle('collapsed', nextState);
+            controlPanelEl.dataset.state = nextState ? 'collapsed' : 'expanded';
+            document.body.classList.toggle('panel-collapsed', nextState);
+            document.body.classList.toggle('panel-open', !nextState);
+
+            if (panelBody) {
+                panelBody.setAttribute('aria-hidden', nextState ? 'true' : 'false');
+            }
+
+            if (collapseBtn) {
+                collapseBtn.setAttribute('aria-expanded', (!nextState).toString());
+                collapseBtn.setAttribute('aria-label', nextState ? 'Expand control panel' : 'Collapse control panel');
+                collapseBtn.dataset.state = nextState ? 'collapsed' : 'expanded';
+                const icon = collapseBtn.querySelector('span');
+                if (icon) {
+                    icon.textContent = nextState ? '▲' : '▼';
+                } else {
+                    collapseBtn.textContent = nextState ? '▲' : '▼';
+                }
+            }
+
+            if (!silent || changed) {
+                emitPanelToggle(nextState, reason);
+            }
+        }
+
+        window.setPanelCollapsed = function(forceState, options = {}) {
+            setPanelCollapsed(forceState, options);
+        };
+
+        window.toggleMobilePanel = function(forceState, options = {}) {
+            if (!controlPanelEl) return;
+            const target = typeof forceState === 'boolean' ? forceState : !panelState.collapsed;
+            const reason = options.reason || 'toggle';
+            const silent = !!options.silent;
+            setPanelCollapsed(target, { reason, silent });
+        };
+
+        if (collapseBtn) {
+            collapseBtn.addEventListener('click', () => window.toggleMobilePanel(undefined, { reason: 'button' }));
+        }
+
+        const collapseMediaQuery = window.matchMedia('(max-width: 900px)');
+        const handlePanelMedia = event => {
+            const preferCollapsed = !!event.matches;
+            setPanelCollapsed(preferCollapsed, { reason: 'media' });
+        };
+
+        handlePanelMedia(collapseMediaQuery);
+        if (typeof collapseMediaQuery.addEventListener === 'function') {
+            collapseMediaQuery.addEventListener('change', handlePanelMedia);
+        } else if (typeof collapseMediaQuery.addListener === 'function') {
+            collapseMediaQuery.addListener(handlePanelMedia);
+        }
+
+        document.body.classList.add('panel-ready');
+        document.body.classList.toggle('panel-open', !panelState.collapsed);
+        document.body.classList.toggle('panel-collapsed', panelState.collapsed);
+
         // Global flag to indicate module readiness
         window.moduleReady = false;
         window.currentSystem = 'faceted';
-        
+
     </script>
     
     <script type="module">

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -77,6 +77,17 @@ export class LatticePulseGame {
         this.currentHue = 200;
         this.startControls = null;
         this.linkedTrackLabel = null;
+        this.currentECT = 0;
+        this.targetECT = 0;
+        this.ectHistory = [];
+        this.lastECTTrend = 0;
+        this.ectSmoothing = options.ectSmoothing ?? 0.68;
+        this.lastStartReason = 'init';
+        this.storageKeys = {
+            introSeen: options.storageKeys?.introSeen || 'latticePulseIntroSeen',
+            autoStart: options.storageKeys?.autoStart || 'latticePulseAutoStart'
+        };
+        this.autoStartPreference = null;
 
         this.geometryDefaults = this.createGeometryDefaults();
         this.visualizerRules = this.createVisualizerRules();
@@ -86,11 +97,151 @@ export class LatticePulseGame {
         this.trackInput = null;
         this.fileInput = null;
         this.hudElements = null;
+        this.onStateChange = typeof options.onStateChange === 'function' ? options.onStateChange : null;
+        this.lastGeometryEvent = null;
 
         this.beatUnsubscribe = this.audioService.onBeat(this.handleBeat);
         this.energyUnsubscribe = this.audioService.onEnergy(payload => this.handleEnergy(payload));
         this.stateUnsubscribe = this.audioService.onStateChange((state, detail) => this.handleAudioStateChange(state, detail));
         this.errorUnsubscribe = this.audioService.onError(error => this.handleAudioError(error));
+    }
+
+    emitStateChange(state, detail = {}) {
+        const previous = this.state;
+        this.state = state;
+
+        const payload = {
+            previous,
+            mode: this.mode,
+            ect: this.currentECT,
+            autoStartEnabled: this.getAutoStartPreference(),
+            ...detail
+        };
+
+        if (typeof this.onStateChange === 'function') {
+            try {
+                this.onStateChange(state, payload);
+            } catch (error) {
+                console.error('[LatticePulseGame] onStateChange callback error', error);
+            }
+        }
+
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            try {
+                window.dispatchEvent(new CustomEvent('latticepulse:state', { detail: { state, ...payload } }));
+            } catch (error) {
+                console.error('[LatticePulseGame] Failed to dispatch state event', error);
+            }
+        }
+    }
+
+    getAutoStartPreference() {
+        if (this.autoStartPreference !== null) {
+            return this.autoStartPreference;
+        }
+
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return null;
+        }
+
+        try {
+            const stored = window.localStorage.getItem(this.storageKeys.autoStart);
+            if (stored === '1') {
+                this.autoStartPreference = true;
+            } else if (stored === '0') {
+                this.autoStartPreference = false;
+            }
+        } catch (error) {
+            console.warn('[LatticePulseGame] Unable to read auto-start preference', error);
+            this.autoStartPreference = null;
+        }
+
+        return this.autoStartPreference;
+    }
+
+    persistAutoStartPreference(enabled) {
+        this.autoStartPreference = typeof enabled === 'boolean' ? enabled : null;
+
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+
+        try {
+            if (enabled === null) {
+                window.localStorage.removeItem(this.storageKeys.autoStart);
+            } else {
+                window.localStorage.setItem(this.storageKeys.autoStart, enabled ? '1' : '0');
+            }
+        } catch (error) {
+            console.warn('[LatticePulseGame] Unable to persist auto-start preference', error);
+        }
+
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            try {
+                window.dispatchEvent(new CustomEvent('latticepulse:autostart-preference', { detail: { enabled } }));
+            } catch (error) {
+                console.error('[LatticePulseGame] Failed to dispatch auto-start preference event', error);
+            }
+        }
+    }
+
+    autoStartSignature(reason = 'auto') {
+        if (this.active || this.state === 'running') {
+            return false;
+        }
+
+        const preference = this.getAutoStartPreference();
+        if (preference === false) {
+            return false;
+        }
+
+        this.lastStartReason = reason;
+        this.startWithMetronome(reason);
+        return true;
+    }
+
+    updateECT(payload = {}, options = {}) {
+        const { immediate = false } = options || {};
+        const lastEnergyPayload = this.audioService.getLastEnergyPayload?.() || {};
+
+        const energy = clamp(payload.energy ?? this.audioService.getEnergy?.() ?? 0, 0, 1);
+        const analysisQuality = clamp(payload.analysisQuality ?? this.audioService.getAnalysisQuality?.() ?? 0, 0, 1);
+        const spectralFlux = clamp(payload.spectralFlux ?? lastEnergyPayload.spectralFlux ?? 0, 0, 1);
+        const fluxConfidence = clamp(payload.fluxConfidence ?? payload.confidence ?? lastEnergyPayload.fluxConfidence ?? 0, 0, 1);
+        const state = payload.state || this.audioService.getState?.() || this.mode;
+        const overlay = payload.metronomeOverlay ?? payload.overlay ?? lastEnergyPayload.metronomeOverlay ?? false;
+
+        const dynamicFlux = Math.max(spectralFlux, fluxConfidence * 0.85);
+        const stability = 1 - Math.min(1, Math.abs(this.displayEnergy - energy) * 1.35);
+
+        let target = (energy * 0.36) + (analysisQuality * 0.34) + (dynamicFlux * 0.22) + (stability * 0.08);
+
+        if (state === 'metronome') {
+            target = Math.min(1, target * (overlay ? 0.94 : 0.9) + 0.12);
+        } else if (state === 'microphone') {
+            target = target * 0.98 + 0.02;
+        } else if (state === 'track') {
+            target = target * 0.95 + fluxConfidence * 0.05;
+        }
+
+        const smoothing = immediate ? Math.min(this.ectSmoothing, 0.52) : this.ectSmoothing;
+        this.targetECT = target;
+        this.currentECT = this.currentECT * smoothing + target * (1 - smoothing);
+
+        this.ectHistory.push(this.currentECT);
+        if (this.ectHistory.length > 64) {
+            this.ectHistory.shift();
+        }
+
+        const historyLength = this.ectHistory.length;
+        if (historyLength >= 2) {
+            const previousValue = this.ectHistory[historyLength - 2];
+            this.lastECTTrend = this.currentECT - previousValue;
+        } else {
+            this.lastECTTrend = 0;
+        }
+
+        return this.currentECT;
     }
 
     init() {
@@ -106,7 +257,8 @@ export class LatticePulseGame {
             this.setHudStatus('Awaiting audio source…', 'info');
         }
 
-        this.state = 'start-screen';
+        this.updateECT({ energy: 0, analysisQuality: 0, spectralFlux: 0 }, { immediate: true });
+        this.emitStateChange('idle', { initial: true });
     }
 
     injectStyles() {
@@ -272,6 +424,22 @@ export class LatticePulseGame {
                 background: rgba(22, 26, 46, 0.7);
                 color: rgba(230, 236, 255, 0.88);
             }
+            .lp-link {
+                background: none;
+                border: none;
+                color: rgba(220, 226, 255, 0.7);
+                font-size: 0.8rem;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                cursor: pointer;
+                padding: 0.35rem 0;
+                align-self: center;
+                transition: opacity 0.2s ease;
+                opacity: 0.75;
+            }
+            .lp-link:hover {
+                opacity: 1;
+            }
             .lp-track-row {
                 display: flex;
                 align-items: center;
@@ -418,7 +586,8 @@ export class LatticePulseGame {
                 width: 0%;
                 background: linear-gradient(90deg, rgba(255, 110, 220, 0.7), rgba(110, 170, 255, 0.85));
                 box-shadow: 0 0 18px rgba(120, 150, 255, 0.55);
-                transition: width 0.18s ease, filter 0.28s ease;
+                transition: width 0.18s ease, filter 0.28s ease, opacity 0.28s ease;
+                opacity: calc(0.55 + var(--lp-ect, 0.35) * 0.4);
             }
             .lp-hud-warning {
                 margin-top: 0.85rem;
@@ -429,6 +598,12 @@ export class LatticePulseGame {
             .lp-hud[data-band="bass"] { border-color: rgba(255, 150, 170, 0.38); }
             .lp-hud[data-band="mid"] { border-color: rgba(140, 200, 255, 0.38); }
             .lp-hud[data-band="treble"] { border-color: rgba(170, 140, 255, 0.4); }
+            .lp-hud[data-ect="high"] { border-color: rgba(90, 220, 255, 0.45); }
+            .lp-hud[data-ect="medium"] { border-color: rgba(170, 200, 255, 0.4); }
+            .lp-hud[data-ect="low"] { border-color: rgba(255, 150, 130, 0.48); }
+            .lp-hud[data-ect="high"] .lp-hud-status { color: rgba(190, 248, 255, 0.95); }
+            .lp-hud[data-ect="medium"] .lp-hud-status { color: rgba(220, 232, 255, 0.9); }
+            .lp-hud[data-ect="low"] .lp-hud-status { color: rgba(255, 215, 190, 0.94); }
             .lp-hud[data-state="metronome"] .lp-hud-status { animation: lpStatusPulse 2.8s ease-in-out infinite; }
             @keyframes lpStartPulse {
                 0% { opacity: 0.4; }
@@ -462,7 +637,7 @@ export class LatticePulseGame {
         if (!this.container || typeof document === 'undefined') return;
 
         const overlay = document.createElement('div');
-        overlay.className = 'lp-start';
+        overlay.className = 'lp-start lp-hidden';
 
         const panel = document.createElement('div');
         panel.className = 'lp-start-panel';
@@ -530,6 +705,12 @@ export class LatticePulseGame {
         fallbackButton.textContent = 'Signature Metronome Mode';
         fallbackButton.addEventListener('click', () => this.startWithMetronome('manual'));
 
+        const skipButton = document.createElement('button');
+        skipButton.className = 'lp-link';
+        skipButton.type = 'button';
+        skipButton.textContent = 'Skip for now';
+        skipButton.addEventListener('click', () => this.skipForNow());
+
         const message = document.createElement('div');
         message.className = 'lp-start-message lp-message-info';
         message.textContent = 'Microphone mode provides the richest experience.';
@@ -537,11 +718,11 @@ export class LatticePulseGame {
         message.setAttribute('aria-live', 'polite');
         this.startMessage = message;
 
-        panel.append(title, tagline, description, spectrum, micButton, trackRow, fileInput, fallbackButton, message);
+        panel.append(title, tagline, description, spectrum, micButton, trackRow, fileInput, fallbackButton, skipButton, message);
         overlay.appendChild(panel);
         this.container.appendChild(overlay);
         this.startScreen = overlay;
-        this.startControls = { mic: micButton, track: trackButton, fallback: fallbackButton };
+        this.startControls = { mic: micButton, track: trackButton, fallback: fallbackButton, skip: skipButton };
     }
 
     createHud() {
@@ -579,6 +760,7 @@ export class LatticePulseGame {
         const bpm = createRow('Tempo', 'lp-hud-bpm');
         const energy = createRow('Energy', 'lp-hud-energy');
         const signal = createRow('Signal Lock', 'lp-hud-signal');
+        const ect = createRow('ECT', 'lp-hud-ect');
         const dominant = createRow('Dominant', 'lp-hud-dominant');
         const geometry = createRow('Geometry', 'lp-hud-geometry');
         const mode = createRow('Mode', 'lp-hud-mode');
@@ -602,6 +784,7 @@ export class LatticePulseGame {
             bpm,
             energy,
             signal,
+            ect,
             dominant,
             geometry,
             mode,
@@ -681,6 +864,82 @@ export class LatticePulseGame {
         });
     }
 
+    showStartScreen(message = 'Choose how you want to feed the visuals.', type = 'info') {
+        this.stop();
+        this.init();
+
+        if (this.startScreen) {
+            this.startScreen.classList.remove('lp-hidden');
+        }
+        if (this.hudElements?.root) {
+            this.hudElements.root.classList.add('lp-hidden');
+        }
+
+        this.setStartMessage(message, type);
+        this.emitStateChange('start-screen', { reason: 'manual' });
+    }
+
+    minimizeStartScreen() {
+        if (this.startScreen) {
+            this.startScreen.classList.add('lp-hidden');
+        }
+    }
+
+    skipForNow() {
+        this.stop();
+        if (this.startScreen) {
+            this.startScreen.classList.add('lp-hidden');
+        }
+        this.persistAutoStartPreference(false);
+        this.emitStateChange('idle', { reason: 'skip' });
+        this.setHudStatus('Game paused. Use the 🎮 control to resume.', 'info');
+    }
+
+    attachEngine(engine) {
+        this.engine = engine || null;
+
+        if (this.engine && this.active && this.lastGeometryEvent?.event) {
+            try {
+                this.applyGeometryEvent(this.lastGeometryEvent.event, this.lastGeometryEvent.beat, { record: false });
+            } catch (error) {
+                console.error('[LatticePulseGame] Failed to synchronize engine after reattachment.', error);
+            }
+        }
+    }
+
+    handleSystemChange(systemName, engineInstance = null) {
+        if (systemName === 'faceted') {
+            if (engineInstance) {
+                this.attachEngine(engineInstance);
+            } else if (!this.engine) {
+                this.attachEngine(engineInstance);
+            }
+
+            if (this.active && this.hudElements?.root) {
+                this.hudElements.root.classList.remove('lp-hidden');
+            }
+
+            const nextState = this.active ? 'running' : (this.state === 'start-screen' ? 'start-screen' : 'idle');
+            this.emitStateChange(nextState, { system: systemName, reason: 'attach' });
+        } else {
+            this.attachEngine(null);
+
+            if (this.active) {
+                this.setHudStatus('Paused while exploring other systems.', 'warning');
+            }
+
+            if (this.hudElements?.root) {
+                this.hudElements.root.dataset.pausedSystem = systemName;
+            }
+
+            this.emitStateChange('paused', { system: systemName });
+        }
+    }
+
+    isRunning() {
+        return !!this.engine && !!this.active;
+    }
+
     setHudStatus(message, type = 'info') {
         if (!this.hudElements?.status) return;
         const statusEl = this.hudElements.status;
@@ -698,12 +957,15 @@ export class LatticePulseGame {
                 this.mode = 'microphone';
                 this.linkedTrackLabel = 'Live microphone';
                 this.setStartMessage('Microphone linked. Listening for live tempo…', 'success');
+                this.lastStartReason = 'microphone';
                 this.beginGame(false);
             } else {
-                const reason = this.describeMetronomeReason(this.audioService.getMetronomeReason());
+                const metronomeReason = this.audioService.getMetronomeReason();
+                const reason = this.describeMetronomeReason(metronomeReason);
                 this.mode = 'metronome';
                 this.linkedTrackLabel = null;
                 this.setStartMessage(`Microphone unavailable${reason ? ` (${reason})` : ''}. Using signature rhythms instead.`, 'error');
+                this.lastStartReason = metronomeReason || 'microphone-fallback';
                 this.beginGame(true);
             }
         } finally {
@@ -745,11 +1007,14 @@ export class LatticePulseGame {
             this.mode = 'track';
             this.linkedTrackLabel = extraOptions.sourceLabel || this.formatSourceLabel(trimmed);
             this.setStartMessage('Audio stream connected. Detecting beat phase…', 'success');
+            this.lastStartReason = 'track';
             this.beginGame(false);
         } else {
+            const metronomeReason = this.audioService.getMetronomeReason();
             this.mode = 'metronome';
             this.linkedTrackLabel = null;
             this.setStartMessage('Failed to play the audio stream. Engaging signature fallback.', 'error');
+            this.lastStartReason = metronomeReason || 'track-failed';
             this.beginGame(true);
         }
     }
@@ -758,7 +1023,14 @@ export class LatticePulseGame {
         this.audioService.enableMetronome(reason);
         this.mode = 'metronome';
         this.linkedTrackLabel = null;
-        this.setStartMessage('Signature rhythm activated. Visuals will use emergent defaults.', 'warning');
+        if (reason === 'auto' || reason === 'pages-auto' || reason === 'deploy-auto') {
+            this.setStartMessage('Signature rhythm preview engaged automatically.', 'info');
+        } else if (reason === 'silence') {
+            this.setStartMessage('Live input quiet. Signature rhythm sustaining visuals.', 'warning');
+        } else {
+            this.setStartMessage('Signature rhythm activated. Visuals will use emergent defaults.', 'warning');
+        }
+        this.lastStartReason = reason;
         this.beginGame(true);
     }
 
@@ -770,7 +1042,6 @@ export class LatticePulseGame {
             this.hudElements.root.classList.remove('lp-hidden');
         }
 
-        this.state = 'running';
         this.active = true;
         this.beatCounter = 0;
         this.geometryDefaults.forEach(mode => { mode.step = 0; });
@@ -781,6 +1052,7 @@ export class LatticePulseGame {
         this.displayEnergy = 0;
         this.lastSignalQuality = 0;
         this.currentHue = 200;
+        this.lastGeometryEvent = null;
         this.lastFrameTime = (typeof performance !== 'undefined' ? performance.now() : Date.now());
 
         if (this.rafId) {
@@ -788,8 +1060,27 @@ export class LatticePulseGame {
         }
         this.rafId = requestAnimationFrame(this.loop);
 
+        const autoStart = ['auto', 'pages-auto', 'deploy-auto'].includes(this.lastStartReason);
+        this.persistAutoStartPreference(true);
+        this.emitStateChange('running', {
+            fallback: isFallback,
+            mode: this.mode,
+            startReason: this.lastStartReason,
+            autoStart
+        });
+
         if (isFallback) {
-            this.setHudStatus('Fallback signature rhythm active.', 'warning');
+            if (autoStart) {
+                this.setHudStatus('Signature rhythm auto-started. Tap 🎮 to link live audio.', 'info');
+            } else if (this.lastStartReason === 'silence') {
+                this.setHudStatus('Live input silent – signature rescue engaged.', 'warning');
+            } else if (this.lastStartReason === 'track-failed' || this.lastStartReason === 'track-fallback') {
+                this.setHudStatus('Linked track unavailable. Signature rhythm sustaining visuals.', 'warning');
+            } else if (this.lastStartReason === 'microphone-fallback' || this.lastStartReason === 'permission-denied' || this.lastStartReason === 'hardware-busy') {
+                this.setHudStatus('Microphone unavailable. Signature rhythm sustaining visuals.', 'warning');
+            } else {
+                this.setHudStatus('Fallback signature rhythm active.', 'warning');
+            }
         } else if (this.mode === 'microphone') {
             this.setHudStatus('Microphone tempo tracking active.', 'success');
         } else {
@@ -798,6 +1089,7 @@ export class LatticePulseGame {
 
         if (this.hudElements?.root) {
             this.hudElements.root.dataset.state = this.mode;
+            this.hudElements.root.dataset.autoStart = autoStart ? '1' : '0';
         }
     }
     loop(timestamp) {
@@ -829,6 +1121,15 @@ export class LatticePulseGame {
             this.lastSignalQuality = beat.analysisQuality;
         }
 
+        this.updateECT({
+            energy: beat?.energy,
+            analysisQuality: beat?.analysisQuality,
+            spectralFlux: beat?.spectralFlux,
+            fluxConfidence: beat?.fluxConfidence,
+            state: beat?.source === 'metronome' ? 'metronome' : this.audioService.getState?.(),
+            metronomeOverlay: beat?.metronomeOverlay || beat?.overlay
+        }, { immediate: true });
+
         let event;
         if (beat?.source === 'metronome' && beat.signature) {
             event = this.buildFallbackEvent(beat);
@@ -837,7 +1138,7 @@ export class LatticePulseGame {
         }
 
         if (event) {
-            this.applyGeometryEvent(event, beat);
+            this.applyGeometryEvent(event, beat, { record: true });
         }
 
         this.refreshHud(beat, event);
@@ -852,17 +1153,23 @@ export class LatticePulseGame {
         if (typeof payload.analysisQuality === 'number') {
             this.lastSignalQuality = payload.analysisQuality;
         }
+        this.updateECT(payload);
         this.refreshHud();
     }
 
     handleAudioStateChange(state, detail) {
         this.mode = state;
         if (state === 'metronome' && detail?.reason) {
-            this.failureState = this.describeMetronomeReason(detail.reason);
-            if (detail.reason === 'silence') {
-                this.setHudStatus('Live input silent – signature rescue engaged.', 'warning');
+            if (detail.reason === 'auto' || detail.reason === 'pages-auto' || detail.reason === 'deploy-auto') {
+                this.failureState = null;
+                this.setHudStatus('Signature rhythm auto-started. Tap 🎮 to link audio.', 'info');
             } else {
-                this.setHudStatus(`Fallback mode: ${this.failureState || 'signature sequence'}`, 'warning');
+                this.failureState = this.describeMetronomeReason(detail.reason);
+                if (detail.reason === 'silence') {
+                    this.setHudStatus('Live input silent – signature rescue engaged.', 'warning');
+                } else {
+                    this.setHudStatus(`Fallback mode: ${this.failureState || 'signature sequence'}`, 'warning');
+                }
             }
         } else if (state === 'microphone') {
             this.failureState = null;
@@ -881,6 +1188,9 @@ export class LatticePulseGame {
         }
         if (this.hudElements?.root) {
             this.hudElements.root.dataset.state = state;
+            if (typeof detail?.autoStart === 'boolean') {
+                this.hudElements.root.dataset.autoStart = detail.autoStart ? '1' : '0';
+            }
         }
         this.refreshHud();
     }
@@ -913,6 +1223,11 @@ export class LatticePulseGame {
                 return 'live input silent';
             case 'manual':
                 return 'manual selection';
+            case 'auto':
+                return 'automatic preview';
+            case 'pages-auto':
+            case 'deploy-auto':
+                return 'deployment auto-start';
             default:
                 return toLabel(reason);
         }
@@ -965,6 +1280,9 @@ export class LatticePulseGame {
     refreshHud(beat = null, event = null) {
         if (!this.hudElements) return;
 
+        const ectValue = clamp(this.currentECT ?? this.targetECT ?? 0, 0, 1);
+        const trend = this.lastECTTrend ?? 0;
+
         if (this.hudElements.source) {
             this.hudElements.source.textContent = this.describeSource();
         }
@@ -978,6 +1296,15 @@ export class LatticePulseGame {
         if (this.hudElements.signal) {
             const signalValue = clamp(this.lastSignalQuality ?? this.audioService.getAnalysisQuality(), 0, 1);
             this.hudElements.signal.textContent = signalValue ? `${Math.round(signalValue * 100)}%` : '—';
+        }
+        if (this.hudElements.ect) {
+            let indicator = '•';
+            if (trend > 0.015) {
+                indicator = '▲';
+            } else if (trend < -0.015) {
+                indicator = '▼';
+            }
+            this.hudElements.ect.textContent = `${Math.round(ectValue * 100)}% ${indicator}`;
         }
         if (this.hudElements.dominant) {
             const dominant = event?.dominantBand || this.getDominantBand(this.lastBandLevels);
@@ -995,6 +1322,8 @@ export class LatticePulseGame {
 
         if (this.hudElements.root) {
             this.hudElements.root.dataset.state = this.mode;
+            this.hudElements.root.dataset.ect = ectValue >= 0.75 ? 'high' : ectValue >= 0.45 ? 'medium' : 'low';
+            this.hudElements.root.style.setProperty('--lp-ect', ectValue.toFixed(3));
         }
 
         this.updateHudTheme(event);
@@ -1004,7 +1333,19 @@ export class LatticePulseGame {
 
     updateFailureHud() {
         if (!this.hudElements?.failure) return;
-        this.hudElements.failure.textContent = this.failureState ? this.failureState : '';
+        if (this.failureState) {
+            this.hudElements.failure.textContent = this.failureState;
+            return;
+        }
+
+        const ectValue = clamp(this.currentECT ?? this.targetECT ?? 0, 0, 1);
+        if (ectValue < 0.32) {
+            this.hudElements.failure.textContent = 'ECT low – stabilizing geometry. Tap 🎮 to link audio.';
+        } else if (ectValue > 0.78) {
+            this.hudElements.failure.textContent = 'ECT locked in – geometry coherence optimal.';
+        } else {
+            this.hudElements.failure.textContent = '';
+        }
     }
 
     updateHudTheme(event = null) {
@@ -1012,6 +1353,7 @@ export class LatticePulseGame {
         const root = this.hudElements.root;
         const energyValue = clamp(this.displayEnergy, 0, 1);
         const signalValue = clamp(this.lastSignalQuality ?? this.audioService.getAnalysisQuality(), 0, 1);
+        const ectValue = clamp(this.currentECT ?? this.targetECT ?? energyValue, 0, 1);
         const dominant = event?.dominantBand || this.currentDominantBand || 'none';
         root.dataset.band = dominant;
         const tempoClass = event?.tempoClass || this.classifyTempo(this.audioService.getCurrentBpm());
@@ -1025,12 +1367,14 @@ export class LatticePulseGame {
 
         root.style.setProperty('--lp-energy', energyValue.toFixed(3));
         root.style.setProperty('--lp-signal', signalValue.toFixed(3));
+        root.style.setProperty('--lp-ect', ectValue.toFixed(3));
         root.style.setProperty('--lp-accent', accentBase);
         root.style.boxShadow = `0 24px 60px rgba(0, 0, 0, 0.45), 0 0 ${Math.round(24 + energyValue * 80)}px ${accentGlow}`;
         root.style.borderColor = `hsla(${Math.round(hue)}, 85%, 68%, ${0.3 + signalValue * 0.3})`;
 
         if (this.hudElements.meter) {
             this.hudElements.meter.style.width = `${Math.round(energyValue * 100)}%`;
+            this.hudElements.meter.style.filter = `drop-shadow(0 0 ${Math.round(10 + ectValue * 22)}px hsla(${Math.round(hue)}, 95%, 70%, ${0.35 + ectValue * 0.25}))`;
         }
     }
     computeAudioRandom(...values) {
@@ -1151,60 +1495,102 @@ export class LatticePulseGame {
         };
     }
 
-    applyGeometryEvent(event, beat) {
+    applyGeometryEvent(event, beat, options = {}) {
         if (!event) return;
 
+        const { record = true } = options;
         const geometry = event.geometry;
         const normalizedLevel = this.normalizeLevel(geometry, event.level);
         const variationIndex = this.getVariationIndex(geometry, normalizedLevel);
         const baseParams = GeometryLibrary.getVariationParameters(geometry, normalizedLevel) || {};
 
-        const bandLevels = beat?.bandLevels || this.lastBandLevels || { bass: 0, mid: 0, treble: 0 };
-        const energy = clamp(beat?.energy ?? this.audioService.getEnergy(), 0, 1);
-        const bpm = beat?.bpm || this.audioService.getCurrentBpm() || 120;
+        const beatData = beat || this.lastGeometryEvent?.beat || null;
+        const bandLevels = beatData?.bandLevels || this.lastBandLevels || { bass: 0, mid: 0, treble: 0 };
+        const energy = clamp(beatData?.energy ?? this.audioService.getEnergy(), 0, 1);
+        const bpm = beatData?.bpm || this.audioService.getCurrentBpm() || 120;
         const tempoFactor = clamp(bpm / 120, 0.5, 2.2);
         const lastEnergyPayload = this.audioService.getLastEnergyPayload?.();
-        const fluxSource = beat?.spectralFlux ?? lastEnergyPayload?.spectralFlux ?? 0;
+        const fluxSource = beatData?.spectralFlux ?? lastEnergyPayload?.spectralFlux ?? 0;
         const fluxFactor = clamp(fluxSource * 4, 0, 1);
-        const signalQuality = clamp(beat?.analysisQuality ?? this.lastSignalQuality ?? this.audioService.getAnalysisQuality(), 0, 1);
+        const signalQuality = clamp(beatData?.analysisQuality ?? this.lastSignalQuality ?? this.audioService.getAnalysisQuality(), 0, 1);
+        const ectValue = clamp(this.currentECT ?? this.targetECT ?? energy, 0, 1);
 
-        const previous = this.engine?.parameterManager?.getAllParameters?.() || {};
+        if (record) {
+            const beatSnapshot = beatData ? {
+                energy: beatData.energy,
+                bpm: beatData.bpm,
+                analysisQuality: beatData.analysisQuality,
+                spectralFlux: beatData.spectralFlux,
+                source: beatData.source,
+                signature: beatData.signature ? { ...beatData.signature } : undefined,
+                bandLevels: beatData.bandLevels ? { ...beatData.bandLevels } : undefined
+            } : null;
+
+            this.lastGeometryEvent = {
+                event: { ...event, level: normalizedLevel },
+                beat: beatSnapshot
+            };
+        }
+
+        const engineInstance = this.engine;
+        const previous = engineInstance?.parameterManager?.getAllParameters?.() || {};
 
         const newParams = {
             ...previous,
             ...baseParams,
             geometry,
             variation: variationIndex,
-            chaos: clamp((baseParams.chaos ?? 0.2) * (0.7 + bandLevels.treble * 0.85 + fluxFactor * 0.2) + event.chaosBoost * energy, 0, 1),
-            speed: clamp((baseParams.speed ?? 1) * (0.65 + tempoFactor * 0.5 + bandLevels.bass * 0.4 + signalQuality * 0.3), 0.1, 3),
-            morphFactor: clamp((baseParams.morphFactor ?? 1) * (0.8 + bandLevels.mid * 0.55 + event.morphBoost * energy + signalQuality * 0.25), 0, 2),
-            gridDensity: clamp((baseParams.gridDensity ?? 12) * (0.75 + bandLevels.treble * 0.6 + energy * 0.35 + fluxFactor * 0.3), 4, 100),
-            intensity: clamp(0.28 + energy * 0.6 + signalQuality * 0.25, 0, 1),
-            saturation: clamp(0.45 + bandLevels.mid * 0.35 + event.saturationBoost * 0.5 + fluxFactor * 0.18, 0, 1),
-            dimension: clamp((previous.dimension ?? 3.5) + (signalQuality - 0.5) * 0.18 + (bandLevels.mid - 0.5) * 0.1, 3, 4.5),
-            hue: this.computeHue(baseParams.hue ?? previous.hue ?? 200, event, beat),
+            chaos: clamp(
+                (baseParams.chaos ?? 0.2) * (0.65 + bandLevels.treble * 0.75 + fluxFactor * 0.2) * (0.6 + ectValue * 0.55) +
+                event.chaosBoost * energy * (0.7 + ectValue * 0.4),
+                0,
+                1
+            ),
+            speed: clamp(
+                (baseParams.speed ?? 1) * (0.65 + tempoFactor * 0.5 + bandLevels.bass * 0.4 + signalQuality * 0.3) * (0.85 + ectValue * 0.2),
+                0.1,
+                3
+            ),
+            morphFactor: clamp(
+                (baseParams.morphFactor ?? 1) * (0.8 + bandLevels.mid * 0.55 + event.morphBoost * energy + signalQuality * 0.25) * (0.85 + ectValue * 0.4),
+                0,
+                2
+            ),
+            gridDensity: clamp(
+                (baseParams.gridDensity ?? 12) * (0.75 + bandLevels.treble * 0.6 + energy * 0.35 + fluxFactor * 0.3) * (0.82 + ectValue * 0.45),
+                4,
+                100
+            ),
+            intensity: clamp(0.28 + energy * 0.6 + signalQuality * 0.25 + ectValue * 0.18, 0, 1),
+            saturation: clamp(0.45 + bandLevels.mid * 0.35 + event.saturationBoost * 0.5 + fluxFactor * 0.18 + ectValue * 0.12, 0, 1),
+            dimension: clamp((previous.dimension ?? 3.5) + (signalQuality - 0.5) * 0.18 + (bandLevels.mid - 0.5) * 0.1 + (ectValue - 0.5) * 0.18, 3, 4.5),
+            hue: this.computeHue(baseParams.hue ?? previous.hue ?? 200, event, beatData),
             rot4dXW: clamp((previous.rot4dXW ?? 0) + (bandLevels.mid - 0.5) * 0.12 + (fluxFactor - 0.3) * 0.05, -2, 2),
             rot4dYW: clamp((previous.rot4dYW ?? 0) + (bandLevels.treble - 0.5) * 0.14 + (signalQuality - 0.5) * 0.04, -2, 2),
             rot4dZW: clamp((previous.rot4dZW ?? 0) + (bandLevels.bass - 0.5) * 0.1 + (fluxFactor - 0.3) * 0.04, -2, 2)
         };
 
-        if (this.engine?.parameterManager?.setParameters) {
-            this.engine.parameterManager.setParameters(newParams);
-        }
-        if (typeof this.engine.updateVisualizers === 'function') {
-            this.engine.updateVisualizers();
-        }
-        if (typeof this.engine.updateDisplayValues === 'function') {
-            this.engine.updateDisplayValues();
-        }
-        if (typeof this.engine.currentVariation === 'number') {
-            this.engine.currentVariation = variationIndex;
-        }
-
         this.currentGeometry = geometry;
         this.currentLevel = normalizedLevel;
         this.currentModeName = event.modeName;
         this.currentHue = newParams.hue;
+
+        if (!engineInstance) {
+            return;
+        }
+
+        if (engineInstance.parameterManager?.setParameters) {
+            engineInstance.parameterManager.setParameters(newParams);
+        }
+        if (typeof engineInstance.updateVisualizers === 'function') {
+            engineInstance.updateVisualizers();
+        }
+        if (typeof engineInstance.updateDisplayValues === 'function') {
+            engineInstance.updateDisplayValues();
+        }
+        if (typeof engineInstance.currentVariation === 'number') {
+            engineInstance.currentVariation = variationIndex;
+        }
     }
 
     computeHue(baseHue, event, beat) {
@@ -1219,8 +1605,10 @@ export class LatticePulseGame {
         const signalShift = clamp(beat?.analysisQuality ?? this.audioService.getAnalysisQuality(), 0, 1) * 24;
         const fluxShift = clamp((beat?.spectralFlux ?? this.audioService.getLastEnergyPayload?.()?.spectralFlux ?? 0) * 12, 0, 1) * 18;
         const paletteHue = event?.paletteHue ?? baseHue;
+        const ectValue = clamp(this.currentECT ?? this.targetECT ?? this.displayEnergy, 0, 1);
+        const coherenceShift = (ectValue - 0.5) * 36;
 
-        return Math.round((paletteHue + offset + tempoShift + energyShift + signalShift + fluxShift) % 360);
+        return Math.round((paletteHue + offset + tempoShift + energyShift + signalShift + fluxShift + coherenceShift) % 360);
     }
 
     stop() {
@@ -1229,10 +1617,10 @@ export class LatticePulseGame {
             cancelAnimationFrame(this.rafId);
             this.rafId = null;
         }
-        this.state = 'stopped';
         if (this.hudElements?.root) {
             this.hudElements.root.classList.add('lp-hidden');
         }
+        this.emitStateChange('stopped', { reason: 'stop' });
     }
 
     destroy() {


### PR DESCRIPTION
## Summary
- add deployment-friendly auto-start logic, preference handling, and button indicators for the Lattice Pulse control in `index.html`
- extend `LatticePulseGame` with auto-start persistence, ECT tracking, HUD feedback, and parameter modulation to keep visuals coherent when audio is absent or unstable

## Testing
- npm test *(fails: `playwright` not executable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b84096588329aed4ebe15a107d27