### PR TITLE
Add configurable touchpad layout controls and shared parameter metadata

### DIFF
--- a/index-clean.html
+++ b/index-clean.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/reactivity.css">
     <link rel="stylesheet" href="styles/mobile.css">
     <link rel="stylesheet" href="styles/animations.css">
+    <link rel="stylesheet" href="styles/performance.css">
 </head>
 <body class="loading">
     <!-- Top Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VIB34D Engine - Canvas Explosion FIXED</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/performance.css">
     <style>
         * {
             margin: 0;

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -9,100 +9,203 @@ export class ParameterManager {
         this.params = {
             // Current variation
             variation: 0,
-            
+
             // 4D Polytopal Mathematics
             rot4dXW: 0.0,      // X-W plane rotation (-2 to 2)
-            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2) 
+            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2)
             rot4dZW: 0.0,      // Z-W plane rotation (-2 to 2)
             dimension: 3.5,    // Dimensional level (3.0 to 4.5)
-            
+
             // Holographic Visualization
-            gridDensity: 15,   // Geometric detail (4 to 30)
+            gridDensity: 15,   // Geometric detail (4 to 100)
             morphFactor: 1.0,  // Shape transformation (0 to 2)
             chaos: 0.2,        // Randomization level (0 to 1)
             speed: 1.0,        // Animation speed (0.1 to 3)
             hue: 200,          // Color rotation (0 to 360)
             intensity: 0.5,    // Visual intensity (0 to 1)
             saturation: 0.8,   // Color saturation (0 to 1)
-            
+
             // Geometry selection
             geometry: 0        // Current geometry type (0-7)
         };
-        
+
         // Parameter definitions for validation and UI
         this.parameterDefs = {
-            variation: { min: 0, max: 99, step: 1, type: 'int' },
-            rot4dXW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dYW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dZW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            dimension: { min: 3.0, max: 4.5, step: 0.01, type: 'float' },
-            gridDensity: { min: 4, max: 100, step: 0.1, type: 'float' },
-            morphFactor: { min: 0, max: 2, step: 0.01, type: 'float' },
-            chaos: { min: 0, max: 1, step: 0.01, type: 'float' },
-            speed: { min: 0.1, max: 3, step: 0.01, type: 'float' },
-            hue: { min: 0, max: 360, step: 1, type: 'int' },
-            intensity: { min: 0, max: 1, step: 0.01, type: 'float' },
-            saturation: { min: 0, max: 1, step: 0.01, type: 'float' },
-            geometry: { min: 0, max: 7, step: 1, type: 'int' }
+            variation: {
+                min: 0,
+                max: 99,
+                step: 1,
+                type: 'int',
+                label: 'Variation Index',
+                category: 'Global'
+            },
+            rot4dXW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: '4D Rotation X↔W',
+                category: '4D Rotation'
+            },
+            rot4dYW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: '4D Rotation Y↔W',
+                category: '4D Rotation'
+            },
+            rot4dZW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: '4D Rotation Z↔W',
+                category: '4D Rotation'
+            },
+            dimension: {
+                min: 3.0,
+                max: 4.5,
+                step: 0.01,
+                type: 'float',
+                label: 'Dimensional Drift',
+                category: '4D Rotation'
+            },
+            gridDensity: {
+                min: 4,
+                max: 100,
+                step: 0.1,
+                type: 'float',
+                label: 'Grid Density',
+                category: 'Geometry'
+            },
+            morphFactor: {
+                min: 0,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Morph Factor',
+                category: 'Geometry'
+            },
+            chaos: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Chaos Modulation',
+                category: 'Dynamics'
+            },
+            speed: {
+                min: 0.1,
+                max: 3,
+                step: 0.01,
+                type: 'float',
+                label: 'Animation Speed',
+                category: 'Dynamics'
+            },
+            hue: {
+                min: 0,
+                max: 360,
+                step: 1,
+                type: 'int',
+                label: 'Hue Orbit',
+                category: 'Color'
+            },
+            intensity: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Light Intensity',
+                category: 'Color'
+            },
+            saturation: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Color Saturation',
+                category: 'Color'
+            },
+            geometry: {
+                min: 0,
+                max: 7,
+                step: 1,
+                type: 'int',
+                label: 'Geometry Type',
+                category: 'Geometry'
+            }
         };
-        
+
         // Default parameter backup for reset
         this.defaults = { ...this.params };
+
+        // Event listeners for reactive extensions
+        this.listeners = new Set();
+
+        // Active interpolation bookkeeping
+        this._activeInterpolation = null;
+        this._interpolationFrame = null;
     }
-    
+
     /**
      * Get all current parameters
      */
     getAllParameters() {
         return { ...this.params };
     }
-    
-    /**
-     * Set a specific parameter with validation
-     */
-    setParameter(name, value) {
-        if (this.parameterDefs[name]) {
-            const def = this.parameterDefs[name];
-            
-            // Clamp value to valid range
-            value = Math.max(def.min, Math.min(def.max, value));
-            
-            // Apply type conversion
-            if (def.type === 'int') {
-                value = Math.round(value);
-            }
-            
-            this.params[name] = value;
-            return true;
-        }
-        
-        console.warn(`Unknown parameter: ${name}`);
-        return false;
-    }
-    
-    /**
-     * Set multiple parameters at once
-     */
-    setParameters(paramObj) {
-        for (const [name, value] of Object.entries(paramObj)) {
-            this.setParameter(name, value);
-        }
-    }
-    
+
     /**
      * Get a specific parameter value
      */
     getParameter(name) {
         return this.params[name];
     }
-    
+
+    /**
+     * Set a specific parameter with validation
+     */
+    setParameter(name, value, source = 'manual', options = {}) {
+        if (!this.parameterDefs[name]) {
+            console.warn(`Unknown parameter: ${name}`);
+            return false;
+        }
+
+        const clampedValue = this.clampToDefinition(name, value);
+        const previousValue = this.params[name];
+        const hasChanged = options.force
+            ? true
+            : this.hasMeaningfulChange(previousValue, clampedValue, this.parameterDefs[name]);
+
+        if (!hasChanged) {
+            return false;
+        }
+
+        this.params[name] = clampedValue;
+
+        if (!options.silent) {
+            this.emitChange(name, clampedValue, source);
+        }
+
+        return true;
+    }
+
+    /**
+     * Set multiple parameters at once
+     */
+    setParameters(paramObj, source = 'bulk', options = {}) {
+        for (const [name, value] of Object.entries(paramObj)) {
+            this.setParameter(name, value, source, options);
+        }
+    }
+
     /**
      * Set geometry type with validation
      */
     setGeometry(geometryType) {
-        this.setParameter('geometry', geometryType);
+        this.setParameter('geometry', geometryType, 'ui');
     }
-    
+
     /**
      * Update parameters from UI controls
      */
@@ -111,23 +214,21 @@ export class ParameterManager {
             'variationSlider', 'rot4dXW', 'rot4dYW', 'rot4dZW', 'dimension',
             'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue'
         ];
-        
+
         controlIds.forEach(id => {
             const element = document.getElementById(id);
-            if (element) {
-                const value = parseFloat(element.value);
-                
-                // Map slider IDs to parameter names
-                let paramName = id;
-                if (id === 'variationSlider') {
-                    paramName = 'variation';
-                }
-                
-                this.setParameter(paramName, value);
+            if (!element) return;
+
+            const value = parseFloat(element.value);
+            let paramName = id;
+            if (id === 'variationSlider') {
+                paramName = 'variation';
             }
+
+            this.setParameter(paramName, value, 'ui');
         });
     }
-    
+
     /**
      * Update UI display values from current parameters
      */
@@ -143,7 +244,7 @@ export class ParameterManager {
         this.updateSliderValue('chaos', this.params.chaos);
         this.updateSliderValue('speed', this.params.speed);
         this.updateSliderValue('hue', this.params.hue);
-        
+
         // Update display texts
         this.updateDisplayText('rot4dXWDisplay', this.params.rot4dXW.toFixed(2));
         this.updateDisplayText('rot4dYWDisplay', this.params.rot4dYW.toFixed(2));
@@ -153,94 +254,96 @@ export class ParameterManager {
         this.updateDisplayText('morphFactorDisplay', this.params.morphFactor.toFixed(2));
         this.updateDisplayText('chaosDisplay', this.params.chaos.toFixed(2));
         this.updateDisplayText('speedDisplay', this.params.speed.toFixed(2));
-        this.updateDisplayText('hueDisplay', this.params.hue + '°');
-        
-        // Update variation info
+        this.updateDisplayText('hueDisplay', `${this.params.hue}°`);
+
+        // Update variation info and geometry buttons
         this.updateVariationInfo();
-        
-        // Update geometry preset buttons
         this.updateGeometryButtons();
     }
-    
+
     updateSliderValue(id, value) {
         const element = document.getElementById(id);
         if (element) {
             element.value = value;
         }
     }
-    
+
     updateDisplayText(id, text) {
         const element = document.getElementById(id);
         if (element) {
             element.textContent = text;
         }
     }
-    
+
     updateVariationInfo() {
         const variationDisplay = document.getElementById('currentVariationDisplay');
-        if (variationDisplay) {
-            const geometryNames = [
-                'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
-                'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
-            ];
-            
-            const geometryType = Math.floor(this.params.variation / 4);
-            const geometryLevel = (this.params.variation % 4) + 1;
-            const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
-            
-            variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
-            
-            if (this.params.variation < 30) {
-                variationDisplay.textContent += ` ${geometryLevel}`;
-            }
+        if (!variationDisplay) return;
+
+        const geometryNames = [
+            'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
+            'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
+        ];
+
+        const geometryType = Math.floor(this.params.variation / 4);
+        const geometryLevel = (this.params.variation % 4) + 1;
+        const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
+
+        variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
+
+        if (this.params.variation < 30) {
+            variationDisplay.textContent += ` ${geometryLevel}`;
         }
     }
-    
+
     updateGeometryButtons() {
         document.querySelectorAll('[data-geometry]').forEach(btn => {
-            btn.classList.toggle('active', parseInt(btn.dataset.geometry) === this.params.geometry);
+            const isActive = parseInt(btn.dataset.geometry) === this.params.geometry;
+            btn.classList.toggle('active', isActive);
         });
     }
-    
+
     /**
      * Randomize all parameters
      */
     randomizeAll() {
-        this.params.rot4dXW = Math.random() * 4 - 2;
-        this.params.rot4dYW = Math.random() * 4 - 2;
-        this.params.rot4dZW = Math.random() * 4 - 2;
-        this.params.dimension = 3.0 + Math.random() * 1.5;
-        this.params.gridDensity = 4 + Math.random() * 26;
-        this.params.morphFactor = Math.random() * 2;
-        this.params.chaos = Math.random();
-        this.params.speed = 0.1 + Math.random() * 2.9;
-        this.params.hue = Math.random() * 360;
-        this.params.geometry = Math.floor(Math.random() * 8);
+        const randomParams = {
+            rot4dXW: Math.random() * 4 - 2,
+            rot4dYW: Math.random() * 4 - 2,
+            rot4dZW: Math.random() * 4 - 2,
+            dimension: 3.0 + Math.random() * 1.5,
+            gridDensity: 4 + Math.random() * 96,
+            morphFactor: Math.random() * 2,
+            chaos: Math.random(),
+            speed: 0.1 + Math.random() * 2.9,
+            hue: Math.random() * 360,
+            geometry: Math.floor(Math.random() * 8)
+        };
+
+        this.setParameters(randomParams, 'randomize');
     }
-    
+
     /**
      * Reset to default parameters
      */
     resetToDefaults() {
-        this.params = { ...this.defaults };
+        this.setParameters(this.defaults, 'reset');
     }
-    
+
     /**
      * Load parameter configuration
      */
     loadConfiguration(config) {
         if (config && typeof config === 'object') {
-            // Validate and apply configuration
             for (const [key, value] of Object.entries(config)) {
                 if (this.parameterDefs[key]) {
-                    this.setParameter(key, value);
+                    this.setParameter(key, value, 'config');
                 }
             }
             return true;
         }
         return false;
     }
-    
+
     /**
      * Export current configuration
      */
@@ -253,16 +356,15 @@ export class ParameterManager {
             parameters: { ...this.params }
         };
     }
-    
+
     /**
      * Generate variation-specific parameters
      */
     generateVariationParameters(variationIndex) {
         if (variationIndex < 30) {
-            // Default variations with consistent patterns
             const geometryType = Math.floor(variationIndex / 4);
             const level = variationIndex % 4;
-            
+
             return {
                 geometry: geometryType,
                 gridDensity: 8 + (level * 4),
@@ -275,32 +377,32 @@ export class ParameterManager {
                 rot4dZW: ((geometryType + level) % 3) * 0.2,
                 dimension: 3.2 + (level * 0.2)
             };
-        } else {
-            // Custom variations - return current parameters
-            return { ...this.params };
         }
+
+        return { ...this.params };
     }
-    
+
     /**
      * Apply variation to current parameters
      */
     applyVariation(variationIndex) {
         const variationParams = this.generateVariationParameters(variationIndex);
-        this.setParameters(variationParams);
+        this.setParameters(variationParams, 'variation');
         this.params.variation = variationIndex;
+        this.emitChange('variation', variationIndex, 'variation');
     }
-    
+
     /**
      * Get HSV color values for current hue
      */
     getColorHSV() {
         return {
             h: this.params.hue,
-            s: 0.8, // Fixed saturation
-            v: 0.9  // Fixed value
+            s: 0.8,
+            v: 0.9
         };
     }
-    
+
     /**
      * Get RGB color values for current hue
      */
@@ -308,7 +410,7 @@ export class ParameterManager {
         const hsv = this.getColorHSV();
         return this.hsvToRgb(hsv.h, hsv.s, hsv.v);
     }
-    
+
     /**
      * Convert HSV to RGB
      */
@@ -317,7 +419,7 @@ export class ParameterManager {
         const c = v * s;
         const x = c * (1 - Math.abs((h % 2) - 1));
         const m = v - c;
-        
+
         let r, g, b;
         if (h < 1) {
             [r, g, b] = [c, x, 0];
@@ -332,14 +434,14 @@ export class ParameterManager {
         } else {
             [r, g, b] = [c, 0, x];
         }
-        
+
         return {
             r: Math.round((r + m) * 255),
             g: Math.round((g + m) * 255),
             b: Math.round((b + m) * 255)
         };
     }
-    
+
     /**
      * Validate parameter configuration
      */
@@ -347,16 +449,15 @@ export class ParameterManager {
         if (!config || typeof config !== 'object') {
             return { valid: false, error: 'Configuration must be an object' };
         }
-        
+
         if (config.type !== 'vib34d-integrated-config') {
             return { valid: false, error: 'Invalid configuration type' };
         }
-        
+
         if (!config.parameters) {
             return { valid: false, error: 'Missing parameters object' };
         }
-        
-        // Validate individual parameters
+
         for (const [key, value] of Object.entries(config.parameters)) {
             if (this.parameterDefs[key]) {
                 const def = this.parameterDefs[key];
@@ -365,7 +466,209 @@ export class ParameterManager {
                 }
             }
         }
-        
+
         return { valid: true };
+    }
+
+    /**
+     * Register a listener for parameter changes
+     */
+    addChangeListener(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    /**
+     * Emit change events to listeners
+     */
+    emitChange(name, value, source = 'manual') {
+        const payload = {
+            name,
+            value,
+            source,
+            params: { ...this.params }
+        };
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(payload);
+            } catch (error) {
+                console.error('Parameter listener error:', error);
+            }
+        });
+    }
+
+    /**
+     * Get the parameter definition (range, step, type)
+     */
+    getParameterDefinition(name) {
+        return this.parameterDefs[name] || null;
+    }
+
+    /**
+     * List parameter keys for UI builders
+     */
+    listParameters() {
+        return this.listParameterDescriptors().map(descriptor => descriptor.name);
+    }
+
+    /**
+     * Provide detailed parameter descriptors for UI builders
+     */
+    listParameterDescriptors() {
+        return Object.entries(this.parameterDefs)
+            .map(([name, definition]) => ({
+                name,
+                label: definition.label || this.formatParameterLabel(name),
+                category: definition.category || 'General',
+                min: definition.min,
+                max: definition.max,
+                step: definition.step,
+                type: definition.type
+            }))
+            .sort((a, b) => {
+                if (a.category === b.category) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.category.localeCompare(b.category);
+            });
+    }
+
+    /**
+     * Human friendly label for parameters
+     */
+    formatParameterLabel(name) {
+        const definition = this.parameterDefs[name];
+        if (definition?.label) {
+            return definition.label;
+        }
+
+        return name
+            .replace(/rot4d/, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+
+    /**
+     * Clamp a value according to its parameter definition
+     */
+    clampToDefinition(name, value) {
+        const def = this.parameterDefs[name];
+        if (!def) return value;
+
+        let clampedValue = Math.max(def.min, Math.min(def.max, value));
+        if (def.type === 'int') {
+            clampedValue = Math.round(clampedValue);
+        }
+
+        return clampedValue;
+    }
+
+    /**
+     * Determine if a change is meaningful (prevents micro-noise)
+     */
+    hasMeaningfulChange(previousValue, nextValue, def) {
+        if (previousValue === undefined) return true;
+
+        if (def?.type === 'int') {
+            return previousValue !== nextValue;
+        }
+
+        const epsilon = def?.step ? def.step / 10 : 1e-4;
+        return Math.abs(previousValue - nextValue) > epsilon;
+    }
+
+    /**
+     * Cancel an active interpolation if one exists
+     */
+    cancelInterpolation() {
+        if (this._interpolationFrame) {
+            cancelAnimationFrame(this._interpolationFrame);
+            this._interpolationFrame = null;
+            this._activeInterpolation = null;
+        }
+    }
+
+    /**
+     * Interpolate parameters toward a target set over time
+     */
+    interpolateTo(targetParams, duration = 1500, options = {}) {
+        if (!targetParams) return;
+
+        const keys = Object.keys(targetParams).filter(name => this.parameterDefs[name]);
+        if (keys.length === 0) return;
+
+        this.cancelInterpolation();
+
+        const initialValues = {};
+        keys.forEach(name => {
+            initialValues[name] = this.params[name];
+        });
+
+        const startTime = performance.now();
+        const totalDuration = Math.max(16, duration);
+        const easingFn = this.resolveEasing(options.easing || 'easeInOut');
+        const source = options.source || 'interpolate';
+
+        const step = (timestamp) => {
+            const elapsed = timestamp - startTime;
+            const progress = Math.min(1, elapsed / totalDuration);
+            const eased = easingFn(progress);
+
+            keys.forEach(name => {
+                const targetValue = this.clampToDefinition(name, targetParams[name]);
+                const startValue = initialValues[name];
+                const interpolated = startValue + (targetValue - startValue) * eased;
+                this.setParameter(name, interpolated, source, { force: true });
+            });
+
+            if (progress < 1) {
+                this._interpolationFrame = requestAnimationFrame(step);
+            } else {
+                this._interpolationFrame = null;
+                this._activeInterpolation = null;
+                if (typeof options.onComplete === 'function') {
+                    options.onComplete();
+                }
+            }
+        };
+
+        this._activeInterpolation = { targetParams, duration, options };
+        this._interpolationFrame = requestAnimationFrame(step);
+    }
+
+    /**
+     * Animate a single parameter toward a target value
+     */
+    animateParameter(name, targetValue, duration = 1000, options = {}) {
+        if (!this.parameterDefs[name]) return;
+        this.interpolateTo({ [name]: targetValue }, duration, {
+            ...options,
+            source: options.source || 'animation'
+        });
+    }
+
+    /**
+     * Resolve easing names into functions
+     */
+    resolveEasing(easingName) {
+        switch (easingName) {
+            case 'linear':
+                return t => t;
+            case 'easeIn':
+                return t => Math.pow(t, 3);
+            case 'easeOut':
+                return t => 1 - Math.pow(1 - t, 3);
+            case 'easeInOut':
+            default:
+                return t => t < 0.5
+                    ? 4 * t * t * t
+                    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+        }
     }
 }

--- a/src/ui/AudioReactivityPanel.js
+++ b/src/ui/AudioReactivityPanel.js
@@ -1,0 +1,399 @@
+/**
+ * Audio Reactivity Control Panel
+ * Provides live performance grade audio mapping configuration
+ */
+
+import { getParameterOptionGroups, populateSelectWithOptions, ensureOption } from './parameterOptions.js';
+
+const DEFAULT_SETTINGS = {
+    master: true,
+    globalSensitivity: 1.0,
+    smoothing: 0.35,
+    bands: {
+        bass: { enabled: true, parameter: 'gridDensity', mode: 'swing', depth: 0.7, curve: 1.2 },
+        mid: { enabled: true, parameter: 'hue', mode: 'absolute', depth: 0.6, curve: 1.1 },
+        high: { enabled: true, parameter: 'intensity', mode: 'absolute', depth: 0.5, curve: 1.3 },
+        energy: { enabled: true, parameter: 'speed', mode: 'absolute', depth: 0.5, curve: 1.0 },
+        rhythm: { enabled: false, parameter: 'chaos', mode: 'swing', depth: 0.4, curve: 1.0 }
+    },
+    flourish: {
+        enabled: true,
+        band: 'energy',
+        threshold: 0.65,
+        boost: 0.45,
+        parameter: 'intensity',
+        duration: 1400,
+        cooldown: 1600
+    }
+};
+
+export class AudioReactivityPanel {
+    constructor(options = {}) {
+        const {
+            parameterManager,
+            container = null,
+            onSettingsChange = null,
+            settings = null
+        } = options;
+
+        this.parameterManager = parameterManager;
+        this.onSettingsChange = onSettingsChange;
+        this.settings = this.mergeSettings(DEFAULT_SETTINGS, settings || {});
+        this.container = container || this.ensureContainer();
+        this.bandControls = new Map();
+        this.parameterOptionGroups = getParameterOptionGroups(this.parameterManager);
+
+        this.buildUI();
+        this.applySettingsToControls();
+        this.notifyChange();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-audio-reactivity');
+        if (existing) return existing;
+
+        const section = document.createElement('section');
+        section.id = 'performance-audio-reactivity';
+        section.classList.add('performance-audio');
+        document.body.appendChild(section);
+        return section;
+    }
+
+    buildUI() {
+        this.container.innerHTML = '';
+        this.bandControls.clear();
+
+        const header = document.createElement('header');
+        header.classList.add('performance-section-header');
+        header.innerHTML = `
+            <div>
+                <h3>Audio Reactivity Matrix</h3>
+                <p class="performance-subtitle">Tune frequency bands, sensitivity and dynamic flourishes for synced shows.</p>
+            </div>
+            <label class="toggle-pill">
+                <input type="checkbox" id="audio-master-toggle" ${this.settings.master ? 'checked' : ''}>
+                <span>Audio Reactive</span>
+            </label>
+        `;
+
+        this.container.appendChild(header);
+
+        const globalControls = document.createElement('div');
+        globalControls.classList.add('audio-global-controls');
+        globalControls.innerHTML = `
+            <label>
+                <span>Sensitivity</span>
+                <input type="range" id="audio-sensitivity" min="0.2" max="3" step="0.05" value="${this.settings.globalSensitivity}">
+            </label>
+            <label>
+                <span>Smoothing</span>
+                <input type="range" id="audio-smoothing" min="0" max="0.9" step="0.05" value="${this.settings.smoothing}">
+            </label>
+        `;
+
+        this.container.appendChild(globalControls);
+
+        const bandGrid = document.createElement('div');
+        bandGrid.classList.add('audio-band-grid');
+        this.container.appendChild(bandGrid);
+
+        Object.entries(this.settings.bands).forEach(([band, bandSettings]) => {
+            const bandElement = this.createBandControl(band, bandSettings);
+            bandGrid.appendChild(bandElement);
+        });
+
+        const flourishSection = document.createElement('div');
+        flourishSection.classList.add('audio-flourish');
+        flourishSection.innerHTML = `
+            <div class="flourish-header">
+                <h4>Reactive Flourish</h4>
+                <label class="toggle-pill">
+                    <input type="checkbox" id="flourish-toggle" ${this.settings.flourish.enabled ? 'checked' : ''}>
+                    <span>Enable</span>
+                </label>
+            </div>
+            <div class="flourish-grid">
+                <label>
+                    <span>Trigger Band</span>
+                    <select id="flourish-band">
+                        ${Object.keys(this.settings.bands).map(band => `<option value="${band}">${this.formatBandLabel(band)}</option>`).join('')}
+                    </select>
+                </label>
+                <label>
+                    <span>Parameter</span>
+                    <select id="flourish-parameter"></select>
+                </label>
+                <label>
+                    <span>Threshold</span>
+                    <input type="range" id="flourish-threshold" min="0.2" max="0.95" step="0.05" value="${this.settings.flourish.threshold}">
+                </label>
+                <label>
+                    <span>Boost</span>
+                    <input type="range" id="flourish-boost" min="0.1" max="1" step="0.05" value="${this.settings.flourish.boost}">
+                </label>
+                <label>
+                    <span>Duration (ms)</span>
+                    <input type="number" id="flourish-duration" min="200" max="6000" step="100" value="${this.settings.flourish.duration}">
+                </label>
+                <label>
+                    <span>Cooldown (ms)</span>
+                    <input type="number" id="flourish-cooldown" min="200" max="6000" step="100" value="${this.settings.flourish.cooldown}">
+                </label>
+            </div>
+        `;
+
+        this.container.appendChild(flourishSection);
+
+        const flourishParameterSelect = flourishSection.querySelector('#flourish-parameter');
+        populateSelectWithOptions(flourishParameterSelect, this.parameterOptionGroups);
+        ensureOption(flourishParameterSelect, this.settings.flourish.parameter, this.formatParameterName(this.settings.flourish.parameter));
+
+        this.bindGlobalEvents();
+        this.bindFlourishEvents();
+    }
+
+    createBandControl(band, bandSettings) {
+        const bandElement = document.createElement('div');
+        bandElement.classList.add('audio-band');
+        bandElement.dataset.band = band;
+        bandElement.innerHTML = `
+            <div class="band-header">
+                <label class="toggle-pill">
+                    <input type="checkbox" data-band-toggle value="${band}" ${bandSettings.enabled ? 'checked' : ''}>
+                    <span>${this.formatBandLabel(band)}</span>
+                </label>
+                <span class="band-preview" data-band-preview></span>
+            </div>
+            <div class="band-control-grid">
+                <label>
+                    <span>Parameter</span>
+                    <select data-band-parameter></select>
+                </label>
+                <label>
+                    <span>Mode</span>
+                    <select data-band-mode>
+                        <option value="absolute">Absolute</option>
+                        <option value="swing">Swing</option>
+                    </select>
+                </label>
+                <label>
+                    <span>Depth</span>
+                    <input type="range" data-band-depth min="0" max="1" step="0.05" value="${bandSettings.depth}">
+                </label>
+                <label>
+                    <span>Curve</span>
+                    <input type="range" data-band-curve min="0.5" max="3" step="0.1" value="${bandSettings.curve}">
+                </label>
+            </div>
+        `;
+
+        const controls = {
+            toggle: bandElement.querySelector('[data-band-toggle]'),
+            parameter: bandElement.querySelector('[data-band-parameter]'),
+            mode: bandElement.querySelector('[data-band-mode]'),
+            depth: bandElement.querySelector('[data-band-depth]'),
+            curve: bandElement.querySelector('[data-band-curve]'),
+            preview: bandElement.querySelector('[data-band-preview]')
+        };
+
+        populateSelectWithOptions(controls.parameter, this.parameterOptionGroups);
+        ensureOption(controls.parameter, bandSettings.parameter, this.formatParameterName(bandSettings.parameter));
+        controls.parameter.value = bandSettings.parameter;
+        controls.preview.textContent = this.formatParameterName(controls.parameter.value);
+        controls.mode.value = bandSettings.mode;
+
+        controls.parameter.addEventListener('change', () => {
+            this.settings.bands[band].parameter = controls.parameter.value;
+            controls.preview.textContent = this.formatParameterName(controls.parameter.value);
+            this.notifyChange();
+        });
+
+        controls.mode.addEventListener('change', () => {
+            this.settings.bands[band].mode = controls.mode.value;
+            this.notifyChange();
+        });
+
+        controls.depth.addEventListener('input', () => {
+            this.settings.bands[band].depth = parseFloat(controls.depth.value);
+            this.notifyChange();
+        });
+
+        controls.curve.addEventListener('input', () => {
+            this.settings.bands[band].curve = parseFloat(controls.curve.value);
+            this.notifyChange();
+        });
+
+        controls.toggle.addEventListener('change', () => {
+            this.settings.bands[band].enabled = controls.toggle.checked;
+            bandElement.classList.toggle('disabled', !controls.toggle.checked);
+            this.notifyChange();
+        });
+
+        bandElement.classList.toggle('disabled', !controls.toggle.checked);
+
+        this.bandControls.set(band, controls);
+        return bandElement;
+    }
+
+    bindGlobalEvents() {
+        const masterToggle = this.container.querySelector('#audio-master-toggle');
+        const sensitivityRange = this.container.querySelector('#audio-sensitivity');
+        const smoothingRange = this.container.querySelector('#audio-smoothing');
+
+        masterToggle.addEventListener('change', () => {
+            this.settings.master = masterToggle.checked;
+            this.notifyChange();
+        });
+
+        sensitivityRange.addEventListener('input', () => {
+            this.settings.globalSensitivity = parseFloat(sensitivityRange.value);
+            this.notifyChange();
+        });
+
+        smoothingRange.addEventListener('input', () => {
+            this.settings.smoothing = parseFloat(smoothingRange.value);
+            this.notifyChange();
+        });
+    }
+
+    bindFlourishEvents() {
+        const toggle = this.container.querySelector('#flourish-toggle');
+        const bandSelect = this.container.querySelector('#flourish-band');
+        const parameterSelect = this.container.querySelector('#flourish-parameter');
+        const thresholdRange = this.container.querySelector('#flourish-threshold');
+        const boostRange = this.container.querySelector('#flourish-boost');
+        const durationInput = this.container.querySelector('#flourish-duration');
+        const cooldownInput = this.container.querySelector('#flourish-cooldown');
+
+        toggle.addEventListener('change', () => {
+            this.settings.flourish.enabled = toggle.checked;
+            this.notifyChange();
+        });
+
+        bandSelect.value = this.settings.flourish.band;
+        bandSelect.addEventListener('change', () => {
+            this.settings.flourish.band = bandSelect.value;
+            this.notifyChange();
+        });
+
+        parameterSelect.value = this.settings.flourish.parameter;
+        parameterSelect.addEventListener('change', () => {
+            this.settings.flourish.parameter = parameterSelect.value;
+            this.notifyChange();
+        });
+
+        thresholdRange.addEventListener('input', () => {
+            this.settings.flourish.threshold = parseFloat(thresholdRange.value);
+            this.notifyChange();
+        });
+
+        boostRange.addEventListener('input', () => {
+            this.settings.flourish.boost = parseFloat(boostRange.value);
+            this.notifyChange();
+        });
+
+        durationInput.addEventListener('input', () => {
+            this.settings.flourish.duration = parseInt(durationInput.value, 10);
+            this.notifyChange();
+        });
+
+        cooldownInput.addEventListener('input', () => {
+            this.settings.flourish.cooldown = parseInt(cooldownInput.value, 10);
+            this.notifyChange();
+        });
+    }
+
+    applySettingsToControls() {
+        // Ensure controls reflect current settings (for external updates)
+        this.bandControls.forEach((controls, band) => {
+            const bandSettings = this.settings.bands[band];
+            if (!bandSettings) return;
+            controls.toggle.checked = !!bandSettings.enabled;
+            ensureOption(controls.parameter, bandSettings.parameter, this.formatParameterName(bandSettings.parameter));
+            controls.parameter.value = bandSettings.parameter;
+            controls.mode.value = bandSettings.mode;
+            controls.depth.value = bandSettings.depth;
+            controls.curve.value = bandSettings.curve;
+            controls.preview.textContent = this.formatParameterName(bandSettings.parameter);
+            controls.toggle.dispatchEvent(new Event('change'));
+        });
+
+        const bandSelect = this.container.querySelector('#flourish-band');
+        const parameterSelect = this.container.querySelector('#flourish-parameter');
+        const thresholdRange = this.container.querySelector('#flourish-threshold');
+        const boostRange = this.container.querySelector('#flourish-boost');
+        const durationInput = this.container.querySelector('#flourish-duration');
+        const cooldownInput = this.container.querySelector('#flourish-cooldown');
+        const toggle = this.container.querySelector('#flourish-toggle');
+
+        if (bandSelect) bandSelect.value = this.settings.flourish.band;
+        if (parameterSelect) {
+            ensureOption(parameterSelect, this.settings.flourish.parameter, this.formatParameterName(this.settings.flourish.parameter));
+            parameterSelect.value = this.settings.flourish.parameter;
+        }
+        if (thresholdRange) thresholdRange.value = this.settings.flourish.threshold;
+        if (boostRange) boostRange.value = this.settings.flourish.boost;
+        if (durationInput) durationInput.value = this.settings.flourish.duration;
+        if (cooldownInput) cooldownInput.value = this.settings.flourish.cooldown;
+        if (toggle) toggle.checked = this.settings.flourish.enabled;
+    }
+
+    mergeSettings(base, overrides) {
+        const merged = JSON.parse(JSON.stringify(base));
+        if (!overrides) return merged;
+
+        if (typeof overrides.master === 'boolean') merged.master = overrides.master;
+        if (typeof overrides.globalSensitivity === 'number') merged.globalSensitivity = overrides.globalSensitivity;
+        if (typeof overrides.smoothing === 'number') merged.smoothing = overrides.smoothing;
+
+        if (overrides.bands) {
+            Object.entries(overrides.bands).forEach(([band, config]) => {
+                merged.bands[band] = { ...merged.bands[band], ...config };
+            });
+        }
+
+        if (overrides.flourish) {
+            merged.flourish = { ...merged.flourish, ...overrides.flourish };
+        }
+
+        return merged;
+    }
+
+    formatBandLabel(band) {
+        return band.charAt(0).toUpperCase() + band.slice(1);
+    }
+
+    formatParameterName(name) {
+        if (this.parameterManager?.formatParameterLabel) {
+            return this.parameterManager.formatParameterLabel(name);
+        }
+
+        return name
+            .replace(/rot4d/, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+
+    getSettings() {
+        return JSON.parse(JSON.stringify(this.settings));
+    }
+
+    notifyChange() {
+        if (typeof this.onSettingsChange === 'function') {
+            this.onSettingsChange(this.getSettings());
+        }
+    }
+
+    setSettings(settings) {
+        this.settings = this.mergeSettings(DEFAULT_SETTINGS, settings || {});
+        this.buildUI();
+        this.applySettingsToControls();
+        this.notifyChange();
+    }
+
+    destroy() {
+        this.bandControls.clear();
+    }
+}

--- a/src/ui/PerformanceLayoutControls.js
+++ b/src/ui/PerformanceLayoutControls.js
@@ -1,0 +1,164 @@
+export class PerformanceLayoutControls {
+    constructor(options = {}) {
+        const {
+            container = null,
+            initialLayout = null,
+            onChange = null
+        } = options;
+
+        this.container = container || this.ensureContainer();
+        this.onChange = onChange;
+        this.suspendNotify = false;
+
+        this.layout = {
+            padCount: 3,
+            columns: 'auto',
+            padSize: 1,
+            padGap: 16,
+            padAspect: 1,
+            crosshair: 16,
+            ...(initialLayout || {})
+        };
+
+        this.buildUI();
+        this.applyLayoutToControls();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-layout');
+        if (existing) return existing;
+
+        const section = document.createElement('section');
+        section.id = 'performance-layout';
+        section.classList.add('performance-layout');
+        document.body.appendChild(section);
+        return section;
+    }
+
+    buildUI() {
+        this.container.innerHTML = `
+            <header class="performance-section-header">
+                <div>
+                    <h3>Touchpad Layout & Feel</h3>
+                    <p class="performance-subtitle">Dial in pad count, spacing and gesture feedback for your rig.</p>
+                </div>
+            </header>
+            <div class="layout-controls">
+                <label>
+                    <span>Pad Count</span>
+                    <input type="range" min="1" max="8" step="1" data-layout-key="padCount">
+                    <output data-layout-output="padCount"></output>
+                </label>
+                <label>
+                    <span>Grid Columns</span>
+                    <select data-layout-key="columns">
+                        <option value="auto">Auto</option>
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                        <option value="4">4</option>
+                        <option value="5">5</option>
+                        <option value="6">6</option>
+                    </select>
+                </label>
+                <label>
+                    <span>Pad Size</span>
+                    <input type="range" min="0.6" max="2.5" step="0.1" data-layout-key="padSize">
+                    <output data-layout-output="padSize"></output>
+                </label>
+                <label>
+                    <span>Pad Gap</span>
+                    <input type="range" min="4" max="48" step="1" data-layout-key="padGap">
+                    <output data-layout-output="padGap"></output>
+                </label>
+                <label>
+                    <span>Aspect Ratio</span>
+                    <input type="range" min="0.5" max="2" step="0.05" data-layout-key="padAspect">
+                    <output data-layout-output="padAspect"></output>
+                </label>
+                <label>
+                    <span>Crosshair Size</span>
+                    <input type="range" min="8" max="48" step="1" data-layout-key="crosshair">
+                    <output data-layout-output="crosshair"></output>
+                </label>
+            </div>
+        `;
+
+        this.container.querySelectorAll('[data-layout-key]').forEach(element => {
+            const eventName = element.tagName === 'SELECT' ? 'change' : 'input';
+            element.addEventListener(eventName, () => this.handleControlChange(element));
+        });
+    }
+
+    handleControlChange(element) {
+        const key = element.dataset.layoutKey;
+        if (!key) return;
+
+        let value = element.value;
+        if (key === 'padCount' || key === 'padGap' || key === 'crosshair') {
+            value = parseInt(value, 10);
+        } else if (key === 'padSize' || key === 'padAspect') {
+            value = parseFloat(value);
+        }
+
+        if (key !== 'columns' && Number.isFinite(value)) {
+            this.layout[key] = value;
+        } else if (key === 'columns') {
+            this.layout[key] = value === 'auto' ? 'auto' : parseInt(value, 10);
+        }
+
+        this.updateOutputs();
+        this.notifyChange();
+    }
+
+    notifyChange() {
+        if (this.suspendNotify) return;
+        if (typeof this.onChange === 'function') {
+            this.onChange({ ...this.layout });
+        }
+    }
+
+    applyLayoutToControls() {
+        this.suspendNotify = true;
+        this.container.querySelectorAll('[data-layout-key]').forEach(element => {
+            const key = element.dataset.layoutKey;
+            const value = this.layout[key];
+
+            if (element.tagName === 'SELECT') {
+                element.value = value === 'auto' ? 'auto' : String(value);
+            } else {
+                element.value = value;
+            }
+        });
+        this.updateOutputs();
+        this.suspendNotify = false;
+    }
+
+    updateOutputs() {
+        this.container.querySelectorAll('[data-layout-output]').forEach(output => {
+            const key = output.dataset.layoutOutput;
+            let value = this.layout[key];
+            if (key === 'padAspect') {
+                value = value.toFixed(2);
+            } else if (key === 'padSize') {
+                value = value.toFixed(1);
+            }
+            output.textContent = value;
+        });
+    }
+
+    setLayout(layout, { silent = false } = {}) {
+        this.layout = {
+            ...this.layout,
+            ...(layout || {})
+        };
+        this.applyLayoutToControls();
+        if (!silent) {
+            this.notifyChange();
+        }
+    }
+
+    destroy() {
+        this.container.innerHTML = '';
+    }
+}

--- a/src/ui/PerformancePresetManager.js
+++ b/src/ui/PerformancePresetManager.js
@@ -1,0 +1,441 @@
+/**
+ * Performance Preset Manager
+ * Handles saving presets and choreographed sequences for live shows
+ */
+
+import { getParameterOptionGroups, populateSelectWithOptions, ensureOption } from './parameterOptions.js';
+
+const STORAGE_KEY = 'vib34d_performance_presets_v1';
+
+export class PerformancePresetManager {
+    constructor(options = {}) {
+        const {
+            parameterManager,
+            touchPadController = null,
+            audioPanel = null,
+            container = null,
+            onPresetApply = null
+        } = options;
+
+        this.parameterManager = parameterManager;
+        this.touchPadController = touchPadController;
+        this.audioPanel = audioPanel;
+        this.onPresetApply = onPresetApply;
+        this.container = container || this.ensureContainer();
+
+        this.presets = this.loadPresets();
+        this.sequence = [];
+        this.sequencePlaying = false;
+        this.currentPresetId = null;
+        this.parameterOptionGroups = getParameterOptionGroups(this.parameterManager);
+
+        this.buildUI();
+        this.renderPresetList();
+        this.renderSequence();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-presets');
+        if (existing) return existing;
+
+        const section = document.createElement('section');
+        section.id = 'performance-presets';
+        section.classList.add('performance-presets');
+        document.body.appendChild(section);
+        return section;
+    }
+
+    buildUI() {
+        this.container.innerHTML = '';
+        this.container.innerHTML = `
+            <header class="performance-section-header">
+                <div>
+                    <h3>Show Presets & Choreography</h3>
+                    <p class="performance-subtitle">Capture parameter states, pad mappings and audio settings for instant recall.</p>
+                </div>
+            </header>
+            <div class="preset-controls">
+                <div class="preset-create">
+                    <input type="text" id="preset-name" placeholder="Preset name (e.g. "Midnight Drop")">
+                    <div class="preset-actions">
+                        <button id="preset-save">Save Preset</button>
+                        <button id="preset-update" disabled>Update</button>
+                        <button id="preset-reset">Clear</button>
+                    </div>
+                </div>
+                <div class="preset-flourish">
+                    <label>
+                        <span>Flourish Parameter</span>
+                        <select id="preset-flourish-parameter"></select>
+                    </label>
+                    <label>
+                        <span>Flourish Boost</span>
+                        <input type="range" id="preset-flourish-amount" min="0.1" max="1" step="0.05" value="0.5">
+                    </label>
+                    <label>
+                        <span>Flourish Duration (ms)</span>
+                        <input type="number" id="preset-flourish-duration" min="200" max="4000" step="100" value="1200">
+                    </label>
+                </div>
+            </div>
+            <div class="preset-list" id="preset-list"></div>
+            <div class="sequence-builder">
+                <div class="sequence-header">
+                    <h4>Choreography Timeline</h4>
+                    <div class="sequence-actions">
+                        <button id="sequence-play">Play Sequence</button>
+                        <button id="sequence-clear">Clear</button>
+                    </div>
+                </div>
+                <div class="sequence-form">
+                    <select id="sequence-preset"></select>
+                    <input type="number" id="sequence-transition" placeholder="Transition ms" min="100" value="1800">
+                    <input type="number" id="sequence-hold" placeholder="Hold ms" min="0" value="1200">
+                    <label class="sequence-flourish">
+                        <input type="checkbox" id="sequence-flourish">
+                        <span>Trigger flourish</span>
+                    </label>
+                    <button id="sequence-add">Add Cue</button>
+                </div>
+                <ol class="sequence-list" id="sequence-list"></ol>
+            </div>
+        `;
+
+        this.populateFlourishParameterOptions();
+        this.bindEvents();
+    }
+
+    populateFlourishParameterOptions() {
+        const select = this.container.querySelector('#preset-flourish-parameter');
+        if (!select || !this.parameterManager) return;
+
+        populateSelectWithOptions(select, this.parameterOptionGroups);
+        if (select.options.length > 0) {
+            select.value = select.options[0].value;
+        }
+    }
+
+    bindEvents() {
+        const saveBtn = this.container.querySelector('#preset-save');
+        const updateBtn = this.container.querySelector('#preset-update');
+        const resetBtn = this.container.querySelector('#preset-reset');
+        const playBtn = this.container.querySelector('#sequence-play');
+        const clearBtn = this.container.querySelector('#sequence-clear');
+        const addBtn = this.container.querySelector('#sequence-add');
+
+        saveBtn.addEventListener('click', () => this.savePreset());
+        updateBtn.addEventListener('click', () => this.updatePreset());
+        resetBtn.addEventListener('click', () => this.resetForm());
+        playBtn.addEventListener('click', () => this.playSequence());
+        clearBtn.addEventListener('click', () => this.clearSequence());
+        addBtn.addEventListener('click', () => this.addSequenceCue());
+    }
+
+    savePreset() {
+        const nameInput = this.container.querySelector('#preset-name');
+        const flourishParam = this.container.querySelector('#preset-flourish-parameter').value;
+        const flourishAmount = parseFloat(this.container.querySelector('#preset-flourish-amount').value);
+        const flourishDuration = parseInt(this.container.querySelector('#preset-flourish-duration').value, 10);
+
+        const preset = {
+            id: this.generatePresetId(),
+            name: nameInput.value.trim() || `Preset ${new Date().toLocaleTimeString()}`,
+            createdAt: Date.now(),
+            params: this.parameterManager?.getAllParameters() || {},
+            mappings: this.touchPadController?.getMappings() || [],
+            audio: this.audioPanel?.getSettings() || null,
+            layout: this.touchPadController?.getLayoutOptions() || null,
+            flourish: {
+                parameter: flourishParam,
+                amount: flourishAmount,
+                duration: flourishDuration
+            }
+        };
+
+        this.presets.push(preset);
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+        this.resetForm();
+    }
+
+    updatePreset() {
+        if (!this.currentPresetId) return;
+
+        const preset = this.presets.find(item => item.id === this.currentPresetId);
+        if (!preset) return;
+
+        const flourishParam = this.container.querySelector('#preset-flourish-parameter').value;
+        const flourishAmount = parseFloat(this.container.querySelector('#preset-flourish-amount').value);
+        const flourishDuration = parseInt(this.container.querySelector('#preset-flourish-duration').value, 10);
+        const nameInput = this.container.querySelector('#preset-name');
+
+        preset.name = nameInput.value.trim() || preset.name;
+        preset.params = this.parameterManager?.getAllParameters() || preset.params;
+        preset.mappings = this.touchPadController?.getMappings() || preset.mappings;
+        preset.audio = this.audioPanel?.getSettings() || preset.audio;
+        preset.layout = this.touchPadController?.getLayoutOptions() || preset.layout;
+        preset.flourish = {
+            parameter: flourishParam,
+            amount: flourishAmount,
+            duration: flourishDuration
+        };
+
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+    }
+
+    resetForm() {
+        this.currentPresetId = null;
+        this.container.querySelector('#preset-name').value = '';
+        this.container.querySelector('#preset-update').disabled = true;
+    }
+
+    renderPresetList() {
+        const list = this.container.querySelector('#preset-list');
+        if (!list) return;
+
+        if (this.presets.length === 0) {
+            list.innerHTML = '<p class="preset-empty">No presets yet. Dial in a look and save it for instant recall.</p>';
+            this.renderSequenceOptions();
+            return;
+        }
+
+        list.innerHTML = '';
+        this.presets
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .forEach(preset => {
+                const item = document.createElement('div');
+                item.classList.add('preset-item');
+                item.innerHTML = `
+                    <div class="preset-meta">
+                        <h4>${preset.name}</h4>
+                        <span>${new Date(preset.createdAt).toLocaleString()}</span>
+                    </div>
+                    <div class="preset-buttons">
+                        <button data-action="apply" data-id="${preset.id}">Apply</button>
+                        <button data-action="flourish" data-id="${preset.id}">Flourish</button>
+                        <button data-action="edit" data-id="${preset.id}">Edit</button>
+                        <button data-action="delete" data-id="${preset.id}">Delete</button>
+                    </div>
+                `;
+
+                item.querySelectorAll('button').forEach(button => {
+                    button.addEventListener('click', () => this.handlePresetAction(button.dataset.action, preset.id));
+                });
+
+                list.appendChild(item);
+            });
+
+        this.renderSequenceOptions();
+    }
+
+    handlePresetAction(action, presetId) {
+        const preset = this.presets.find(item => item.id === presetId);
+        if (!preset) return;
+
+        switch (action) {
+            case 'apply':
+                this.applyPreset(preset);
+                break;
+            case 'flourish':
+                this.triggerFlourish(preset);
+                break;
+            case 'edit':
+                this.populateForm(preset);
+                break;
+            case 'delete':
+                this.deletePreset(presetId);
+                break;
+        }
+    }
+
+    populateForm(preset) {
+        this.currentPresetId = preset.id;
+        this.container.querySelector('#preset-name').value = preset.name;
+        const flourishSelect = this.container.querySelector('#preset-flourish-parameter');
+        const parameterValue = preset.flourish?.parameter || this.parameterManager.listParameters()[0];
+        ensureOption(flourishSelect, parameterValue, this.getParameterLabel(parameterValue));
+        flourishSelect.value = parameterValue;
+        this.container.querySelector('#preset-flourish-amount').value = preset.flourish?.amount ?? 0.5;
+        this.container.querySelector('#preset-flourish-duration').value = preset.flourish?.duration ?? 1200;
+        this.container.querySelector('#preset-update').disabled = false;
+    }
+
+    deletePreset(presetId) {
+        this.presets = this.presets.filter(item => item.id !== presetId);
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+    }
+
+    applyPreset(preset, options = {}) {
+        const transition = options.transition || 1800;
+        if (this.parameterManager) {
+            this.parameterManager.interpolateTo(preset.params, transition, { source: 'preset' });
+        }
+
+        if (this.touchPadController && preset.layout) {
+            this.touchPadController.applyLayoutOptions(preset.layout, { silent: true });
+        }
+
+        if (this.touchPadController && preset.mappings) {
+            this.touchPadController.applyMappings(preset.mappings);
+        }
+
+        if (this.audioPanel && preset.audio) {
+            this.audioPanel.setSettings(preset.audio);
+        }
+
+        if (typeof this.onPresetApply === 'function') {
+            this.onPresetApply(preset);
+        }
+    }
+
+    triggerFlourish(preset) {
+        if (!preset?.flourish || !this.parameterManager) return;
+
+        const { parameter, amount, duration } = preset.flourish;
+        const definition = this.parameterManager.getParameterDefinition(parameter);
+        if (!definition) return;
+
+        const baseValue = this.parameterManager.getParameter(parameter);
+        const span = definition.max - definition.min;
+        const target = this.parameterManager.clampToDefinition(parameter, baseValue + span * amount);
+
+        this.parameterManager.animateParameter(parameter, target, duration, {
+            source: 'flourish',
+            onComplete: () => {
+                this.parameterManager.animateParameter(parameter, baseValue, duration, { source: 'flourish-return' });
+            }
+        });
+    }
+
+    addSequenceCue() {
+        const select = this.container.querySelector('#sequence-preset');
+        const transitionInput = this.container.querySelector('#sequence-transition');
+        const holdInput = this.container.querySelector('#sequence-hold');
+        const flourishToggle = this.container.querySelector('#sequence-flourish');
+
+        if (!select.value) return;
+
+        this.sequence.push({
+            presetId: select.value,
+            transition: parseInt(transitionInput.value, 10) || 1800,
+            hold: parseInt(holdInput.value, 10) || 0,
+            flourish: flourishToggle.checked
+        });
+
+        flourishToggle.checked = false;
+        this.renderSequence();
+    }
+
+    renderSequence() {
+        const list = this.container.querySelector('#sequence-list');
+        if (!list) return;
+
+        list.innerHTML = '';
+        this.sequence.forEach((cue, index) => {
+            const preset = this.presets.find(item => item.id === cue.presetId);
+            if (!preset) return;
+
+            const item = document.createElement('li');
+            item.innerHTML = `
+                <span>${index + 1}. ${preset.name} — ${cue.transition}ms transition, ${cue.hold}ms hold${cue.flourish ? ', flourish' : ''}</span>
+                <button data-index="${index}">Remove</button>
+            `;
+
+            item.querySelector('button').addEventListener('click', () => {
+                this.sequence.splice(index, 1);
+                this.renderSequence();
+            });
+
+            list.appendChild(item);
+        });
+    }
+
+    renderSequenceOptions() {
+        const select = this.container.querySelector('#sequence-preset');
+        if (!select) return;
+
+        select.innerHTML = this.presets
+            .map(preset => `<option value="${preset.id}">${preset.name}</option>`)
+            .join('');
+    }
+
+    async playSequence() {
+        if (this.sequencePlaying || this.sequence.length === 0) return;
+
+        this.sequencePlaying = true;
+        for (const cue of this.sequence) {
+            const preset = this.presets.find(item => item.id === cue.presetId);
+            if (!preset) continue;
+
+            this.applyPreset(preset, { transition: cue.transition });
+            if (cue.flourish) {
+                setTimeout(() => this.triggerFlourish(preset), cue.transition / 2);
+            }
+
+            await this.wait(cue.transition + cue.hold);
+        }
+        this.sequencePlaying = false;
+    }
+
+    clearSequence() {
+        this.sequence = [];
+        this.renderSequence();
+    }
+
+    wait(duration) {
+        return new Promise(resolve => setTimeout(resolve, duration));
+    }
+
+    generatePresetId() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+        return `preset-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    }
+
+    loadPresets() {
+        try {
+            const data = window.localStorage.getItem(STORAGE_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (error) {
+            console.warn('Unable to load performance presets:', error);
+            return [];
+        }
+    }
+
+    persistPresets() {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.presets));
+        } catch (error) {
+            console.warn('Unable to persist presets:', error);
+        }
+    }
+
+    clearSequenceOptions() {
+        const select = this.container.querySelector('#sequence-preset');
+        if (select) select.innerHTML = '';
+    }
+
+    formatParameterName(name) {
+        return this.getParameterLabel(name);
+    }
+
+    getParameterLabel(name) {
+        if (!name) return 'Unknown';
+        if (this.parameterManager?.formatParameterLabel) {
+            return this.parameterManager.formatParameterLabel(name);
+        }
+
+        return name
+            .replace(/rot4d/, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+}

--- a/src/ui/PerformanceSuite.js
+++ b/src/ui/PerformanceSuite.js
@@ -1,0 +1,149 @@
+import { TouchPadController } from './TouchPadController.js';
+import { AudioReactivityPanel } from './AudioReactivityPanel.js';
+import { PerformancePresetManager } from './PerformancePresetManager.js';
+import { PerformanceLayoutControls } from './PerformanceLayoutControls.js';
+
+/**
+ * PerformanceSuite orchestrates live performance controls for the engine.
+ */
+export class PerformanceSuite {
+    constructor(options = {}) {
+        const { engine, parameterManager } = options;
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+
+        this.root = null;
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.mappingSnapshot = [];
+        this.audioSettings = null;
+        this.unsubscribe = null;
+        this.layoutControls = null;
+        this.layoutSnapshot = null;
+
+        this.init();
+    }
+
+    init() {
+        this.createLayout();
+        this.touchPadController = new TouchPadController({
+            parameterManager: this.parameterManager,
+            container: this.touchpadContainer,
+            onMappingChange: (mappings) => {
+                this.mappingSnapshot = mappings;
+            },
+            onLayoutChange: (layout) => {
+                this.layoutSnapshot = layout;
+                this.layoutControls?.setLayout(layout, { silent: true });
+            },
+            layoutOptions: this.layoutSnapshot
+        });
+
+        this.layoutSnapshot = this.touchPadController.getLayoutOptions();
+
+        this.layoutControls = new PerformanceLayoutControls({
+            container: this.layoutContainer,
+            initialLayout: this.layoutSnapshot,
+            onChange: (layout) => {
+                this.touchPadController.applyLayoutOptions(layout);
+                this.layoutSnapshot = this.touchPadController.getLayoutOptions();
+            }
+        });
+
+        this.audioPanel = new AudioReactivityPanel({
+            parameterManager: this.parameterManager,
+            container: this.audioContainer,
+            onSettingsChange: (settings) => this.handleAudioSettingsChange(settings)
+        });
+
+        this.presetManager = new PerformancePresetManager({
+            parameterManager: this.parameterManager,
+            touchPadController: this.touchPadController,
+            audioPanel: this.audioPanel,
+            container: this.presetsContainer,
+            onPresetApply: (preset) => this.handlePresetApplied(preset)
+        });
+
+        this.mappingSnapshot = this.touchPadController.getMappings();
+        this.audioSettings = this.audioPanel.getSettings();
+        this.applyAudioSettingsToEngine();
+
+        if (this.parameterManager) {
+            this.unsubscribe = this.parameterManager.addChangeListener(() => {
+                // Could be used for analytics or additional behaviours.
+            });
+        }
+
+        window.performanceSuite = this;
+    }
+
+    createLayout() {
+        const host = document.getElementById('controlPanel') || document.body;
+
+        this.root = document.createElement('section');
+        this.root.classList.add('performance-suite');
+
+        const columns = document.createElement('div');
+        columns.classList.add('performance-columns');
+
+        this.layoutContainer = document.createElement('section');
+        this.layoutContainer.classList.add('performance-column', 'performance-column--layout');
+
+        this.touchpadContainer = document.createElement('section');
+        this.touchpadContainer.classList.add('performance-column', 'performance-column--touchpads');
+
+        this.audioContainer = document.createElement('section');
+        this.audioContainer.classList.add('performance-column', 'performance-column--audio');
+
+        this.presetsContainer = document.createElement('section');
+        this.presetsContainer.classList.add('performance-column', 'performance-column--presets');
+
+        columns.appendChild(this.layoutContainer);
+        columns.appendChild(this.touchpadContainer);
+        columns.appendChild(this.audioContainer);
+        columns.appendChild(this.presetsContainer);
+
+        this.root.appendChild(columns);
+        host.appendChild(this.root);
+    }
+
+    handleAudioSettingsChange(settings) {
+        this.audioSettings = settings;
+        this.applyAudioSettingsToEngine();
+    }
+
+    applyAudioSettingsToEngine() {
+        if (!this.engine) return;
+        this.engine.liveAudioSettings = this.audioSettings;
+    }
+
+    handlePresetApplied(preset) {
+        if (!preset) return;
+        this.mappingSnapshot = preset.mappings || this.mappingSnapshot;
+        if (preset.audio) {
+            this.audioSettings = preset.audio;
+            this.applyAudioSettingsToEngine();
+        }
+        if (preset.layout) {
+            this.touchPadController.applyLayoutOptions(preset.layout, { silent: true });
+            this.layoutControls?.setLayout(preset.layout, { silent: true });
+            this.layoutSnapshot = this.touchPadController.getLayoutOptions();
+            this.touchPadController.emitLayoutChange?.();
+        }
+    }
+
+    getAudioSettings() {
+        return this.audioSettings;
+    }
+
+    destroy() {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+        }
+        this.touchPadController?.destroy();
+        this.audioPanel?.destroy();
+        this.layoutControls?.destroy();
+        this.root?.remove();
+    }
+}

--- a/src/ui/TouchPadController.js
+++ b/src/ui/TouchPadController.js
@@ -1,0 +1,731 @@
+/**
+ * Performance TouchPad Controller
+ * Multi-touch XY pads with configurable parameter mappings
+ */
+
+import { getParameterOptionGroups, populateSelectWithOptions, ensureOption } from './parameterOptions.js';
+
+export class TouchPadController {
+    constructor(options) {
+        const {
+            parameterManager,
+            container = null,
+            padCount = 3,
+            availableParameters = null,
+            defaultMappings = [],
+            onMappingChange = null,
+            layoutOptions = null,
+            onLayoutChange = null
+        } = options || {};
+
+        this.parameterManager = parameterManager;
+        this.padCount = padCount;
+        this.onMappingChange = onMappingChange;
+        this.onLayoutChange = onLayoutChange;
+        this.availableParameters = availableParameters || parameterManager?.listParameters() || [];
+
+        this.rootElement = null;
+        this.container = container || this.ensureContainer();
+        this.padStates = [];
+        this.unsubscribe = null;
+        this.defaultMappings = defaultMappings;
+        this.layoutOptions = {
+            padCount: this.padCount,
+            columns: 'auto',
+            padSize: 1,
+            padGap: 16,
+            padAspect: 1,
+            crosshair: 16,
+            ...layoutOptions
+        };
+
+        this.parameterOptionGroups = this.resolveParameterOptionGroups();
+
+        this.buildUI();
+        this.applyLayoutOptions(this.layoutOptions, { silent: true });
+        this.registerListeners();
+    }
+
+    resolveParameterOptionGroups() {
+        if (Array.isArray(this.availableParameters) && this.availableParameters.length > 0 && typeof this.availableParameters[0] === 'object') {
+            return this.availableParameters;
+        }
+
+        return getParameterOptionGroups(this.parameterManager);
+    }
+
+    /**
+     * Ensure a container exists for the touch pads
+     */
+    ensureContainer() {
+        const existing = document.getElementById('performance-touchpads');
+        if (existing) return existing;
+
+        const element = document.createElement('section');
+        element.id = 'performance-touchpads';
+        element.classList.add('performance-touchpads');
+        document.body.appendChild(element);
+        return element;
+    }
+
+    /**
+     * Build touch pad UI elements
+     */
+    buildUI() {
+        if (!this.parameterManager) {
+            console.warn('TouchPadController requires a ParameterManager instance');
+            return;
+        }
+
+        // Clear container for rebuilds
+        const preservedMappings = this.padStates.length > 0 ? this.getMappings() : null;
+
+        this.container.innerHTML = '';
+        this.padStates = [];
+
+        const title = document.createElement('header');
+        title.classList.add('performance-section-header');
+        title.innerHTML = `
+            <div>
+                <h3>Multi-Touch Control Pads</h3>
+                <p class="performance-subtitle">Assign any engine parameter to live XY pads with multi-touch gestures.</p>
+            </div>
+        `;
+
+        this.container.appendChild(title);
+
+        const padGrid = document.createElement('div');
+        padGrid.classList.add('touchpad-grid');
+        this.container.appendChild(padGrid);
+
+        const defaults = this.createDefaultMappings();
+
+        for (let i = 0; i < this.padCount; i++) {
+            const savedMapping = preservedMappings?.find(item => item.id === i);
+            const mapping = savedMapping
+                ? {
+                    x: savedMapping.bindings?.x,
+                    y: savedMapping.bindings?.y,
+                    gesture: savedMapping.bindings?.gesture,
+                    mode: savedMapping.modes
+                }
+                : (defaults[i] || defaults[defaults.length - 1]);
+
+            const padElement = this.createPadElement(i, mapping);
+            padGrid.appendChild(padElement);
+        }
+
+        if (preservedMappings) {
+            this.notifyMappingChange();
+        }
+    }
+
+    /**
+     * Create default mapping presets for pads
+     */
+    createDefaultMappings() {
+        if (Array.isArray(this.defaultMappings) && this.defaultMappings.length > 0) {
+            return this.defaultMappings;
+        }
+
+        return [
+            { x: 'rot4dXW', y: 'rot4dYW', gesture: 'rot4dZW' },
+            { x: 'gridDensity', y: 'morphFactor', gesture: 'chaos' },
+            { x: 'hue', y: 'intensity', gesture: 'saturation' }
+        ];
+    }
+
+    /**
+     * Create a single pad element with controls
+     */
+    createPadElement(index, mapping) {
+        const padWrapper = document.createElement('div');
+        padWrapper.classList.add('touchpad-wrapper');
+
+        const padHeader = document.createElement('div');
+        padHeader.classList.add('touchpad-header');
+        padHeader.innerHTML = `
+            <div class="touchpad-title">Pad ${index + 1}</div>
+            <div class="touchpad-mapping"></div>
+        `;
+
+        const mappingContainer = padHeader.querySelector('.touchpad-mapping');
+
+        const padState = {
+            id: index,
+            element: padWrapper,
+            surface: null,
+            readout: null,
+            axisBindings: {
+                x: mapping?.x || 'rot4dXW',
+                y: mapping?.y || 'rot4dYW',
+                gesture: mapping?.gesture || 'none'
+            },
+            axisModes: {
+                x: mapping?.mode?.x || 'swing',
+                y: mapping?.mode?.y || 'swing',
+                gesture: mapping?.mode?.gesture || 'absolute'
+            },
+            axisBaselines: {
+                x: null,
+                y: null,
+                gesture: null
+            },
+            activePointers: new Map(),
+            centroid: { x: 0.5, y: 0.5 },
+            gestureValue: 0
+        };
+
+        padState.controls = {
+            x: this.createAxisControl('X Axis', 'x', padState.axisBindings.x, padState.axisModes.x),
+            y: this.createAxisControl('Y Axis', 'y', padState.axisBindings.y, padState.axisModes.y),
+            gesture: this.createAxisControl('Gesture', 'gesture', padState.axisBindings.gesture, padState.axisModes.gesture, true)
+        };
+
+        mappingContainer.appendChild(padState.controls.x.container);
+        mappingContainer.appendChild(padState.controls.y.container);
+        mappingContainer.appendChild(padState.controls.gesture.container);
+
+        const padSurface = document.createElement('div');
+        padSurface.classList.add('touchpad-surface');
+        padSurface.setAttribute('data-pad-index', index);
+        padSurface.setAttribute('tabindex', '0');
+
+        const crosshair = document.createElement('div');
+        crosshair.classList.add('touchpad-crosshair');
+        padSurface.appendChild(crosshair);
+
+        const readout = document.createElement('div');
+        readout.classList.add('touchpad-readout');
+        readout.innerHTML = `
+            <div><span>X:</span> <strong>0.00</strong></div>
+            <div><span>Y:</span> <strong>0.00</strong></div>
+            <div class="touchpad-gesture"><span>Spread:</span> <strong>0.00</strong></div>
+        `;
+
+        padWrapper.appendChild(padHeader);
+        padWrapper.appendChild(padSurface);
+        padWrapper.appendChild(readout);
+
+        padState.surface = padSurface;
+        padState.readout = readout;
+        padState.crosshair = crosshair;
+
+        this.attachPadEvents(padState);
+        this.padStates.push(padState);
+
+        // Initialize baselines with current parameter values
+        ['x', 'y', 'gesture'].forEach(axis => {
+            const param = padState.axisBindings[axis];
+            if (param && param !== 'none') {
+                padState.axisBaselines[axis] = this.parameterManager.getParameter(param);
+            }
+        });
+
+        return padWrapper;
+    }
+
+    applyLayoutOptions(options = {}, { silent = false } = {}) {
+        const next = {
+            ...this.layoutOptions,
+            ...options
+        };
+
+        next.padCount = Math.max(1, Math.min(8, parseInt(next.padCount, 10) || this.layoutOptions.padCount));
+        next.columns = next.columns === 'auto'
+            ? 'auto'
+            : Math.max(1, Math.min(6, parseInt(next.columns, 10) || this.layoutOptions.columns));
+        next.padSize = Math.max(0.6, Math.min(2.5, parseFloat(next.padSize) || this.layoutOptions.padSize));
+        next.padGap = Math.max(4, Math.min(48, parseInt(next.padGap, 10) || this.layoutOptions.padGap));
+        next.padAspect = Math.max(0.5, Math.min(2, parseFloat(next.padAspect) || this.layoutOptions.padAspect));
+        next.crosshair = Math.max(8, Math.min(48, parseInt(next.crosshair, 10) || this.layoutOptions.crosshair));
+
+        const padCountChanged = next.padCount !== this.padCount;
+
+        this.layoutOptions = next;
+
+        if (padCountChanged) {
+            this.padCount = next.padCount;
+            this.buildUI();
+        }
+
+        this.updateLayoutStyles();
+
+        if (!silent) {
+            this.emitLayoutChange();
+        }
+    }
+
+    updateLayoutStyles() {
+        if (!this.container) return;
+
+        const {
+            columns,
+            padSize,
+            padGap,
+            padAspect,
+            crosshair
+        } = this.layoutOptions;
+
+        const minHeight = Math.round(220 * padSize);
+        const padding = Math.max(8, Math.round(12 * padSize));
+        const radius = Math.max(8, Math.round(14 * padSize));
+        const template = columns === 'auto'
+            ? `repeat(auto-fit, minmax(${minHeight}px, 1fr))`
+            : `repeat(${columns}, minmax(${minHeight}px, 1fr))`;
+
+        this.container.style.setProperty('--touchpad-template', template);
+        this.container.style.setProperty('--touchpad-gap', `${padGap}px`);
+        this.container.style.setProperty('--touchpad-min-height', `${minHeight}px`);
+        this.container.style.setProperty('--touchpad-aspect', padAspect.toFixed(2));
+        this.container.style.setProperty('--touchpad-padding', `${padding}px`);
+        this.container.style.setProperty('--touchpad-radius', `${radius}px`);
+        this.container.style.setProperty('--touchpad-crosshair', `${crosshair}px`);
+    }
+
+    emitLayoutChange() {
+        if (typeof this.onLayoutChange === 'function') {
+            this.onLayoutChange(this.getLayoutOptions());
+        }
+    }
+
+    getLayoutOptions() {
+        return { ...this.layoutOptions };
+    }
+
+    /**
+     * Create axis selector and mode toggle controls
+     */
+    createAxisControl(label, axisKey, selectedValue, mode, allowNone = false) {
+        const container = document.createElement('div');
+        container.classList.add('axis-control');
+
+        const labelElement = document.createElement('label');
+        labelElement.textContent = label;
+
+        const select = document.createElement('select');
+        select.classList.add('axis-select');
+
+        populateSelectWithOptions(select, this.parameterOptionGroups, { allowNone });
+
+        if (selectedValue && selectedValue !== 'none') {
+            ensureOption(select, selectedValue, this.getParameterLabel(selectedValue));
+        }
+
+        if (selectedValue) {
+            select.value = selectedValue;
+        } else {
+            select.value = allowNone ? 'none' : select.options[0]?.value;
+        }
+
+        const modeButton = document.createElement('button');
+        modeButton.type = 'button';
+        modeButton.classList.add('axis-mode');
+        modeButton.dataset.axis = axisKey;
+        this.updateModeButton(modeButton, mode);
+
+        container.appendChild(labelElement);
+        container.appendChild(select);
+        container.appendChild(modeButton);
+
+        return {
+            container,
+            select,
+            modeButton
+        };
+    }
+
+    /**
+     * Update mode button visual state
+     */
+    updateModeButton(button, mode) {
+        button.dataset.mode = mode;
+        if (mode === 'swing') {
+            button.textContent = '±';
+            button.title = 'Swing mode: center is neutral';
+        } else if (mode === 'absolute') {
+            button.textContent = '→';
+            button.title = 'Absolute mode: full range control';
+        } else {
+            button.textContent = '∑';
+            button.title = 'Aggregate mode';
+        }
+    }
+
+    /**
+     * Attach pointer and control events to a pad
+     */
+    attachPadEvents(padState) {
+        const { surface, controls } = padState;
+
+        surface.addEventListener('pointerdown', (event) => {
+            surface.setPointerCapture(event.pointerId);
+            this.addPointer(padState, event);
+        });
+
+        surface.addEventListener('pointermove', (event) => {
+            if (!padState.activePointers.has(event.pointerId)) return;
+            this.updatePointer(padState, event);
+        });
+
+        ['pointerup', 'pointercancel', 'pointerleave', 'pointerout'].forEach(type => {
+            surface.addEventListener(type, (event) => {
+                this.removePointer(padState, event.pointerId);
+            });
+        });
+
+        // Keyboard fallback for single pointer adjustments
+        surface.addEventListener('keydown', (event) => {
+            const step = (event.shiftKey ? 0.05 : 0.02);
+            if (event.key === 'ArrowLeft') {
+                this.nudgePad(padState, -step, 0);
+                event.preventDefault();
+            } else if (event.key === 'ArrowRight') {
+                this.nudgePad(padState, step, 0);
+                event.preventDefault();
+            } else if (event.key === 'ArrowUp') {
+                this.nudgePad(padState, 0, step);
+                event.preventDefault();
+            } else if (event.key === 'ArrowDown') {
+                this.nudgePad(padState, 0, -step);
+                event.preventDefault();
+            }
+        });
+
+        controls.x.select.addEventListener('change', () => this.updateAxisBinding(padState, 'x'));
+        controls.y.select.addEventListener('change', () => this.updateAxisBinding(padState, 'y'));
+        controls.gesture.select.addEventListener('change', () => this.updateAxisBinding(padState, 'gesture'));
+
+        controls.x.modeButton.addEventListener('click', () => this.toggleAxisMode(padState, 'x'));
+        controls.y.modeButton.addEventListener('click', () => this.toggleAxisMode(padState, 'y'));
+        controls.gesture.modeButton.addEventListener('click', () => this.toggleAxisMode(padState, 'gesture', ['absolute', 'swing']));
+    }
+
+    /**
+     * Update axis bindings when drop-down changes
+     */
+    updateAxisBinding(padState, axis) {
+        const control = padState.controls[axis];
+        const newValue = control.select.value;
+        padState.axisBindings[axis] = newValue;
+
+        if (newValue && newValue !== 'none') {
+            padState.axisBaselines[axis] = this.parameterManager.getParameter(newValue);
+        }
+
+        this.notifyMappingChange();
+    }
+
+    /**
+     * Toggle axis control mode
+     */
+    toggleAxisMode(padState, axis, allowedModes = ['swing', 'absolute']) {
+        const currentMode = padState.axisModes[axis];
+        const index = allowedModes.indexOf(currentMode);
+        const nextMode = allowedModes[(index + 1) % allowedModes.length];
+        padState.axisModes[axis] = nextMode;
+        this.updateModeButton(padState.controls[axis].modeButton, nextMode);
+        this.notifyMappingChange();
+    }
+
+    /**
+     * Add a pointer to the pad state
+     */
+    addPointer(padState, event) {
+        padState.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+        this.updatePadFromPointers(padState);
+    }
+
+    /**
+     * Update pointer position
+     */
+    updatePointer(padState, event) {
+        padState.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+        this.updatePadFromPointers(padState);
+    }
+
+    /**
+     * Remove pointer from pad state
+     */
+    removePointer(padState, pointerId) {
+        if (padState.activePointers.has(pointerId)) {
+            padState.activePointers.delete(pointerId);
+            this.updatePadFromPointers(padState, { pointerReleased: true });
+        }
+    }
+
+    /**
+     * Nudge pad position via keyboard controls
+     */
+    nudgePad(padState, deltaX, deltaY) {
+        padState.centroid.x = this.clamp01(padState.centroid.x + deltaX);
+        padState.centroid.y = this.clamp01(padState.centroid.y - deltaY);
+        this.applyPadValues(padState);
+    }
+
+    /**
+     * Update pad values based on active pointers
+     */
+    updatePadFromPointers(padState, options = {}) {
+        const { surface } = padState;
+        const rect = surface.getBoundingClientRect();
+
+        if (padState.activePointers.size === 0) {
+            if (options.pointerReleased) {
+                // Optionally ease back to center on release in swing mode
+                if (padState.axisModes.x === 'swing' || padState.axisModes.y === 'swing') {
+                    padState.centroid = { x: 0.5, y: 0.5 };
+                    padState.gestureValue = 0;
+                    this.applyPadValues(padState, { graceful: true });
+                }
+            }
+            return;
+        }
+
+        const positions = Array.from(padState.activePointers.values()).map(pointer => {
+            return {
+                x: this.clamp01((pointer.x - rect.left) / rect.width),
+                y: this.clamp01((pointer.y - rect.top) / rect.height)
+            };
+        });
+
+        const centroid = positions.reduce((acc, pos) => ({
+            x: acc.x + pos.x,
+            y: acc.y + pos.y
+        }), { x: 0, y: 0 });
+
+        centroid.x /= positions.length;
+        centroid.y /= positions.length;
+
+        padState.centroid = centroid;
+        padState.gestureValue = this.calculateGestureValue(positions, centroid, rect);
+
+        this.applyPadValues(padState);
+    }
+
+    /**
+     * Calculate gesture intensity based on multi-touch spread
+     */
+    calculateGestureValue(positions, centroid, rect) {
+        if (positions.length <= 1) return 0;
+
+        const maxDistance = Math.sqrt(rect.width ** 2 + rect.height ** 2) / Math.sqrt(2);
+        const distances = positions.map(pos => {
+            const dx = (pos.x - centroid.x) * rect.width;
+            const dy = (pos.y - centroid.y) * rect.height;
+            return Math.sqrt(dx * dx + dy * dy);
+        });
+
+        const averageDistance = distances.reduce((sum, distance) => sum + distance, 0) / distances.length;
+        return this.clamp01(averageDistance / maxDistance);
+    }
+
+    /**
+     * Apply current pad values to parameters
+     */
+    applyPadValues(padState, options = {}) {
+        const { centroid, gestureValue } = padState;
+        const crosshair = padState.crosshair;
+
+        crosshair.style.setProperty('--x', `${centroid.x * 100}%`);
+        crosshair.style.setProperty('--y', `${centroid.y * 100}%`);
+
+        const xParam = padState.axisBindings.x;
+        const yParam = padState.axisBindings.y;
+        const gestureParam = padState.axisBindings.gesture;
+
+        const updates = [];
+
+        if (xParam && xParam !== 'none') {
+            const value = this.convertNormalizedToParam(xParam, centroid.x, padState.axisModes.x, padState.axisBaselines.x);
+            updates.push({ param: xParam, value, axis: 'x' });
+        }
+
+        if (yParam && yParam !== 'none') {
+            const invertedY = 1 - centroid.y;
+            const value = this.convertNormalizedToParam(yParam, invertedY, padState.axisModes.y, padState.axisBaselines.y);
+            updates.push({ param: yParam, value, axis: 'y' });
+        }
+
+        if (gestureParam && gestureParam !== 'none') {
+            const value = this.convertNormalizedToParam(
+                gestureParam,
+                gestureValue,
+                padState.axisModes.gesture,
+                padState.axisBaselines.gesture
+            );
+            updates.push({ param: gestureParam, value, axis: 'gesture' });
+        }
+
+        updates.forEach(update => {
+            const applied = this.parameterManager.setParameter(update.param, update.value, 'touchpad');
+            if (applied) {
+                if (update.axis === 'x') padState.axisBaselines.x = this.parameterManager.getParameter(update.param);
+                if (update.axis === 'y') padState.axisBaselines.y = this.parameterManager.getParameter(update.param);
+                if (update.axis === 'gesture') padState.axisBaselines.gesture = this.parameterManager.getParameter(update.param);
+            }
+        });
+
+        this.updateReadout(padState, updates);
+
+        if (!options.graceful) {
+            this.notifyMappingChange();
+        }
+    }
+
+    /**
+     * Convert normalized 0-1 input to parameter range
+     */
+    convertNormalizedToParam(paramName, normalizedValue, mode, baseline) {
+        const definition = this.parameterManager.getParameterDefinition(paramName);
+        if (!definition) return normalizedValue;
+
+        const span = definition.max - definition.min;
+
+        if (mode === 'swing') {
+            const base = baseline != null ? baseline : this.parameterManager.getParameter(paramName);
+            const delta = (normalizedValue * 2 - 1) * span * 0.5;
+            return this.parameterManager.clampToDefinition(paramName, base + delta);
+        }
+
+        return this.parameterManager.clampToDefinition(paramName, definition.min + normalizedValue * span);
+    }
+
+    /**
+     * Update readout values for a pad
+     */
+    updateReadout(padState, updates) {
+        if (!padState.readout) return;
+        const xLine = padState.readout.querySelector('div:nth-child(1) strong');
+        const yLine = padState.readout.querySelector('div:nth-child(2) strong');
+        const gestureLine = padState.readout.querySelector('.touchpad-gesture strong');
+
+        updates.forEach(update => {
+            const valueText = update.value.toFixed(2);
+            if (update.axis === 'x') xLine.textContent = valueText;
+            if (update.axis === 'y') yLine.textContent = valueText;
+            if (update.axis === 'gesture') gestureLine.textContent = valueText;
+        });
+    }
+
+    /**
+     * Register listeners for parameter updates
+     */
+    registerListeners() {
+        if (!this.parameterManager) return;
+        this.unsubscribe = this.parameterManager.addChangeListener(({ name, value }) => {
+            this.padStates.forEach(padState => {
+                ['x', 'y', 'gesture'].forEach(axis => {
+                    if (padState.axisBindings[axis] === name) {
+                        if (padState.axisModes[axis] === 'swing') {
+                            padState.axisBaselines[axis] = value;
+                        }
+                        if (axis === 'x') {
+                            const xLine = padState.readout.querySelector('div:nth-child(1) strong');
+                            xLine.textContent = value.toFixed(2);
+                        } else if (axis === 'y') {
+                            const yLine = padState.readout.querySelector('div:nth-child(2) strong');
+                            yLine.textContent = value.toFixed(2);
+                        } else if (axis === 'gesture') {
+                            const gestureLine = padState.readout.querySelector('.touchpad-gesture strong');
+                            gestureLine.textContent = value.toFixed(2);
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    /**
+     * Notify listeners about mapping changes
+     */
+    notifyMappingChange() {
+        if (typeof this.onMappingChange === 'function') {
+            this.onMappingChange(this.getMappings());
+        }
+    }
+
+    /**
+     * Retrieve current mappings for persistence
+     */
+    getMappings() {
+        return this.padStates.map(padState => ({
+            id: padState.id,
+            bindings: { ...padState.axisBindings },
+            modes: { ...padState.axisModes }
+        }));
+    }
+
+    /**
+     * Apply mappings from saved preset
+     */
+    applyMappings(mappings = []) {
+        mappings.forEach(mapping => {
+            const padState = this.padStates[mapping.id];
+            if (!padState) return;
+
+            ['x', 'y', 'gesture'].forEach(axis => {
+                const param = mapping.bindings?.[axis];
+                if (param) {
+                    padState.axisBindings[axis] = param;
+                    if (padState.controls[axis]) {
+                        ensureOption(padState.controls[axis].select, param, this.getParameterLabel(param));
+                        padState.controls[axis].select.value = param;
+                    }
+                    if (param !== 'none') {
+                        padState.axisBaselines[axis] = this.parameterManager.getParameter(param);
+                    }
+                }
+
+                const mode = mapping.modes?.[axis];
+                if (mode) {
+                    padState.axisModes[axis] = mode;
+                    if (padState.controls[axis]) {
+                        this.updateModeButton(padState.controls[axis].modeButton, mode);
+                    }
+                }
+            });
+        });
+
+        this.notifyMappingChange();
+    }
+
+    /**
+     * Format parameter names for UI
+     */
+    formatParameterName(name) {
+        return this.getParameterLabel(name);
+    }
+
+    getParameterLabel(name) {
+        if (!name || name === 'none') return 'None';
+        if (this.parameterManager?.formatParameterLabel) {
+            return this.parameterManager.formatParameterLabel(name);
+        }
+
+        return name
+            .replace(/rot4d/, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+
+    clamp01(value) {
+        return Math.max(0, Math.min(1, value));
+    }
+
+    /**
+     * Destroy controller and detach listeners
+     */
+    destroy() {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+            this.unsubscribe = null;
+        }
+
+        this.padStates.forEach(padState => {
+            padState.activePointers.clear();
+        });
+    }
+}

--- a/src/ui/parameterOptions.js
+++ b/src/ui/parameterOptions.js
@@ -1,0 +1,88 @@
+export function getParameterOptionGroups(parameterManager, options = {}) {
+    if (!parameterManager) return [];
+
+    const descriptors = typeof parameterManager.listParameterDescriptors === 'function'
+        ? parameterManager.listParameterDescriptors(options)
+        : (parameterManager.listParameters?.() || []).map(name => ({
+            name,
+            label: parameterManager.formatParameterLabel
+                ? parameterManager.formatParameterLabel(name)
+                : formatFallbackLabel(name),
+            category: 'General'
+        }));
+
+    const groups = new Map();
+    descriptors.forEach(descriptor => {
+        const category = descriptor.category || 'General';
+        if (!groups.has(category)) {
+            groups.set(category, []);
+        }
+        groups.get(category).push({
+            value: descriptor.name,
+            label: descriptor.label,
+            descriptor
+        });
+    });
+
+    return Array.from(groups.entries())
+        .map(([category, options]) => ({
+            category,
+            options: options.sort((a, b) => a.label.localeCompare(b.label))
+        }))
+        .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+export function ensureOption(selectElement, value, label) {
+    if (!selectElement || value == null) return;
+    const exists = Array.from(selectElement.options).some(option => option.value === String(value));
+    if (!exists) {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label || value;
+        selectElement.appendChild(option);
+    }
+}
+
+export function populateSelectWithOptions(selectElement, groups, { allowNone = false, noneLabel = 'None' } = {}) {
+    if (!selectElement) return;
+    selectElement.innerHTML = '';
+
+    if (allowNone) {
+        const noneOption = document.createElement('option');
+        noneOption.value = 'none';
+        noneOption.textContent = noneLabel;
+        selectElement.appendChild(noneOption);
+    }
+
+    groups.forEach(group => {
+        if (group.options.length === 0) return;
+
+        if (groups.length > 1) {
+            const optgroup = document.createElement('optgroup');
+            optgroup.label = group.category;
+            group.options.forEach(optionData => {
+                const option = document.createElement('option');
+                option.value = optionData.value;
+                option.textContent = optionData.label;
+                optgroup.appendChild(option);
+            });
+            selectElement.appendChild(optgroup);
+        } else {
+            group.options.forEach(optionData => {
+                const option = document.createElement('option');
+                option.value = optionData.value;
+                option.textContent = optionData.label;
+                selectElement.appendChild(option);
+            });
+        }
+    });
+}
+
+function formatFallbackLabel(name) {
+    return name
+        .replace(/rot4d/, '4D ')
+        .replace(/([A-Z])/g, ' $1')
+        .replace(/_/g, ' ')
+        .replace(/^./, char => char.toUpperCase())
+        .trim();
+}

--- a/styles/performance.css
+++ b/styles/performance.css
@@ -1,0 +1,438 @@
+.performance-suite {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(10, 20, 40, 0.85), rgba(5, 10, 30, 0.85));
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+    --touchpad-template: repeat(auto-fit, minmax(220px, 1fr));
+    --touchpad-gap: 16px;
+    --touchpad-min-height: 220px;
+    --touchpad-aspect: 1;
+    --touchpad-padding: 12px;
+    --touchpad-radius: 16px;
+    --touchpad-crosshair: 16px;
+}
+
+.performance-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.performance-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(12, 20, 40, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.1);
+}
+
+.performance-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.performance-section-header h3 {
+    font-size: 1.1rem;
+    letter-spacing: 0.05em;
+    color: #7ef9ff;
+}
+
+.performance-subtitle {
+    font-size: 0.75rem;
+    opacity: 0.75;
+    margin-top: 0.25rem;
+}
+
+.toggle-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(0, 255, 255, 0.1);
+    border: 1px solid rgba(0, 255, 255, 0.3);
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.toggle-pill input {
+    accent-color: #00e6ff;
+}
+
+.touchpad-grid {
+    display: grid;
+    grid-template-columns: var(--touchpad-template);
+    gap: var(--touchpad-gap);
+}
+
+.touchpad-wrapper {
+    background: rgba(6, 15, 30, 0.8);
+    border-radius: var(--touchpad-radius);
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    padding: var(--touchpad-padding);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.touchpad-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.touchpad-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: #9effff;
+}
+
+.touchpad-mapping {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+}
+
+.axis-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.7rem;
+}
+
+.axis-control label {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.axis-select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 25, 0.6);
+    color: #e8f8ff;
+}
+
+.axis-mode {
+    border: 1px solid rgba(0, 255, 255, 0.35);
+    background: rgba(0, 60, 90, 0.35);
+    color: #9effff;
+    padding: 0.3rem;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.touchpad-surface {
+    position: relative;
+    width: 100%;
+    min-height: var(--touchpad-min-height);
+    aspect-ratio: var(--touchpad-aspect);
+    border-radius: calc(var(--touchpad-radius) - 2px);
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: radial-gradient(circle at center, rgba(0, 255, 255, 0.1), rgba(0, 20, 40, 0.8));
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.touchpad-crosshair {
+    position: absolute;
+    top: var(--y, 50%);
+    left: var(--x, 50%);
+    width: var(--touchpad-crosshair);
+    height: var(--touchpad-crosshair);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.6);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
+
+.touchpad-readout {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    color: rgba(200, 240, 255, 0.9);
+}
+
+.touchpad-readout span {
+    opacity: 0.7;
+    margin-right: 0.25rem;
+}
+
+.performance-column--layout .layout-controls {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.performance-column--layout label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.performance-column--layout input[type="range"],
+.performance-column--layout select {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 10, 25, 0.6);
+    color: #e8f8ff;
+    padding: 0.35rem 0.5rem;
+}
+
+.performance-column--layout output {
+    font-size: 0.7rem;
+    color: rgba(170, 220, 255, 0.85);
+}
+
+.audio-global-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.75rem;
+}
+
+.audio-global-controls label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+}
+
+.audio-global-controls input[type="range"] {
+    accent-color: #00e6ff;
+}
+
+.audio-band-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.audio-band {
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(6, 18, 40, 0.65);
+}
+
+.audio-band.disabled {
+    opacity: 0.5;
+}
+
+.band-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.band-preview {
+    font-size: 0.75rem;
+    opacity: 0.8;
+}
+
+.band-control-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.band-control-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.band-control-grid select,
+.band-control-grid input {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.6);
+    color: #e8f8ff;
+    padding: 0.35rem 0.5rem;
+}
+
+.audio-flourish {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 120, 255, 0.2);
+    background: rgba(40, 12, 40, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.flourish-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.flourish-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.flourish-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.performance-presets .preset-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.preset-create {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.preset-create input {
+    padding: 0.5rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 15, 25, 0.6);
+    color: #e8f8ff;
+}
+
+.preset-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.preset-actions button,
+.preset-buttons button,
+.sequence-actions button,
+.sequence-form button {
+    padding: 0.45rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.3);
+    background: rgba(0, 40, 60, 0.6);
+    color: #9effff;
+    cursor: pointer;
+    font-size: 0.75rem;
+}
+
+.preset-buttons {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.preset-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.15);
+    background: rgba(8, 18, 35, 0.6);
+    margin-bottom: 0.5rem;
+}
+
+.preset-meta h4 {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+}
+
+.preset-meta span {
+    font-size: 0.7rem;
+    opacity: 0.6;
+}
+
+.preset-empty {
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
+
+.sequence-builder {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    background: rgba(6, 18, 30, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sequence-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.sequence-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.5rem;
+}
+
+.sequence-form select,
+.sequence-form input {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.55);
+    color: #e8f8ff;
+    padding: 0.4rem 0.5rem;
+}
+
+.sequence-flourish {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.sequence-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sequence-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(4, 12, 24, 0.7);
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    font-size: 0.75rem;
+}
+
+.sequence-list button {
+    border: 1px solid rgba(255, 120, 120, 0.35);
+    background: rgba(60, 10, 10, 0.55);
+    color: #ffdede;
+}
+
+@media (max-width: 960px) {
+    .performance-suite {
+        margin-top: 1rem;
+        padding: 1rem;
+    }
+
+    .performance-columns {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- enrich the parameter manager with labels, categories, and descriptor helpers for UI builders
- add shared parameter option utilities plus a layout control panel so touchpads can be resized, regrouped, and saved with presets
- update the performance suite, audio reactivity panel, and preset manager to use the new metadata and configurable layouts while refreshing the performance styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc05caa6508329ab27b723e3f7b18c