### PR TITLE
Add live performance engine with multitouch control

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Mobile performance is optimized. The system loads quickly on phones and runs at 
 - **Trading card export** in multiple formats
 - **Audio reactivity** in holographic system
 - **Cross-system compatibility** - parameters work across all engines
+- **Live performance console** with multitouch pads, preset management, and choreographed flourishes
+
+## 🎛️ Live Performance Extensions
+
+The new **Live Performance Engine** transforms VIB34D into a stage-ready visualizer for DJs and bands:
+
+- Three configurable multi-touch pads let you map any parameter to X, Y, pinch, or rotation axes using dropdown selectors.
+- Expanded audio reactivity controls allow per-band toggles (bass/mid/high/energy) plus a master audio switch.
+- Save, recall, and crossfade presets with custom transition times for choreographed scenes.
+- Build flourish sequences by capturing keyframes, then trigger them manually or automatically when audio energy peaks.
+- Reactive flourishes can be bound to specific frequency bands with adjustable thresholds and cooldowns for reliable stage playback.
+
+Everything lives in a docked console near the bottom of the viewport so performers can manage visuals without leaving the browser window.
 
 ## 🔧 Development
 

--- a/index.html
+++ b/index.html
@@ -1569,6 +1569,7 @@
         import { CanvasManager } from './src/core/CanvasManager.js';
         import { TradingCardGenerator } from './src/export/TradingCardGenerator.js';
         import { ReactivityManager } from './src/core/ReactivityManager.js';
+        import { LivePerformanceEngine } from './src/core/LivePerformanceEngine.js';
         // Universal reactivity system removed - implementing modular reactivity system
         
         // Global state - CRITICAL FIX: Check for gallery preview data FIRST
@@ -1629,9 +1630,9 @@
             if (window.engine) window.engine.useBuiltInReactivity = false;
             if (window.quantumEngine) window.quantumEngine.useBuiltInReactivity = false;
             if (window.holographicSystem) window.holographicSystem.useBuiltInReactivity = false;
-            
+
             console.log('⚡ Built-in system reactivity DISABLED - ReactivityManager taking control');
-            
+
             // Connect ReactivityManager to global interactivity toggle
             if (window.toggleInteractivity) {
                 const originalToggle = window.toggleInteractivity;
@@ -1642,7 +1643,15 @@
                     }
                 };
             }
-            
+
+            // Initialize live performance engine for stage control
+            window.livePerformanceEngine = new LivePerformanceEngine({
+                parameterSchema: parameterMapper?.unifiedSchema,
+                updateParameter: (param, value) => window.updateParameter?.(param, value),
+                reactivityManager: window.unifiedReactivityManager || null,
+                container: document.body
+            });
+
             console.log('🚀 VIB34D Clean Interface Ready - All systems + modular reactivity initialized');
         });
         

--- a/src/core/AudioReactivityController.js
+++ b/src/core/AudioReactivityController.js
@@ -1,0 +1,67 @@
+/**
+ * AudioReactivityController
+ * Centralizes access to filtered audio-reactive bands and
+ * respects live performance band toggles.
+ */
+export class AudioReactivityController {
+    static defaultBands = {
+        bass: true,
+        mid: true,
+        high: true,
+        energy: true
+    };
+
+    static getBandValue(band) {
+        if (!window.audioEnabled || !window.audioReactive) {
+            return 0;
+        }
+
+        const bands = window.audioReactivityBands || AudioReactivityController.defaultBands;
+        if (bands && bands[band] === false) {
+            return 0;
+        }
+
+        return window.audioReactive?.[band] || 0;
+    }
+
+    static getFilteredBands() {
+        if (!window.audioEnabled || !window.audioReactive) {
+            return null;
+        }
+
+        const bands = window.audioReactivityBands || AudioReactivityController.defaultBands;
+        return {
+            bass: bands.bass === false ? 0 : (window.audioReactive?.bass || 0),
+            mid: bands.mid === false ? 0 : (window.audioReactive?.mid || 0),
+            high: bands.high === false ? 0 : (window.audioReactive?.high || 0),
+            energy: bands.energy === false ? 0 : (window.audioReactive?.energy || 0)
+        };
+    }
+
+    static setBandEnabled(band, enabled) {
+        const next = {
+            ...AudioReactivityController.defaultBands,
+            ...(window.audioReactivityBands || {})
+        };
+
+        next[band] = enabled;
+        window.audioReactivityBands = next;
+        window.dispatchEvent(new CustomEvent('audio-reactivity-bands-changed', {
+            detail: { bands: next, band, enabled }
+        }));
+        return next;
+    }
+
+    static setBands(bands) {
+        window.audioReactivityBands = {
+            ...AudioReactivityController.defaultBands,
+            ...bands
+        };
+        window.dispatchEvent(new CustomEvent('audio-reactivity-bands-changed', {
+            detail: { bands: window.audioReactivityBands }
+        }));
+        return window.audioReactivityBands;
+    }
+}
+
+window.AudioReactivityController = AudioReactivityController;

--- a/src/core/LivePerformanceEngine.js
+++ b/src/core/LivePerformanceEngine.js
@@ -1,0 +1,383 @@
+import { PerformancePresetManager } from './PerformancePresetManager.js';
+import { AudioReactivityController } from './AudioReactivityController.js';
+import { LiveTouchPadConsole } from '../ui/LiveTouchPadConsole.js';
+
+export class LivePerformanceEngine {
+    constructor({
+        parameterSchema = window.parameterMapper?.unifiedSchema || {},
+        updateParameter = (param, value) => window.updateParameter?.(param, value),
+        reactivityManager = window.unifiedReactivityManager,
+        container = document.body
+    } = {}) {
+        this.schema = parameterSchema;
+        this.updateParameter = updateParameter;
+        this.reactivityManager = reactivityManager;
+        this.container = container;
+
+        this.audioEnabled = window.audioEnabled ?? true;
+        this.audioBands = {
+            bass: true,
+            mid: true,
+            high: true,
+            energy: true,
+            ...(window.audioReactivityBands || {})
+        };
+
+        this.reactiveFlourish = null;
+        this.reactiveConfig = { threshold: 0.85, band: 'energy', cooldown: 2000, lastTrigger: 0 };
+        this.monitorHandle = null;
+
+        this.touchPadConsole = new LiveTouchPadConsole({
+            parameterSchema: this.schema,
+            container: this.container,
+            onParameterChange: (param, value) => this.handleParameterChange(param, value),
+            onAxisChange: (index, mappings) => this.handleAxisChange(index, mappings)
+        });
+
+        this.presetManager = new PerformancePresetManager({
+            schema: this.schema,
+            captureState: () => this.collectCurrentParameters(),
+            applyParameter: (param, value) => this.applyParameter(param, value)
+        });
+
+        this.buildControlPanel();
+        this.monitorAudio();
+
+        window.livePerformanceEngine = this;
+    }
+
+    collectCurrentParameters() {
+        if (typeof window.getCurrentUIParameterState === 'function') {
+            return { ...window.getCurrentUIParameterState(), ...this.presetManager.currentLiveState };
+        }
+
+        const state = { ...this.presetManager.currentLiveState };
+        Object.keys(this.schema).forEach(param => {
+            if (state[param] !== undefined) return;
+            const input = document.getElementById(param);
+            if (input) {
+                state[param] = parseFloat(input.value);
+            }
+        });
+        return state;
+    }
+
+    applyParameter(param, value) {
+        if (typeof this.updateParameter === 'function') {
+            this.updateParameter(param, value);
+        }
+    }
+
+    handleParameterChange(param, value) {
+        this.applyParameter(param, value);
+        this.presetManager.recordLiveValue(param, value);
+    }
+
+    handleAxisChange(index, mappings) {
+        console.log(`🎚️ Touch pad ${index} mappings updated`, mappings);
+    }
+
+    buildControlPanel() {
+        const panel = document.createElement('div');
+        panel.className = 'performance-control-panel';
+        panel.innerHTML = `
+            <style>
+                #live-touch-console .performance-control-panel {
+                    margin-top: 16px;
+                    background: rgba(0, 14, 26, 0.9);
+                    border: 1px solid rgba(0, 180, 255, 0.35);
+                    border-radius: 12px;
+                    padding: 12px;
+                    font-size: 0.7rem;
+                }
+
+                .performance-control-panel h3 {
+                    margin: 8px 0;
+                    font-size: 0.75rem;
+                    color: #7ff6ff;
+                    text-transform: uppercase;
+                    letter-spacing: 0.06em;
+                }
+
+                .toggle-row, .preset-row, .flourish-row {
+                    display: flex;
+                    gap: 8px;
+                    flex-wrap: wrap;
+                    margin-bottom: 8px;
+                }
+
+                .toggle-row button {
+                    flex: 1 1 80px;
+                    background: rgba(0, 60, 100, 0.6);
+                    border: 1px solid rgba(0, 200, 255, 0.4);
+                    border-radius: 8px;
+                    color: #c8f6ff;
+                    padding: 6px 8px;
+                    cursor: pointer;
+                    transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+                }
+
+                .toggle-row button.active {
+                    background: linear-gradient(120deg, #00f6ff, #0094ff);
+                    color: #00111f;
+                    border-color: rgba(0, 255, 255, 0.8);
+                }
+
+                .preset-row input, .flourish-row input, .flourish-row select, .preset-row select {
+                    flex: 1 1 120px;
+                    background: rgba(0, 40, 70, 0.8);
+                    color: #e0f8ff;
+                    border: 1px solid rgba(0, 200, 255, 0.4);
+                    border-radius: 6px;
+                    padding: 5px 6px;
+                }
+
+                .preset-row button, .flourish-row button {
+                    flex: 0 0 auto;
+                    background: rgba(0, 80, 120, 0.7);
+                    border: 1px solid rgba(0, 200, 255, 0.5);
+                    color: #dffbff;
+                    border-radius: 6px;
+                    padding: 5px 10px;
+                    cursor: pointer;
+                }
+
+                .preset-row button:hover, .flourish-row button:hover, .toggle-row button:hover {
+                    background: rgba(0, 160, 220, 0.9);
+                }
+            </style>
+            <div class="panel-section">
+                <h3>Audio Reactivity</h3>
+                <div class="toggle-row">
+                    <button data-band="master">Audio</button>
+                    <button data-band="bass">Bass</button>
+                    <button data-band="mid">Mid</button>
+                    <button data-band="high">High</button>
+                    <button data-band="energy">Energy</button>
+                </div>
+            </div>
+            <div class="panel-section">
+                <h3>Presets</h3>
+                <div class="preset-row">
+                    <input type="text" class="preset-name" placeholder="Preset name" />
+                    <input type="number" class="preset-duration" placeholder="Transition (ms)" min="0" value="1200" />
+                    <button data-action="save-preset">Save</button>
+                </div>
+                <div class="preset-row">
+                    <select class="preset-select"></select>
+                    <button data-action="load-preset">Load</button>
+                    <button data-action="delete-preset">Delete</button>
+                </div>
+            </div>
+            <div class="panel-section">
+                <h3>Flourishes</h3>
+                <div class="flourish-row">
+                    <input type="text" class="flourish-name" placeholder="Flourish name" />
+                    <input type="number" class="flourish-duration" placeholder="Duration (ms)" value="1000" min="0" />
+                    <input type="number" class="flourish-hold" placeholder="Hold (ms)" value="0" min="0" />
+                    <button data-action="add-step">Add Step</button>
+                </div>
+                <div class="flourish-row">
+                    <select class="flourish-select"></select>
+                    <button data-action="play-flourish">Play</button>
+                    <button data-action="clear-flourish">Clear</button>
+                </div>
+                <div class="flourish-row">
+                    <select class="reactive-band">
+                        <option value="energy">Energy</option>
+                        <option value="bass">Bass</option>
+                        <option value="mid">Mid</option>
+                        <option value="high">High</option>
+                    </select>
+                    <input type="number" class="reactive-threshold" value="0.85" step="0.05" min="0" max="1" />
+                    <input type="number" class="reactive-cooldown" value="2000" min="0" />
+                    <button data-action="set-reactive">Set Reactive</button>
+                </div>
+            </div>
+        `;
+
+        this.touchPadConsole.root.appendChild(panel);
+
+        this.audioButtons = panel.querySelectorAll('.toggle-row button');
+        this.presetNameInput = panel.querySelector('.preset-name');
+        this.presetDurationInput = panel.querySelector('.preset-duration');
+        this.presetSelect = panel.querySelector('.preset-select');
+        this.flourishNameInput = panel.querySelector('.flourish-name');
+        this.flourishDurationInput = panel.querySelector('.flourish-duration');
+        this.flourishHoldInput = panel.querySelector('.flourish-hold');
+        this.flourishSelect = panel.querySelector('.flourish-select');
+        this.reactiveBandSelect = panel.querySelector('.reactive-band');
+        this.reactiveThresholdInput = panel.querySelector('.reactive-threshold');
+        this.reactiveCooldownInput = panel.querySelector('.reactive-cooldown');
+
+        panel.querySelector('[data-action="save-preset"]').addEventListener('click', () => this.savePreset());
+        panel.querySelector('[data-action="load-preset"]').addEventListener('click', () => this.loadPreset());
+        panel.querySelector('[data-action="delete-preset"]').addEventListener('click', () => this.deletePreset());
+        panel.querySelector('[data-action="add-step"]').addEventListener('click', () => this.addFlourishStep());
+        panel.querySelector('[data-action="play-flourish"]').addEventListener('click', () => this.playFlourish());
+        panel.querySelector('[data-action="clear-flourish"]').addEventListener('click', () => this.clearFlourish());
+        panel.querySelector('[data-action="set-reactive"]').addEventListener('click', () => this.configureReactiveFlourish());
+
+        this.audioButtons.forEach(button => {
+            button.addEventListener('click', () => this.toggleAudio(button.dataset.band));
+        });
+
+        this.syncAudioUI();
+        this.updatePresetSelect();
+        this.updateFlourishSelect();
+    }
+
+    toggleAudio(band) {
+        if (band === 'master') {
+            this.audioEnabled = !this.audioEnabled;
+            this.applyAudioState();
+        } else {
+            this.audioBands[band] = !this.audioBands[band];
+            this.applyAudioState();
+        }
+    }
+
+    applyAudioState() {
+        if (this.reactivityManager?.setState) {
+            this.reactivityManager.setState({
+                audio: this.audioEnabled,
+                audioBands: { ...this.audioBands }
+            });
+        } else {
+            window.audioEnabled = this.audioEnabled;
+            AudioReactivityController.setBands(this.audioBands);
+        }
+        this.syncAudioUI();
+    }
+
+    syncAudioUI() {
+        this.audioButtons.forEach(button => {
+            if (button.dataset.band === 'master') {
+                button.classList.toggle('active', !!this.audioEnabled);
+                button.textContent = this.audioEnabled ? 'Audio ON' : 'Audio OFF';
+            } else {
+                button.classList.toggle('active', this.audioBands[button.dataset.band] !== false);
+            }
+        });
+    }
+
+    savePreset() {
+        const name = (this.presetNameInput.value || '').trim();
+        if (!name) {
+            alert('Enter a preset name');
+            return;
+        }
+        this.presetManager.savePreset(name);
+        this.updatePresetSelect(name);
+    }
+
+    loadPreset() {
+        const name = this.presetSelect.value;
+        if (!name) return;
+        const duration = parseInt(this.presetDurationInput.value, 10);
+        if (duration > 0) {
+            this.presetManager.loadPreset(name, { duration });
+        } else {
+            this.presetManager.loadPreset(name);
+        }
+    }
+
+    deletePreset() {
+        const name = this.presetSelect.value;
+        if (!name) return;
+        this.presetManager.deletePreset(name);
+        this.updatePresetSelect();
+    }
+
+    updatePresetSelect(selected) {
+        const names = this.presetManager.getPresetNames();
+        this.presetSelect.innerHTML = names.map(name => `<option value="${name}">${name}</option>`).join('');
+        if (selected && names.includes(selected)) {
+            this.presetSelect.value = selected;
+        }
+    }
+
+    addFlourishStep() {
+        const name = (this.flourishNameInput.value || '').trim();
+        if (!name) {
+            alert('Enter a flourish name');
+            return;
+        }
+        if (!this.presetManager.flourishes.has(name)) {
+            this.presetManager.startFlourish(name);
+        }
+        const duration = Math.max(0, parseInt(this.flourishDurationInput.value, 10) || 0);
+        const hold = Math.max(0, parseInt(this.flourishHoldInput.value, 10) || 0);
+        this.presetManager.addFlourishStep(name, {
+            state: this.collectCurrentParameters(),
+            duration,
+            hold
+        });
+        this.updateFlourishSelect(name);
+    }
+
+    playFlourish() {
+        const name = this.flourishSelect.value || this.flourishNameInput.value;
+        if (!name) return;
+        this.presetManager.triggerFlourish(name);
+    }
+
+    clearFlourish() {
+        const name = this.flourishSelect.value || this.flourishNameInput.value;
+        if (!name) return;
+        this.presetManager.clearFlourish(name);
+        if (this.reactiveFlourish === name) {
+            this.reactiveFlourish = null;
+        }
+        this.updateFlourishSelect();
+    }
+
+    configureReactiveFlourish() {
+        const name = this.flourishSelect.value || this.flourishNameInput.value;
+        if (!name) return;
+        this.reactiveFlourish = name;
+        this.reactiveConfig = {
+            band: this.reactiveBandSelect.value,
+            threshold: parseFloat(this.reactiveThresholdInput.value) || 0.85,
+            cooldown: parseInt(this.reactiveCooldownInput.value, 10) || 2000,
+            lastTrigger: 0
+        };
+        this.presetManager.setFlourishReactive(name, this.reactiveConfig);
+    }
+
+    updateFlourishSelect(selected) {
+        const names = this.presetManager.getFlourishNames();
+        this.flourishSelect.innerHTML = names.map(name => `<option value="${name}">${name}</option>`).join('');
+        if (selected && names.includes(selected)) {
+            this.flourishSelect.value = selected;
+        }
+    }
+
+    monitorAudio() {
+        const step = () => {
+            const bands = AudioReactivityController.getFilteredBands();
+            if (bands && this.reactiveFlourish) {
+                const value = bands[this.reactiveConfig.band] ?? bands.energy ?? 0;
+                const now = performance.now();
+                if (value >= this.reactiveConfig.threshold && (now - this.reactiveConfig.lastTrigger) > this.reactiveConfig.cooldown) {
+                    this.presetManager.triggerFlourish(this.reactiveFlourish);
+                    this.reactiveConfig.lastTrigger = now;
+                }
+            }
+            this.monitorHandle = requestAnimationFrame(step);
+        };
+        this.monitorHandle = requestAnimationFrame(step);
+    }
+
+    destroy() {
+        if (this.monitorHandle) {
+            cancelAnimationFrame(this.monitorHandle);
+            this.monitorHandle = null;
+        }
+        if (this.touchPadConsole) {
+            this.touchPadConsole.destroy();
+        }
+    }
+}
+
+window.LivePerformanceEngine = LivePerformanceEngine;

--- a/src/core/PerformancePresetManager.js
+++ b/src/core/PerformancePresetManager.js
@@ -1,0 +1,212 @@
+/**
+ * PerformancePresetManager
+ * Handles saving/loading live performance parameter presets and
+ * executing choreographed flourish sequences.
+ */
+export class PerformancePresetManager {
+    constructor({ schema = {}, captureState, applyParameter } = {}) {
+        this.schema = schema;
+        this.captureState = captureState || (() => ({}));
+        this.applyParameter = applyParameter || (() => {});
+
+        this.presets = new Map();
+        this.flourishes = new Map();
+        this.currentLiveState = {};
+        this.isPlayingFlourish = false;
+        this.activeFlourish = null;
+        this.pendingFrame = null;
+
+        this.easingFunctions = {
+            linear: (t) => t,
+            easeInQuad: (t) => t * t,
+            easeOutQuad: (t) => t * (2 - t),
+            easeInOutQuad: (t) => (t < 0.5) ? 2 * t * t : -1 + (4 - 2 * t) * t,
+            easeOutCubic: (t) => (--t) * t * t + 1,
+            easeInOutCubic: (t) => t < 0.5
+                ? 4 * t * t * t
+                : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
+        };
+    }
+
+    /**
+     * Normalize value according to schema limits
+     */
+    normalizeValue(param, value) {
+        const spec = this.schema?.[param];
+        if (!spec) return value;
+
+        const min = spec.min ?? 0;
+        const max = spec.max ?? 1;
+        let next = value;
+
+        if (typeof next === 'number') {
+            if (Number.isFinite(min)) next = Math.max(min, next);
+            if (Number.isFinite(max)) next = Math.min(max, next);
+        }
+
+        if (spec.type === 'integer') {
+            next = Math.round(next);
+        }
+
+        return next;
+    }
+
+    /**
+     * Save a preset
+     */
+    savePreset(name, state = this.captureState()) {
+        if (!name) throw new Error('Preset name is required');
+        const normalized = {};
+        Object.entries(state).forEach(([param, value]) => {
+            normalized[param] = this.normalizeValue(param, value);
+        });
+        this.presets.set(name, normalized);
+        return normalized;
+    }
+
+    /**
+     * Remove a preset
+     */
+    deletePreset(name) {
+        this.presets.delete(name);
+    }
+
+    /**
+     * Apply state immediately
+     */
+    applyState(state, { recordLive = true } = {}) {
+        if (!state) return;
+        Object.entries(state).forEach(([param, value]) => {
+            const normalized = this.normalizeValue(param, value);
+            this.applyParameter(param, normalized);
+            if (recordLive) {
+                this.currentLiveState[param] = normalized;
+            }
+        });
+    }
+
+    /**
+     * Load preset optionally with transition
+     */
+    loadPreset(name, options = {}) {
+        const preset = this.presets.get(name);
+        if (!preset) return false;
+
+        if (options.duration && options.duration > 0) {
+            return this.animateTransition(preset, options);
+        }
+
+        this.applyState(preset);
+        return true;
+    }
+
+    /**
+     * Animate transition to target state
+     */
+    animateTransition(targetState, { duration = 1000, easing = 'easeInOutQuad', onComplete } = {}) {
+        if (this.pendingFrame) {
+            cancelAnimationFrame(this.pendingFrame);
+            this.pendingFrame = null;
+        }
+
+        const startState = { ...this.captureState(), ...this.currentLiveState };
+        const keys = Array.from(new Set([...Object.keys(startState), ...Object.keys(targetState)]));
+        const easingFn = this.easingFunctions[easing] || this.easingFunctions.easeInOutQuad;
+        const startTime = performance.now();
+
+        return new Promise((resolve) => {
+            const step = (now) => {
+                const t = Math.min(1, (now - startTime) / duration);
+                const progress = easingFn(t);
+                const frameState = {};
+
+                keys.forEach((param) => {
+                    const startValue = startState[param] ?? targetState[param];
+                    const endValue = targetState[param] ?? startState[param];
+                    if (startValue === undefined || endValue === undefined) return;
+                    const next = startValue + (endValue - startValue) * progress;
+                    frameState[param] = this.normalizeValue(param, next);
+                });
+
+                this.applyState(frameState, { recordLive: true });
+
+                if (t < 1) {
+                    this.pendingFrame = requestAnimationFrame(step);
+                } else {
+                    this.pendingFrame = null;
+                    if (typeof onComplete === 'function') onComplete();
+                    resolve(true);
+                }
+            };
+
+            this.pendingFrame = requestAnimationFrame(step);
+        });
+    }
+
+    /**
+     * Record live parameter change
+     */
+    recordLiveValue(param, value) {
+        this.currentLiveState[param] = this.normalizeValue(param, value);
+    }
+
+    /**
+     * Start recording flourish
+     */
+    startFlourish(name) {
+        if (!name) throw new Error('Flourish name required');
+        this.flourishes.set(name, { steps: [], reactive: false, metadata: {} });
+        return this.flourishes.get(name);
+    }
+
+    addFlourishStep(name, { state = this.captureState(), duration = 1000, easing = 'easeInOutQuad', hold = 0 } = {}) {
+        const flourish = this.flourishes.get(name);
+        if (!flourish) throw new Error(`Flourish ${name} not found`);
+        flourish.steps.push({ state, duration, easing, hold });
+        return flourish.steps.length;
+    }
+
+    setFlourishReactive(name, reactiveConfig = {}) {
+        const flourish = this.flourishes.get(name);
+        if (!flourish) throw new Error(`Flourish ${name} not found`);
+        flourish.reactive = true;
+        flourish.metadata = {
+            threshold: reactiveConfig.threshold ?? 0.85,
+            band: reactiveConfig.band || 'energy',
+            cooldown: reactiveConfig.cooldown ?? 2000,
+            lastTrigger: 0
+        };
+    }
+
+    clearFlourish(name) {
+        this.flourishes.delete(name);
+    }
+
+    async triggerFlourish(name) {
+        const flourish = this.flourishes.get(name);
+        if (!flourish || flourish.steps.length === 0) return false;
+        if (this.isPlayingFlourish) return false;
+
+        this.isPlayingFlourish = true;
+        this.activeFlourish = name;
+
+        for (const step of flourish.steps) {
+            await this.animateTransition(step.state, { duration: step.duration, easing: step.easing });
+            if (step.hold) {
+                await new Promise((resolve) => setTimeout(resolve, step.hold));
+            }
+        }
+
+        this.isPlayingFlourish = false;
+        this.activeFlourish = null;
+        return true;
+    }
+
+    getPresetNames() {
+        return Array.from(this.presets.keys());
+    }
+
+    getFlourishNames() {
+        return Array.from(this.flourishes.keys());
+    }
+}

--- a/src/core/PolychoraSystem.js
+++ b/src/core/PolychoraSystem.js
@@ -1,6 +1,8 @@
+import { AudioReactivityController } from './AudioReactivityController.js';
+
 /**
  * Polychora System - 5-Layer Glassmorphic 4D Polytope Renderer
- * 
+ *
  * Features:
  * - 5 layered canvases (background, shadow, content, highlight, accent)
  * - Real 4D polytope mathematics with proper distance functions
@@ -394,13 +396,14 @@ class PolychoraVisualizer {
         let dimension = parameters.dimension || 3.8;
         let hue = parameters.hue || 280;
         
-        if (window.audioEnabled && window.audioReactive) {
+        const audioBands = AudioReactivityController.getFilteredBands();
+        if (audioBands) {
             // Polychora audio mapping: Bass drives 4D rotation, Mid affects cross-section, High affects glow
-            rot4dXW += window.audioReactive.bass * 3.0;        // Bass rotates through XW plane
-            rot4dYW += window.audioReactive.mid * 2.5;         // Mid rotates through YW plane  
-            rot4dZW += window.audioReactive.high * 2.0;        // High rotates through ZW plane
-            dimension += window.audioReactive.energy * 0.5;    // Energy affects 4D cross-section depth
-            hue += window.audioReactive.bass * 60;             // Bass affects polytope color
+            rot4dXW += audioBands.bass * 3.0;        // Bass rotates through XW plane
+            rot4dYW += audioBands.mid * 2.5;         // Mid rotates through YW plane
+            rot4dZW += audioBands.high * 2.0;        // High rotates through ZW plane
+            dimension += audioBands.energy * 0.5;    // Energy affects 4D cross-section depth
+            hue += audioBands.bass * 60;             // Bass affects polytope color
         }
         
         // Set uniforms with audio-reactive 4D rotation and advanced glass effects

--- a/src/core/PolychoraSystemNew.js
+++ b/src/core/PolychoraSystemNew.js
@@ -12,6 +12,7 @@
  */
 
 import { ParameterManager } from './Parameters.js';
+import { AudioReactivityController } from './AudioReactivityController.js';
 
 /**
  * True4DPolychoraVisualizer - Individual layer renderer for 4D polytopes
@@ -439,9 +440,9 @@ class True4DPolychoraVisualizer {
         this.setUniform('u_layerColor', this.layerColor);
         
         // Audio reactivity - DNA pattern
-        this.setUniform('u_bass', window.audioReactive?.bass || 0);
-        this.setUniform('u_mid', window.audioReactive?.mid || 0);
-        this.setUniform('u_high', window.audioReactive?.high || 0);
+        this.setUniform('u_bass', AudioReactivityController.getBandValue('bass'));
+        this.setUniform('u_mid', AudioReactivityController.getBandValue('mid'));
+        this.setUniform('u_high', AudioReactivityController.getBandValue('high'));
         
         // Draw quad
         this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
@@ -611,19 +612,20 @@ export class NewPolychoraEngine {
             };
             
             // Audio-reactive 4D rotation enhancement
-            if (window.audioReactive) {
+            const audioBands = AudioReactivityController.getFilteredBands();
+            if (audioBands) {
                 // Bass drives 4D rotation through XW plane
-                params.rot4dXW += window.audioReactive.bass * 2.0;
+                params.rot4dXW += audioBands.bass * 2.0;
                 // Mid drives YW plane rotation
-                params.rot4dYW += window.audioReactive.mid * 1.5;
+                params.rot4dYW += audioBands.mid * 1.5;
                 // High drives ZW plane rotation
-                params.rot4dZW += window.audioReactive.high * 1.0;
-                
+                params.rot4dZW += audioBands.high * 1.0;
+
                 // Audio affects polytope morphing
-                params.morphFactor += window.audioReactive.bass * 0.5;
-                
+                params.morphFactor += audioBands.bass * 0.5;
+
                 // Color shifting based on audio
-                params.hue += (window.audioReactive.mid + window.audioReactive.high) * 30;
+                params.hue += (audioBands.mid + audioBands.high) * 30;
             }
             
             // Render all layers - DNA pattern

--- a/src/core/ReactivityManager.js
+++ b/src/core/ReactivityManager.js
@@ -9,11 +9,13 @@ export class ReactivityManager {
         
         // Global reactivity state
         this.enabled = true; // Master toggle (controlled by existing global toggle)
-        
+
         // Individual category toggles
         this.mouseEnabled = true;
         this.clickEnabled = true;
         this.scrollEnabled = true;
+        this.audioEnabled = false;
+        this.audioBands = { bass: true, mid: true, high: true, energy: true };
         
         // Current active system (receives parameter updates)
         this.activeSystem = null;
@@ -310,6 +312,32 @@ export class ReactivityManager {
     setEnabled(enabled) {
         this.enabled = enabled;
         console.log(`⚡ Global reactivity: ${enabled ? 'ON' : 'OFF'}`);
+    }
+
+    /**
+     * Receive updates from UnifiedReactivityManager for audio/device state
+     */
+    updateReactivityState(state) {
+        if (!state) return;
+
+        if (typeof state.interactivity === 'boolean') {
+            this.enabled = state.interactivity;
+        }
+
+        if (typeof state.audio === 'boolean') {
+            this.audioEnabled = state.audio;
+        }
+
+        if (state.audioBands) {
+            this.audioBands = {
+                ...this.audioBands,
+                ...state.audioBands
+            };
+        }
+
+        if (state.system) {
+            this.activeSystemName = state.system;
+        }
     }
 }
 

--- a/src/core/UnifiedReactivityManager.js
+++ b/src/core/UnifiedReactivityManager.js
@@ -1,3 +1,5 @@
+import { AudioReactivityController } from './AudioReactivityController.js';
+
 /**
  * Unified Reactivity Manager for VIB34D
  * Handles reactivity parameters for all 4 systems consistently
@@ -12,6 +14,7 @@ export class UnifiedReactivityManager {
             click: { faceted: true, quantum: false, holographic: false, polychora: false, mixed: false },
             scroll: { faceted: true, quantum: false, holographic: false, polychora: false, mixed: false },
             audio: false,
+            audioBands: { bass: true, mid: true, high: true, energy: true },
             interactivity: true,
             deviceTilt: false
         };
@@ -37,6 +40,7 @@ export class UnifiedReactivityManager {
             click: { ...this.reactivityState.click },
             scroll: { ...this.reactivityState.scroll },
             audio: this.reactivityState.audio,
+            audioBands: { ...this.reactivityState.audioBands },
             interactivity: this.reactivityState.interactivity,
             deviceTilt: this.reactivityState.deviceTilt,
             
@@ -65,6 +69,7 @@ export class UnifiedReactivityManager {
         if (state.click) this.reactivityState.click = { ...state.click };
         if (state.scroll) this.reactivityState.scroll = { ...state.scroll };
         if (typeof state.audio === 'boolean') this.reactivityState.audio = state.audio;
+        if (state.audioBands) this.reactivityState.audioBands = { ...this.reactivityState.audioBands, ...state.audioBands };
         if (typeof state.interactivity === 'boolean') this.reactivityState.interactivity = state.interactivity;
         if (typeof state.deviceTilt === 'boolean') this.reactivityState.deviceTilt = state.deviceTilt;
         
@@ -100,9 +105,10 @@ export class UnifiedReactivityManager {
         this.reactivityState.mouse[systemDefaults.mouse] = true;
         this.reactivityState.click[systemDefaults.click] = true;
         this.reactivityState.scroll[systemDefaults.scroll] = true;
-        
+
         // Audio defaults
         this.reactivityState.audio = system === 'holographic';
+        this.reactivityState.audioBands = { bass: true, mid: true, high: true, energy: true };
         
         this.currentSystem = system;
         this.syncToGlobals();
@@ -129,6 +135,7 @@ export class UnifiedReactivityManager {
     syncToGlobals() {
         // Sync to window globals for engine integration
         window.audioEnabled = this.reactivityState.audio;
+        AudioReactivityController.setBands(this.reactivityState.audioBands);
         window.interactivityEnabled = this.reactivityState.interactivity;
         
         // Device tilt integration

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -4,6 +4,7 @@
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { AudioReactivityController } from './AudioReactivityController.js';
 
 export class IntegratedHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
@@ -596,11 +597,12 @@ void main() {
         let hue = this.params.hue;
         let intensity = this.params.intensity;
         
-        if (window.audioEnabled && window.audioReactive) {
+        const audioBands = AudioReactivityController.getFilteredBands();
+        if (audioBands) {
             // Faceted audio mapping: Bass affects grid density, Mid affects hue, High affects intensity
-            gridDensity += window.audioReactive.bass * 30;  // Bass makes patterns denser
-            hue += window.audioReactive.mid * 60;           // Mid frequencies shift colors
-            intensity += window.audioReactive.high * 0.4;   // High frequencies brighten
+            gridDensity += audioBands.bass * 30;  // Bass makes patterns denser
+            hue += audioBands.mid * 60;           // Mid frequencies shift colors
+            intensity += audioBands.high * 0.4;   // High frequencies brighten
         }
         
         this.gl.uniform1f(this.uniforms.gridDensity, Math.min(100, gridDensity));

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -1,3 +1,5 @@
+import { AudioReactivityController } from '../core/AudioReactivityController.js';
+
 /**
  * Core Holographic Visualizer - Clean WebGL rendering engine
  * Extracted from working system, no debugging mess
@@ -785,14 +787,15 @@ export class HolographicVisualizer {
         // 🎵 HOLOGRAPHIC AUDIO REACTIVITY - Direct and beautiful
         let audioDensity = 0, audioMorph = 0, audioSpeed = 0, audioChaos = 0, audioColor = 0;
         
-        if (window.audioEnabled && window.audioReactive) {
+        const audioBands = AudioReactivityController.getFilteredBands();
+        if (audioBands) {
             // Holographic audio mapping: Rich volumetric effects
-            audioDensity = window.audioReactive.bass * 1.5;     // Bass creates density in holographic layers
-            audioMorph = window.audioReactive.mid * 1.2;        // Mid frequencies morph the hologram
-            audioSpeed = window.audioReactive.high * 0.8;       // High frequencies speed up animation
-            audioChaos = window.audioReactive.energy * 0.6;     // Energy creates chaotic holographic distortion
-            audioColor = window.audioReactive.bass * 45;        // Bass affects holographic color shifts
-            
+            audioDensity = audioBands.bass * 1.5;     // Bass creates density in holographic layers
+            audioMorph = audioBands.mid * 1.2;        // Mid frequencies morph the hologram
+            audioSpeed = audioBands.high * 0.8;       // High frequencies speed up animation
+            audioChaos = audioBands.energy * 0.6;     // Energy creates chaotic holographic distortion
+            audioColor = audioBands.bass * 45;        // Bass affects holographic color shifts
+
             // Debug logging every 10 seconds to verify holographic audio reactivity
             if (Date.now() % 10000 < 16) {
                 console.log(`✨ Holographic audio reactivity: Density+${audioDensity.toFixed(2)} Morph+${audioMorph.toFixed(2)} Speed+${audioSpeed.toFixed(2)} Chaos+${audioChaos.toFixed(2)} Color+${audioColor.toFixed(1)}`);

--- a/src/quantum/QuantumVisualizer.js
+++ b/src/quantum/QuantumVisualizer.js
@@ -5,6 +5,7 @@
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { AudioReactivityController } from '../core/AudioReactivityController.js';
 
 export class QuantumHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
@@ -897,16 +898,17 @@ void main() {
         let hue = this.params.hue;
         let chaos = this.params.chaos;
         
-        if (window.audioEnabled && window.audioReactive) {
+        const audioBands = AudioReactivityController.getFilteredBands();
+        if (audioBands) {
             // Quantum audio mapping: Enhanced complex lattice response
-            gridDensity += window.audioReactive.bass * 40;      // Bass creates dense lattice structures
-            morphFactor += window.audioReactive.mid * 1.2;      // Mid frequencies morph the geometry
-            hue += window.audioReactive.high * 120;             // High frequencies shift colors dramatically
-            chaos += window.audioReactive.energy * 0.6;         // Overall energy adds chaos/complexity
-            
+            gridDensity += audioBands.bass * 40;      // Bass creates dense lattice structures
+            morphFactor += audioBands.mid * 1.2;      // Mid frequencies morph the geometry
+            hue += audioBands.high * 120;             // High frequencies shift colors dramatically
+            chaos += audioBands.energy * 0.6;         // Overall energy adds chaos/complexity
+
             // Debug logging every 10 seconds to verify audio reactivity is working
             if (Date.now() % 10000 < 16) {
-                console.log(`🌌 Quantum audio reactivity: Density+${(window.audioReactive.bass * 40).toFixed(1)} Morph+${(window.audioReactive.mid * 1.2).toFixed(2)} Hue+${(window.audioReactive.high * 120).toFixed(1)} Chaos+${(window.audioReactive.energy * 0.6).toFixed(2)}`);
+                console.log(`🌌 Quantum audio reactivity: Density+${(audioBands.bass * 40).toFixed(1)} Morph+${(audioBands.mid * 1.2).toFixed(2)} Hue+${(audioBands.high * 120).toFixed(1)} Chaos+${(audioBands.energy * 0.6).toFixed(2)}`);
             }
         }
         

--- a/src/ui/LiveTouchPadConsole.js
+++ b/src/ui/LiveTouchPadConsole.js
@@ -1,0 +1,387 @@
+/**
+ * LiveTouchPadConsole
+ * Multi-touch performance console with configurable axes per touch pad.
+ */
+export class LiveTouchPadConsole {
+    constructor({
+        parameterSchema = {},
+        padCount = 3,
+        container = document.body,
+        onParameterChange = () => {},
+        onAxisChange = () => {}
+    } = {}) {
+        this.schema = parameterSchema;
+        this.padCount = padCount;
+        this.container = container;
+        this.onParameterChange = onParameterChange;
+        this.onAxisChange = onAxisChange;
+
+        this.padStates = new Map();
+
+        this.parameterOptions = this.buildParameterOptions();
+        this.buildConsole();
+    }
+
+    buildParameterOptions() {
+        const baseOptions = Object.keys(this.schema);
+        if (!baseOptions.includes('hue')) baseOptions.unshift('hue');
+        return baseOptions;
+    }
+
+    buildConsole() {
+        this.root = document.createElement('div');
+        this.root.id = 'live-touch-console';
+        this.root.innerHTML = `
+            <style>
+                #live-touch-console {
+                    position: fixed;
+                    left: 20px;
+                    bottom: 20px;
+                    width: 420px;
+                    max-width: calc(100vw - 40px);
+                    background: rgba(4, 8, 15, 0.9);
+                    border: 2px solid rgba(0, 255, 255, 0.4);
+                    border-radius: 14px;
+                    padding: 16px;
+                    z-index: 2100;
+                    color: #d6f6ff;
+                    font-family: 'Orbitron', sans-serif;
+                    backdrop-filter: blur(16px);
+                    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+                }
+
+                #live-touch-console h2 {
+                    margin: 0 0 12px;
+                    font-size: 1rem;
+                    color: #00f6ff;
+                    letter-spacing: 0.08em;
+                    text-shadow: 0 0 12px rgba(0, 255, 255, 0.4);
+                }
+
+                .pad-grid {
+                    display: grid;
+                    grid-template-columns: 1fr;
+                    gap: 12px;
+                }
+
+                .touch-pad {
+                    background: rgba(0, 10, 25, 0.9);
+                    border: 1px solid rgba(0, 200, 255, 0.4);
+                    border-radius: 12px;
+                    padding: 12px;
+                }
+
+                .pad-header {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 8px;
+                    font-size: 0.8rem;
+                    color: #9ee8ff;
+                }
+
+                .axis-config {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 6px;
+                    margin-bottom: 8px;
+                }
+
+                .axis-config label {
+                    display: flex;
+                    flex-direction: column;
+                    font-size: 0.65rem;
+                    color: #7fc4ff;
+                }
+
+                .axis-config select {
+                    margin-top: 2px;
+                    background: rgba(0, 40, 70, 0.8);
+                    color: #e0f8ff;
+                    border: 1px solid rgba(0, 200, 255, 0.4);
+                    border-radius: 6px;
+                    padding: 4px;
+                    font-size: 0.65rem;
+                }
+
+                .pad-surface {
+                    position: relative;
+                    width: 100%;
+                    height: 150px;
+                    border-radius: 12px;
+                    background: radial-gradient(circle at center, rgba(0, 120, 255, 0.2), rgba(0, 40, 80, 0.65));
+                    overflow: hidden;
+                    touch-action: none;
+                }
+
+                .pad-surface::after {
+                    content: '';
+                    position: absolute;
+                    inset: 0;
+                    border-radius: 12px;
+                    border: 1px dashed rgba(0, 255, 255, 0.2);
+                }
+
+                .pad-status {
+                    margin-top: 6px;
+                    font-size: 0.65rem;
+                    display: flex;
+                    justify-content: space-between;
+                    color: #b7f1ff;
+                }
+
+                @media (max-width: 768px) {
+                    #live-touch-console {
+                        width: auto;
+                        right: 20px;
+                        left: 20px;
+                    }
+                }
+            </style>
+            <h2>LIVE PERFORMANCE CONSOLE</h2>
+            <div class="pad-grid"></div>
+        `;
+
+        this.container.appendChild(this.root);
+        this.padGrid = this.root.querySelector('.pad-grid');
+
+        for (let i = 0; i < this.padCount; i++) {
+            this.createPad(i);
+        }
+    }
+
+    createPad(index) {
+        const pad = document.createElement('div');
+        pad.className = 'touch-pad';
+        pad.dataset.index = index;
+
+        const axisOptions = this.parameterOptions.map(param => `<option value="${param}">${param}</option>`).join('');
+        const noneOption = '<option value="none">none</option>';
+
+        const defaultMappings = this.getDefaultMappings(index);
+
+        pad.innerHTML = `
+            <div class="pad-header">
+                <span>Pad ${String.fromCharCode(65 + index)}</span>
+                <span class="pointer-count">0 touches</span>
+            </div>
+            <div class="axis-config">
+                <label>X Axis
+                    <select class="axis-select" data-axis="x">
+                        ${axisOptions}
+                    </select>
+                </label>
+                <label>Y Axis
+                    <select class="axis-select" data-axis="y">
+                        ${axisOptions}
+                    </select>
+                </label>
+                <label>Pinch Axis
+                    <select class="axis-select" data-axis="pinch">
+                        ${noneOption}${axisOptions}
+                    </select>
+                </label>
+                <label>Rotation Axis
+                    <select class="axis-select" data-axis="rotation">
+                        ${noneOption}${axisOptions}
+                    </select>
+                </label>
+            </div>
+            <div class="pad-surface"></div>
+            <div class="pad-status">
+                <span class="status-position">X: 0.50 Y: 0.50</span>
+                <span class="status-gesture">Pinch: 0.50 Rot: 0.50</span>
+            </div>
+        `;
+
+        this.padGrid.appendChild(pad);
+
+        const selects = pad.querySelectorAll('.axis-select');
+        selects.forEach(select => {
+            const axis = select.dataset.axis;
+            const value = defaultMappings[axis] || (axis === 'pinch' || axis === 'rotation' ? 'none' : this.parameterOptions[0]);
+            select.value = value;
+            select.addEventListener('change', () => {
+                this.updatePadMapping(index, axis, select.value);
+            });
+        });
+
+        const padState = {
+            index,
+            element: pad,
+            surface: pad.querySelector('.pad-surface'),
+            mappings: { ...defaultMappings },
+            pointers: new Map(),
+            baseDistance: null,
+            baseAngle: null
+        };
+
+        this.padStates.set(index, padState);
+        this.bindPadEvents(padState);
+    }
+
+    getDefaultMappings(index) {
+        const defaults = [
+            { x: 'rot4dXW', y: 'rot4dYW', pinch: 'rot4dZW', rotation: 'hue' },
+            { x: 'gridDensity', y: 'morphFactor', pinch: 'chaos', rotation: 'speed' },
+            { x: 'hue', y: 'saturation', pinch: 'intensity', rotation: 'dimension' }
+        ];
+        return defaults[index] || { x: this.parameterOptions[0], y: this.parameterOptions[1] || this.parameterOptions[0] };
+    }
+
+    bindPadEvents(padState) {
+        const surface = padState.surface;
+        surface.addEventListener('pointerdown', (event) => this.handlePointerDown(padState, event));
+        surface.addEventListener('pointermove', (event) => this.handlePointerMove(padState, event));
+        surface.addEventListener('pointerup', (event) => this.handlePointerEnd(padState, event));
+        surface.addEventListener('pointercancel', (event) => this.handlePointerEnd(padState, event));
+        surface.addEventListener('pointerout', (event) => this.handlePointerEnd(padState, event));
+    }
+
+    handlePointerDown(padState, event) {
+        event.preventDefault();
+        padState.surface.setPointerCapture(event.pointerId);
+        padState.pointers.set(event.pointerId, { clientX: event.clientX, clientY: event.clientY });
+        this.updateGestureBase(padState);
+        this.updateStatus(padState);
+    }
+
+    handlePointerMove(padState, event) {
+        if (!padState.pointers.has(event.pointerId)) return;
+        event.preventDefault();
+        padState.pointers.set(event.pointerId, { clientX: event.clientX, clientY: event.clientY });
+        this.processPadGesture(padState);
+    }
+
+    handlePointerEnd(padState, event) {
+        if (padState.pointers.has(event.pointerId)) {
+            padState.pointers.delete(event.pointerId);
+            if (padState.pointers.size < 2) {
+                padState.baseDistance = null;
+                padState.baseAngle = null;
+            }
+            this.updateStatus(padState);
+        }
+    }
+
+    updateGestureBase(padState) {
+        if (padState.pointers.size >= 2) {
+            const [p1, p2] = Array.from(padState.pointers.values());
+            padState.baseDistance = this.distance(p1, p2);
+            padState.baseAngle = this.angle(p1, p2);
+        }
+    }
+
+    processPadGesture(padState) {
+        const rect = padState.surface.getBoundingClientRect();
+        const normalized = this.computeNormalizedValues(padState, rect);
+        this.updateStatus(padState, normalized);
+        this.dispatchParameterUpdates(padState, normalized);
+    }
+
+    computeNormalizedValues(padState, rect) {
+        const pointers = Array.from(padState.pointers.values());
+        const count = pointers.length;
+
+        let centerX = 0.5;
+        let centerY = 0.5;
+        let pinch = 0.5;
+        let rotation = 0.5;
+
+        if (count >= 1) {
+            const avg = pointers.reduce((acc, point) => {
+                acc.x += point.clientX;
+                acc.y += point.clientY;
+                return acc;
+            }, { x: 0, y: 0 });
+            centerX = (avg.x / count - rect.left) / rect.width;
+            centerY = (avg.y / count - rect.top) / rect.height;
+        }
+
+        if (count >= 2) {
+            const [p1, p2] = pointers;
+            const distance = this.distance(p1, p2);
+            const diagonal = Math.sqrt(rect.width * rect.width + rect.height * rect.height);
+            pinch = distance / diagonal;
+            pinch = Math.max(0, Math.min(1, pinch));
+
+            const angle = this.angle(p1, p2);
+            const baseAngle = padState.baseAngle ?? angle;
+            let delta = angle - baseAngle;
+            while (delta > Math.PI) delta -= 2 * Math.PI;
+            while (delta < -Math.PI) delta += 2 * Math.PI;
+            rotation = (delta + Math.PI) / (2 * Math.PI);
+            rotation = Math.max(0, Math.min(1, rotation));
+        }
+
+        return {
+            x: Math.max(0, Math.min(1, centerX)),
+            y: Math.max(0, Math.min(1, 1 - centerY)),
+            pinch,
+            rotation,
+            count
+        };
+    }
+
+    dispatchParameterUpdates(padState, values) {
+        const mapParam = (param, normalized) => {
+            if (!param || param === 'none') return;
+            const schema = this.schema[param];
+            if (!schema) {
+                this.onParameterChange(param, normalized);
+                return;
+            }
+            const value = schema.min + (schema.max - schema.min) * normalized;
+            const finalValue = schema.type === 'integer' ? Math.round(value) : parseFloat(value.toFixed(4));
+            this.onParameterChange(param, finalValue);
+        };
+
+        mapParam(padState.mappings.x, values.x);
+        mapParam(padState.mappings.y, values.y);
+        mapParam(padState.mappings.pinch, values.pinch);
+        mapParam(padState.mappings.rotation, values.rotation);
+    }
+
+    updateStatus(padState, values = { x: 0.5, y: 0.5, pinch: 0.5, rotation: 0.5, count: padState.pointers.size }) {
+        const position = padState.element.querySelector('.status-position');
+        const gesture = padState.element.querySelector('.status-gesture');
+        const pointerCount = padState.element.querySelector('.pointer-count');
+
+        if (position) {
+            position.textContent = `X: ${values.x.toFixed(2)} Y: ${values.y.toFixed(2)}`;
+        }
+        if (gesture) {
+            gesture.textContent = `Pinch: ${values.pinch.toFixed(2)} Rot: ${values.rotation.toFixed(2)}`;
+        }
+        if (pointerCount) {
+            pointerCount.textContent = `${padState.pointers.size} touch${padState.pointers.size === 1 ? '' : 'es'}`;
+        }
+    }
+
+    updatePadMapping(index, axis, param) {
+        const padState = this.padStates.get(index);
+        if (!padState) return;
+        padState.mappings[axis] = param;
+        this.onAxisChange(index, { ...padState.mappings });
+    }
+
+    distance(p1, p2) {
+        const dx = p2.clientX - p1.clientX;
+        const dy = p2.clientY - p1.clientY;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    angle(p1, p2) {
+        const dx = p2.clientX - p1.clientX;
+        const dy = p2.clientY - p1.clientY;
+        return Math.atan2(dy, dx);
+    }
+
+    destroy() {
+        if (this.root) {
+            this.root.remove();
+            this.root = null;
+        }
+        this.padStates.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a LivePerformanceEngine that wires three configurable multitouch pads, preset storage, and choreographed flourish playback for stage use
- add an AudioReactivityController plus band-level toggles and propagate the filtered bands across all visualizer systems
- document the live performance workflow in the README and initialize the engine from the main index entry point

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc05caa6508329ab27b723e3f7b18c