### PR TITLE
Enable Lattice Pulse game launch on static build

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,17 @@
             width: 100%;
             height: 100%;
         }
+
+        #latticePulseRoot {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 1500;
+        }
+
+        #latticePulseRoot > * {
+            pointer-events: auto;
+        }
         
         /* ========== CONTROL PANEL ========== */
         .control-panel {
@@ -566,6 +577,7 @@
         
         <div class="action-buttons">
             <button class="action-btn" onclick="openGallery()" title="Gallery">🖼️</button>
+            <button class="action-btn" onclick="launchLatticePulseGame()" title="Lattice Pulse Audio Game">🎮</button>
             <button class="action-btn" onclick="toggleAudio()" title="Audio">🎵</button>
             <button class="action-btn" onclick="showLLMInterface()" title="AI Parameters">🤖</button>
             <button class="action-btn" onclick="toggleInteractivity()" title="Interactivity Menu (Press I)">I</button>
@@ -875,6 +887,8 @@
         </div>
     </div>
     
+    <div id="latticePulseRoot" aria-live="polite"></div>
+
     <!-- CRITICAL BUG FIX: Move switchSystem function outside ES6 module for global access -->
     <script>
         // CRITICAL FIX: Parse URL parameters FIRST, before any ES6 module loading
@@ -1041,7 +1055,13 @@
                         };
                         const panelHeader = document.getElementById('panelHeader');
                         if (panelHeader) panelHeader.textContent = headers[system] || 'VIB34D SYSTEM';
-                        
+
+                        if (system === 'holographic') {
+                            await ensureLatticePulseGame();
+                        } else if (latticePulseGame && typeof latticePulseGame.attachEngine === 'function') {
+                            latticePulseGame.attachEngine(null);
+                        }
+
                         console.log(`✅ Switched to ${system} system successfully`);
                         return; // Success - exit early
                     } else if (system === 'polychora') {
@@ -1569,6 +1589,7 @@
         import { CanvasManager } from './src/core/CanvasManager.js';
         import { TradingCardGenerator } from './src/export/TradingCardGenerator.js';
         import { ReactivityManager } from './src/core/ReactivityManager.js';
+        import { LatticePulseGame } from './src/game/LatticePulseGame.js';
         // Universal reactivity system removed - implementing modular reactivity system
         
         // Global state - CRITICAL FIX: Check for gallery preview data FIRST
@@ -1586,6 +1607,8 @@
         let parameterMapper = null;
         let savedVariationsCount = 0;
         let reactivityManager = null;
+        let latticePulseGame = null;
+        let latticePulseRoot = null;
         
         // Geometry configurations
         const geometries = {
@@ -1607,6 +1630,7 @@
         
         // Initialize
         document.addEventListener('DOMContentLoaded', async () => {
+            latticePulseRoot = document.getElementById('latticePulseRoot');
             setupGeometry('faceted');
             const success = await initializeEngine();
             
@@ -1675,7 +1699,46 @@
             console.log(`✅ WebGL available: ${version}`);
             return true;
         }
-        
+
+        function getLatticePulseRoot() {
+            if (!latticePulseRoot || !document.body.contains(latticePulseRoot)) {
+                latticePulseRoot = document.getElementById('latticePulseRoot');
+            }
+
+            if (!latticePulseRoot) {
+                latticePulseRoot = document.createElement('div');
+                latticePulseRoot.id = 'latticePulseRoot';
+                latticePulseRoot.setAttribute('aria-live', 'polite');
+                document.body.appendChild(latticePulseRoot);
+            }
+
+            return latticePulseRoot;
+        }
+
+        async function ensureLatticePulseGame({ initializeUI = false } = {}) {
+            if (!window.holographicSystem) {
+                console.warn('🎮 Lattice Pulse: holographic system not ready');
+                return null;
+            }
+
+            if (!latticePulseGame) {
+                const root = getLatticePulseRoot();
+                latticePulseGame = new LatticePulseGame(window.holographicSystem, { container: root });
+                window.latticePulseGame = latticePulseGame;
+                console.log('🎮 Lattice Pulse: game instance created');
+            }
+
+            if (latticePulseGame && latticePulseGame.attachEngine && latticePulseGame.engine !== window.holographicSystem) {
+                latticePulseGame.attachEngine(window.holographicSystem);
+            }
+
+            if (initializeUI && latticePulseGame && !latticePulseGame.initialized) {
+                latticePulseGame.init();
+            }
+
+            return latticePulseGame;
+        }
+
         // Initialize VIB34D Engine
         async function initializeEngine() {
             try {
@@ -2203,7 +2266,7 @@
             console.log('🖼️ Navigating to gallery...');
             // MEMORY OPTIMIZATION: Navigate in same tab instead of opening new window
             window.location.href = './gallery.html';
-            
+
             // Listen for gallery window close
             if (window.galleryWindow) {
                 const checkClosed = setInterval(() => {
@@ -2215,7 +2278,44 @@
                 }, 1000);
             }
         }
-        
+
+        window.launchLatticePulseGame = async function() {
+            console.log('🎮 Launch requested for Lattice Pulse');
+
+            if (!window.moduleReady) {
+                console.warn('🎮 Lattice Pulse: module not ready yet');
+                return false;
+            }
+
+            if (window.currentSystem !== 'holographic') {
+                console.log('🎮 Switching to holographic system for Lattice Pulse');
+                await window.switchSystem('holographic');
+            }
+
+            if (!window.holographicSystem) {
+                console.error('❌ Lattice Pulse: holographic system unavailable');
+                return false;
+            }
+
+            const game = await ensureLatticePulseGame({ initializeUI: true });
+            if (!game) {
+                console.error('❌ Lattice Pulse: failed to initialize game instance');
+                return false;
+            }
+
+            if (game.attachEngine) {
+                game.attachEngine(window.holographicSystem);
+            }
+
+            if (typeof game.presentStartScreen === 'function') {
+                game.presentStartScreen({ reset: true });
+            } else if (!game.initialized && typeof game.init === 'function') {
+                game.init();
+            }
+
+            return true;
+        }
+
         window.toggleAudio = async function() {
             audioEnabled = !audioEnabled;
             window.audioEnabled = audioEnabled; // Update global flag

--- a/src/game/LatticePulseGame.js
+++ b/src/game/LatticePulseGame.js
@@ -109,6 +109,43 @@ export class LatticePulseGame {
         this.state = 'start-screen';
     }
 
+    presentStartScreen({ reset = false } = {}) {
+        if (!this.initialized) {
+            this.init();
+        }
+
+        if (this.rafId) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+        }
+
+        this.active = false;
+        this.mode = 'idle';
+
+        if (this.hudElements?.root) {
+            this.hudElements.root.classList.add('lp-hidden');
+        }
+
+        if (this.startScreen) {
+            this.startScreen.classList.remove('lp-hidden');
+        }
+
+        if (reset && this.startMessage) {
+            this.setStartMessage('Microphone mode provides the richest experience.', 'info');
+        }
+
+        this.setHudStatus('Awaiting audio source…', 'info');
+        this.beatCounter = 0;
+        this.lastBeat = null;
+        this.displayEnergy = 0;
+        this.currentModeName = null;
+        this.currentDominantBand = null;
+        this.failureState = null;
+
+        this.state = 'start-screen';
+        return true;
+    }
+
     injectStyles() {
         if (typeof document === 'undefined') return;
         if (document.getElementById('lattice-pulse-styles')) return;
@@ -1149,6 +1186,32 @@ export class LatticePulseGame {
             saturationBoost: 0.1,
             paletteHue: defaultMode.hueShift ?? signature.paletteHue
         };
+    }
+
+    attachEngine(engine) {
+        if (!engine) {
+            console.warn('[LatticePulseGame] Detaching from rendering engine.');
+            this.engine = null;
+            return false;
+        }
+
+        if (this.engine === engine) {
+            return true;
+        }
+
+        this.engine = engine;
+        console.log('[LatticePulseGame] Attached to holographic engine');
+
+        if (this.state === 'running') {
+            if (typeof this.engine.updateVisualizers === 'function') {
+                this.engine.updateVisualizers();
+            }
+            if (typeof this.engine.updateDisplayValues === 'function') {
+                this.engine.updateDisplayValues();
+            }
+        }
+
+        return true;
     }
 
     applyGeometryEvent(event, beat) {


### PR DESCRIPTION
## Summary
- add a dedicated overlay container and launch control so the Lattice Pulse game can appear in the static UI
- ensure holographic engine switches initialize and reconnect the game via helper utilities and a global launcher
- extend the LatticePulseGame class with start-screen reset and engine attachment support for reused instances

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1b84096588329aed4ebe15a107d27