### PR TITLE
Add touchpad layout preset management controls

### DIFF
--- a/index-clean.html
+++ b/index-clean.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/reactivity.css">
     <link rel="stylesheet" href="styles/mobile.css">
     <link rel="stylesheet" href="styles/animations.css">
+    <link rel="stylesheet" href="styles/performance.css">
 </head>
 <body class="loading">
     <!-- Top Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VIB34D Engine - Canvas Explosion FIXED</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/performance.css">
     <style>
         * {
             margin: 0;

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -9,100 +9,216 @@ export class ParameterManager {
         this.params = {
             // Current variation
             variation: 0,
-            
+
             // 4D Polytopal Mathematics
             rot4dXW: 0.0,      // X-W plane rotation (-2 to 2)
-            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2) 
+            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2)
             rot4dZW: 0.0,      // Z-W plane rotation (-2 to 2)
             dimension: 3.5,    // Dimensional level (3.0 to 4.5)
-            
+
             // Holographic Visualization
-            gridDensity: 15,   // Geometric detail (4 to 30)
+            gridDensity: 15,   // Geometric detail (4 to 100)
             morphFactor: 1.0,  // Shape transformation (0 to 2)
             chaos: 0.2,        // Randomization level (0 to 1)
             speed: 1.0,        // Animation speed (0.1 to 3)
             hue: 200,          // Color rotation (0 to 360)
             intensity: 0.5,    // Visual intensity (0 to 1)
             saturation: 0.8,   // Color saturation (0 to 1)
-            
+
             // Geometry selection
             geometry: 0        // Current geometry type (0-7)
         };
-        
+
         // Parameter definitions for validation and UI
         this.parameterDefs = {
-            variation: { min: 0, max: 99, step: 1, type: 'int' },
-            rot4dXW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dYW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dZW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            dimension: { min: 3.0, max: 4.5, step: 0.01, type: 'float' },
-            gridDensity: { min: 4, max: 100, step: 0.1, type: 'float' },
-            morphFactor: { min: 0, max: 2, step: 0.01, type: 'float' },
-            chaos: { min: 0, max: 1, step: 0.01, type: 'float' },
-            speed: { min: 0.1, max: 3, step: 0.01, type: 'float' },
-            hue: { min: 0, max: 360, step: 1, type: 'int' },
-            intensity: { min: 0, max: 1, step: 0.01, type: 'float' },
-            saturation: { min: 0, max: 1, step: 0.01, type: 'float' },
-            geometry: { min: 0, max: 7, step: 1, type: 'int' }
+            variation: {
+                min: 0,
+                max: 99,
+                step: 1,
+                type: 'int',
+                label: 'Variation Index',
+                group: 'Show Control',
+                tags: ['variation', 'preset']
+            },
+            rot4dXW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation X↔W',
+                group: '4D Rotation',
+                tags: ['rotation', 'geometry', 'performance']
+            },
+            rot4dYW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Y↔W',
+                group: '4D Rotation',
+                tags: ['rotation', 'geometry', 'performance']
+            },
+            rot4dZW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Z↔W',
+                group: '4D Rotation',
+                tags: ['rotation', 'geometry', 'performance']
+            },
+            dimension: {
+                min: 3.0,
+                max: 4.5,
+                step: 0.01,
+                type: 'float',
+                label: 'Dimensional Blend',
+                group: '4D Rotation',
+                tags: ['geometry', 'morph']
+            },
+            gridDensity: {
+                min: 4,
+                max: 100,
+                step: 0.1,
+                type: 'float',
+                label: 'Grid Density',
+                group: 'Structure',
+                tags: ['structure', 'resolution', 'audio']
+            },
+            morphFactor: {
+                min: 0,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Morph Factor',
+                group: 'Structure',
+                tags: ['morph', 'performance']
+            },
+            chaos: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Chaos',
+                group: 'Dynamics',
+                tags: ['randomness', 'audio']
+            },
+            speed: {
+                min: 0.1,
+                max: 3,
+                step: 0.01,
+                type: 'float',
+                label: 'Animation Speed',
+                group: 'Dynamics',
+                tags: ['tempo', 'audio', 'performance']
+            },
+            hue: {
+                min: 0,
+                max: 360,
+                step: 1,
+                type: 'int',
+                label: 'Hue Rotation',
+                group: 'Color',
+                tags: ['color', 'audio']
+            },
+            intensity: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Light Intensity',
+                group: 'Color',
+                tags: ['color', 'dynamics', 'audio']
+            },
+            saturation: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Saturation',
+                group: 'Color',
+                tags: ['color']
+            },
+            geometry: {
+                min: 0,
+                max: 7,
+                step: 1,
+                type: 'int',
+                label: 'Geometry Index',
+                group: 'Structure',
+                tags: ['structure', 'preset']
+            }
         };
-        
+
         // Default parameter backup for reset
         this.defaults = { ...this.params };
+
+        // Event listeners for reactive extensions
+        this.listeners = new Set();
+
+        // Active interpolation bookkeeping
+        this._activeInterpolation = null;
+        this._interpolationFrame = null;
     }
-    
+
     /**
      * Get all current parameters
      */
     getAllParameters() {
         return { ...this.params };
     }
-    
-    /**
-     * Set a specific parameter with validation
-     */
-    setParameter(name, value) {
-        if (this.parameterDefs[name]) {
-            const def = this.parameterDefs[name];
-            
-            // Clamp value to valid range
-            value = Math.max(def.min, Math.min(def.max, value));
-            
-            // Apply type conversion
-            if (def.type === 'int') {
-                value = Math.round(value);
-            }
-            
-            this.params[name] = value;
-            return true;
-        }
-        
-        console.warn(`Unknown parameter: ${name}`);
-        return false;
-    }
-    
-    /**
-     * Set multiple parameters at once
-     */
-    setParameters(paramObj) {
-        for (const [name, value] of Object.entries(paramObj)) {
-            this.setParameter(name, value);
-        }
-    }
-    
+
     /**
      * Get a specific parameter value
      */
     getParameter(name) {
         return this.params[name];
     }
-    
+
+    /**
+     * Set a specific parameter with validation
+     */
+    setParameter(name, value, source = 'manual', options = {}) {
+        if (!this.parameterDefs[name]) {
+            console.warn(`Unknown parameter: ${name}`);
+            return false;
+        }
+
+        const clampedValue = this.clampToDefinition(name, value);
+        const previousValue = this.params[name];
+        const hasChanged = options.force
+            ? true
+            : this.hasMeaningfulChange(previousValue, clampedValue, this.parameterDefs[name]);
+
+        if (!hasChanged) {
+            return false;
+        }
+
+        this.params[name] = clampedValue;
+
+        if (!options.silent) {
+            this.emitChange(name, clampedValue, source);
+        }
+
+        return true;
+    }
+
+    /**
+     * Set multiple parameters at once
+     */
+    setParameters(paramObj, source = 'bulk', options = {}) {
+        for (const [name, value] of Object.entries(paramObj)) {
+            this.setParameter(name, value, source, options);
+        }
+    }
+
     /**
      * Set geometry type with validation
      */
     setGeometry(geometryType) {
-        this.setParameter('geometry', geometryType);
+        this.setParameter('geometry', geometryType, 'ui');
     }
-    
+
     /**
      * Update parameters from UI controls
      */
@@ -111,23 +227,21 @@ export class ParameterManager {
             'variationSlider', 'rot4dXW', 'rot4dYW', 'rot4dZW', 'dimension',
             'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue'
         ];
-        
+
         controlIds.forEach(id => {
             const element = document.getElementById(id);
-            if (element) {
-                const value = parseFloat(element.value);
-                
-                // Map slider IDs to parameter names
-                let paramName = id;
-                if (id === 'variationSlider') {
-                    paramName = 'variation';
-                }
-                
-                this.setParameter(paramName, value);
+            if (!element) return;
+
+            const value = parseFloat(element.value);
+            let paramName = id;
+            if (id === 'variationSlider') {
+                paramName = 'variation';
             }
+
+            this.setParameter(paramName, value, 'ui');
         });
     }
-    
+
     /**
      * Update UI display values from current parameters
      */
@@ -143,7 +257,7 @@ export class ParameterManager {
         this.updateSliderValue('chaos', this.params.chaos);
         this.updateSliderValue('speed', this.params.speed);
         this.updateSliderValue('hue', this.params.hue);
-        
+
         // Update display texts
         this.updateDisplayText('rot4dXWDisplay', this.params.rot4dXW.toFixed(2));
         this.updateDisplayText('rot4dYWDisplay', this.params.rot4dYW.toFixed(2));
@@ -153,94 +267,96 @@ export class ParameterManager {
         this.updateDisplayText('morphFactorDisplay', this.params.morphFactor.toFixed(2));
         this.updateDisplayText('chaosDisplay', this.params.chaos.toFixed(2));
         this.updateDisplayText('speedDisplay', this.params.speed.toFixed(2));
-        this.updateDisplayText('hueDisplay', this.params.hue + '°');
-        
-        // Update variation info
+        this.updateDisplayText('hueDisplay', `${this.params.hue}°`);
+
+        // Update variation info and geometry buttons
         this.updateVariationInfo();
-        
-        // Update geometry preset buttons
         this.updateGeometryButtons();
     }
-    
+
     updateSliderValue(id, value) {
         const element = document.getElementById(id);
         if (element) {
             element.value = value;
         }
     }
-    
+
     updateDisplayText(id, text) {
         const element = document.getElementById(id);
         if (element) {
             element.textContent = text;
         }
     }
-    
+
     updateVariationInfo() {
         const variationDisplay = document.getElementById('currentVariationDisplay');
-        if (variationDisplay) {
-            const geometryNames = [
-                'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
-                'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
-            ];
-            
-            const geometryType = Math.floor(this.params.variation / 4);
-            const geometryLevel = (this.params.variation % 4) + 1;
-            const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
-            
-            variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
-            
-            if (this.params.variation < 30) {
-                variationDisplay.textContent += ` ${geometryLevel}`;
-            }
+        if (!variationDisplay) return;
+
+        const geometryNames = [
+            'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
+            'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
+        ];
+
+        const geometryType = Math.floor(this.params.variation / 4);
+        const geometryLevel = (this.params.variation % 4) + 1;
+        const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
+
+        variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
+
+        if (this.params.variation < 30) {
+            variationDisplay.textContent += ` ${geometryLevel}`;
         }
     }
-    
+
     updateGeometryButtons() {
         document.querySelectorAll('[data-geometry]').forEach(btn => {
-            btn.classList.toggle('active', parseInt(btn.dataset.geometry) === this.params.geometry);
+            const isActive = parseInt(btn.dataset.geometry) === this.params.geometry;
+            btn.classList.toggle('active', isActive);
         });
     }
-    
+
     /**
      * Randomize all parameters
      */
     randomizeAll() {
-        this.params.rot4dXW = Math.random() * 4 - 2;
-        this.params.rot4dYW = Math.random() * 4 - 2;
-        this.params.rot4dZW = Math.random() * 4 - 2;
-        this.params.dimension = 3.0 + Math.random() * 1.5;
-        this.params.gridDensity = 4 + Math.random() * 26;
-        this.params.morphFactor = Math.random() * 2;
-        this.params.chaos = Math.random();
-        this.params.speed = 0.1 + Math.random() * 2.9;
-        this.params.hue = Math.random() * 360;
-        this.params.geometry = Math.floor(Math.random() * 8);
+        const randomParams = {
+            rot4dXW: Math.random() * 4 - 2,
+            rot4dYW: Math.random() * 4 - 2,
+            rot4dZW: Math.random() * 4 - 2,
+            dimension: 3.0 + Math.random() * 1.5,
+            gridDensity: 4 + Math.random() * 96,
+            morphFactor: Math.random() * 2,
+            chaos: Math.random(),
+            speed: 0.1 + Math.random() * 2.9,
+            hue: Math.random() * 360,
+            geometry: Math.floor(Math.random() * 8)
+        };
+
+        this.setParameters(randomParams, 'randomize');
     }
-    
+
     /**
      * Reset to default parameters
      */
     resetToDefaults() {
-        this.params = { ...this.defaults };
+        this.setParameters(this.defaults, 'reset');
     }
-    
+
     /**
      * Load parameter configuration
      */
     loadConfiguration(config) {
         if (config && typeof config === 'object') {
-            // Validate and apply configuration
             for (const [key, value] of Object.entries(config)) {
                 if (this.parameterDefs[key]) {
-                    this.setParameter(key, value);
+                    this.setParameter(key, value, 'config');
                 }
             }
             return true;
         }
         return false;
     }
-    
+
     /**
      * Export current configuration
      */
@@ -253,16 +369,15 @@ export class ParameterManager {
             parameters: { ...this.params }
         };
     }
-    
+
     /**
      * Generate variation-specific parameters
      */
     generateVariationParameters(variationIndex) {
         if (variationIndex < 30) {
-            // Default variations with consistent patterns
             const geometryType = Math.floor(variationIndex / 4);
             const level = variationIndex % 4;
-            
+
             return {
                 geometry: geometryType,
                 gridDensity: 8 + (level * 4),
@@ -275,32 +390,32 @@ export class ParameterManager {
                 rot4dZW: ((geometryType + level) % 3) * 0.2,
                 dimension: 3.2 + (level * 0.2)
             };
-        } else {
-            // Custom variations - return current parameters
-            return { ...this.params };
         }
+
+        return { ...this.params };
     }
-    
+
     /**
      * Apply variation to current parameters
      */
     applyVariation(variationIndex) {
         const variationParams = this.generateVariationParameters(variationIndex);
-        this.setParameters(variationParams);
+        this.setParameters(variationParams, 'variation');
         this.params.variation = variationIndex;
+        this.emitChange('variation', variationIndex, 'variation');
     }
-    
+
     /**
      * Get HSV color values for current hue
      */
     getColorHSV() {
         return {
             h: this.params.hue,
-            s: 0.8, // Fixed saturation
-            v: 0.9  // Fixed value
+            s: 0.8,
+            v: 0.9
         };
     }
-    
+
     /**
      * Get RGB color values for current hue
      */
@@ -308,7 +423,7 @@ export class ParameterManager {
         const hsv = this.getColorHSV();
         return this.hsvToRgb(hsv.h, hsv.s, hsv.v);
     }
-    
+
     /**
      * Convert HSV to RGB
      */
@@ -317,7 +432,7 @@ export class ParameterManager {
         const c = v * s;
         const x = c * (1 - Math.abs((h % 2) - 1));
         const m = v - c;
-        
+
         let r, g, b;
         if (h < 1) {
             [r, g, b] = [c, x, 0];
@@ -332,14 +447,14 @@ export class ParameterManager {
         } else {
             [r, g, b] = [c, 0, x];
         }
-        
+
         return {
             r: Math.round((r + m) * 255),
             g: Math.round((g + m) * 255),
             b: Math.round((b + m) * 255)
         };
     }
-    
+
     /**
      * Validate parameter configuration
      */
@@ -347,16 +462,15 @@ export class ParameterManager {
         if (!config || typeof config !== 'object') {
             return { valid: false, error: 'Configuration must be an object' };
         }
-        
+
         if (config.type !== 'vib34d-integrated-config') {
             return { valid: false, error: 'Invalid configuration type' };
         }
-        
+
         if (!config.parameters) {
             return { valid: false, error: 'Missing parameters object' };
         }
-        
-        // Validate individual parameters
+
         for (const [key, value] of Object.entries(config.parameters)) {
             if (this.parameterDefs[key]) {
                 const def = this.parameterDefs[key];
@@ -365,7 +479,242 @@ export class ParameterManager {
                 }
             }
         }
-        
+
         return { valid: true };
+    }
+
+    /**
+     * Register a listener for parameter changes
+     */
+    addChangeListener(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    /**
+     * Emit change events to listeners
+     */
+    emitChange(name, value, source = 'manual') {
+        const payload = {
+            name,
+            value,
+            source,
+            params: { ...this.params }
+        };
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(payload);
+            } catch (error) {
+                console.error('Parameter listener error:', error);
+            }
+        });
+    }
+
+    /**
+     * Get the parameter definition (range, step, type)
+     */
+    getParameterDefinition(name) {
+        return this.parameterDefs[name] || null;
+    }
+
+    /**
+     * List parameter keys for UI builders
+     */
+    listParameters() {
+        return Object.keys(this.parameterDefs);
+    }
+
+    /**
+     * Retrieve metadata for a parameter key
+     */
+    getParameterMetadata(name) {
+        const def = this.parameterDefs[name];
+        if (!def) return null;
+
+        return {
+            id: name,
+            key: name,
+            label: def.label || this.formatParameterLabel(name),
+            group: def.group || 'General',
+            min: def.min,
+            max: def.max,
+            step: def.step,
+            type: def.type,
+            tags: Array.isArray(def.tags) ? [...def.tags] : []
+        };
+    }
+
+    /**
+     * List parameter metadata for UI builders with optional filtering
+     */
+    listParameterMetadata(filter = {}) {
+        const { groups = null, tags = null } = filter;
+        const groupFilter = Array.isArray(groups) && groups.length > 0 ? new Set(groups) : null;
+        const tagFilter = Array.isArray(tags) && tags.length > 0 ? new Set(tags) : null;
+
+        return Object.keys(this.parameterDefs)
+            .map(name => this.getParameterMetadata(name))
+            .filter(meta => {
+                if (!meta) return false;
+                if (groupFilter && !groupFilter.has(meta.group)) {
+                    return false;
+                }
+                if (tagFilter) {
+                    const hasTag = meta.tags.some(tag => tagFilter.has(tag));
+                    if (!hasTag) return false;
+                }
+                return true;
+            })
+            .sort((a, b) => {
+                if (a.group === b.group) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.group.localeCompare(b.group);
+            });
+    }
+
+    /**
+     * Format a readable parameter label from its key
+     */
+    formatParameterLabel(name) {
+        if (!name) return '';
+        return name
+            .replace(/rot4d/gi, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .replace(/^./, char => char.toUpperCase());
+    }
+
+    /**
+     * Get the numeric range for a parameter definition
+     */
+    getParameterRange(name) {
+        const def = this.parameterDefs[name];
+        if (!def) return null;
+        return { min: def.min, max: def.max };
+    }
+
+    /**
+     * Clamp a value according to its parameter definition
+     */
+    clampToDefinition(name, value) {
+        const def = this.parameterDefs[name];
+        if (!def) return value;
+
+        let clampedValue = Math.max(def.min, Math.min(def.max, value));
+        if (def.type === 'int') {
+            clampedValue = Math.round(clampedValue);
+        }
+
+        return clampedValue;
+    }
+
+    /**
+     * Determine if a change is meaningful (prevents micro-noise)
+     */
+    hasMeaningfulChange(previousValue, nextValue, def) {
+        if (previousValue === undefined) return true;
+
+        if (def?.type === 'int') {
+            return previousValue !== nextValue;
+        }
+
+        const epsilon = def?.step ? def.step / 10 : 1e-4;
+        return Math.abs(previousValue - nextValue) > epsilon;
+    }
+
+    /**
+     * Cancel an active interpolation if one exists
+     */
+    cancelInterpolation() {
+        if (this._interpolationFrame) {
+            cancelAnimationFrame(this._interpolationFrame);
+            this._interpolationFrame = null;
+            this._activeInterpolation = null;
+        }
+    }
+
+    /**
+     * Interpolate parameters toward a target set over time
+     */
+    interpolateTo(targetParams, duration = 1500, options = {}) {
+        if (!targetParams) return;
+
+        const keys = Object.keys(targetParams).filter(name => this.parameterDefs[name]);
+        if (keys.length === 0) return;
+
+        this.cancelInterpolation();
+
+        const initialValues = {};
+        keys.forEach(name => {
+            initialValues[name] = this.params[name];
+        });
+
+        const startTime = performance.now();
+        const totalDuration = Math.max(16, duration);
+        const easingFn = this.resolveEasing(options.easing || 'easeInOut');
+        const source = options.source || 'interpolate';
+
+        const step = (timestamp) => {
+            const elapsed = timestamp - startTime;
+            const progress = Math.min(1, elapsed / totalDuration);
+            const eased = easingFn(progress);
+
+            keys.forEach(name => {
+                const targetValue = this.clampToDefinition(name, targetParams[name]);
+                const startValue = initialValues[name];
+                const interpolated = startValue + (targetValue - startValue) * eased;
+                this.setParameter(name, interpolated, source, { force: true });
+            });
+
+            if (progress < 1) {
+                this._interpolationFrame = requestAnimationFrame(step);
+            } else {
+                this._interpolationFrame = null;
+                this._activeInterpolation = null;
+                if (typeof options.onComplete === 'function') {
+                    options.onComplete();
+                }
+            }
+        };
+
+        this._activeInterpolation = { targetParams, duration, options };
+        this._interpolationFrame = requestAnimationFrame(step);
+    }
+
+    /**
+     * Animate a single parameter toward a target value
+     */
+    animateParameter(name, targetValue, duration = 1000, options = {}) {
+        if (!this.parameterDefs[name]) return;
+        this.interpolateTo({ [name]: targetValue }, duration, {
+            ...options,
+            source: options.source || 'animation'
+        });
+    }
+
+    /**
+     * Resolve easing names into functions
+     */
+    resolveEasing(easingName) {
+        switch (easingName) {
+            case 'linear':
+                return t => t;
+            case 'easeIn':
+                return t => Math.pow(t, 3);
+            case 'easeOut':
+                return t => 1 - Math.pow(1 - t, 3);
+            case 'easeInOut':
+            default:
+                return t => t < 0.5
+                    ? 4 * t * t * t
+                    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+        }
     }
 }

--- a/src/ui/AudioReactivityPanel.js
+++ b/src/ui/AudioReactivityPanel.js
@@ -1,0 +1,867 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+/**
+ * Audio Reactivity Control Panel
+ * Provides live performance grade audio mapping configuration
+ */
+
+const DEFAULT_SETTINGS = {
+    master: true,
+    globalSensitivity: 1.0,
+    smoothing: 0.35,
+    tempo: {
+        enabled: false,
+        bpm: DEFAULT_PERFORMANCE_CONFIG.audio?.tempo?.defaultBpm ?? 120,
+        subdivision: DEFAULT_PERFORMANCE_CONFIG.audio?.tempo?.defaultSubdivision ?? '1/4',
+        autoFollow: true,
+        sourceBand: 'energy',
+        linkToPads: true,
+        nudge: 0
+    },
+    routing: {
+        sendToPads: true,
+        sendToPresets: false,
+        broadcastMidiClock: false
+    },
+    advanced: {
+        freezeOnSilence: DEFAULT_PERFORMANCE_CONFIG.audio?.advanced?.defaults?.freezeOnSilence ?? false,
+        accentuatePeaks: DEFAULT_PERFORMANCE_CONFIG.audio?.advanced?.defaults?.accentuatePeaks ?? true,
+        headroom: DEFAULT_PERFORMANCE_CONFIG.audio?.advanced?.defaults?.headroom ?? 0.2
+    },
+    bands: {
+        bass: { enabled: true, parameter: 'gridDensity', mode: 'swing', depth: 0.7, curve: 1.2 },
+        mid: { enabled: true, parameter: 'hue', mode: 'absolute', depth: 0.6, curve: 1.1 },
+        high: { enabled: true, parameter: 'intensity', mode: 'absolute', depth: 0.5, curve: 1.3 },
+        energy: { enabled: true, parameter: 'speed', mode: 'absolute', depth: 0.5, curve: 1.0 },
+        rhythm: { enabled: false, parameter: 'chaos', mode: 'swing', depth: 0.4, curve: 1.0 }
+    },
+    flourish: {
+        enabled: true,
+        band: 'energy',
+        threshold: 0.65,
+        boost: 0.45,
+        parameter: 'intensity',
+        duration: 1400,
+        cooldown: 1600
+    }
+};
+
+export class AudioReactivityPanel {
+    constructor(options = {}) {
+        const {
+            parameterManager,
+            container = null,
+            onSettingsChange = null,
+            settings = null,
+            config = DEFAULT_PERFORMANCE_CONFIG.audio,
+            hub = null
+        } = options;
+
+        this.parameterManager = parameterManager;
+        this.onSettingsChange = onSettingsChange;
+        this.hub = hub;
+        this.config = config || DEFAULT_PERFORMANCE_CONFIG.audio;
+        this.tempoConfig = this.config.tempo || DEFAULT_PERFORMANCE_CONFIG.audio.tempo || {};
+        this.routingConfig = this.config.routing || DEFAULT_PERFORMANCE_CONFIG.audio.routing || {};
+        this.availableParameters = this.buildParameterOptions();
+        this.parameterLabels = new Map(this.availableParameters.map(meta => [meta.id, meta.label]));
+        this.settings = this.mergeSettings(DEFAULT_SETTINGS, settings || {});
+        this.ensureTempoSourceBand();
+        this.ensureRoutingDefaults();
+        this.container = container || this.ensureContainer();
+        this.bandControls = new Map();
+        this.tapTimestamps = [];
+
+        this.buildUI();
+        this.applySettingsToControls();
+        this.notifyChange();
+    }
+
+    buildParameterOptions() {
+        if (!this.parameterManager) return [];
+        return this.parameterManager.listParameterMetadata().map(meta => ({
+            id: meta.id,
+            label: meta.label,
+            group: meta.group || 'General'
+        }));
+    }
+
+    ensureTempoSourceBand() {
+        const bandKeys = Object.keys(this.settings.bands || {});
+        if (bandKeys.length === 0) {
+            this.settings.tempo.sourceBand = 'energy';
+            return;
+        }
+        if (!bandKeys.includes(this.settings.tempo.sourceBand)) {
+            this.settings.tempo.sourceBand = bandKeys.includes('energy') ? 'energy' : bandKeys[0];
+        }
+    }
+
+    ensureRoutingDefaults() {
+        const toggles = Array.isArray(this.routingConfig?.toggles) && this.routingConfig.toggles.length
+            ? this.routingConfig.toggles
+            : [
+                { key: 'sendToPads', label: 'Drive Touch Pads' },
+                { key: 'sendToPresets', label: 'Influence Presets' },
+                { key: 'broadcastMidiClock', label: 'Broadcast MIDI Clock' }
+            ];
+        if (!this.settings.routing || typeof this.settings.routing !== 'object') {
+            this.settings.routing = {};
+        }
+        toggles.forEach(toggle => {
+            if (typeof this.settings.routing[toggle.key] !== 'boolean') {
+                this.settings.routing[toggle.key] = toggle.key === 'sendToPads';
+            }
+        });
+    }
+
+    renderParameterOptions(selectedValue, { allowNone = false } = {}) {
+        const groups = new Map();
+        this.availableParameters.forEach(meta => {
+            const group = meta.group || 'General';
+            if (!groups.has(group)) {
+                groups.set(group, []);
+            }
+            groups.get(group).push(meta);
+        });
+
+        const fragments = [];
+
+        if (allowNone) {
+            fragments.push(`<option value="none"${selectedValue === 'none' ? ' selected' : ''}>None</option>`);
+        }
+
+        groups.forEach((options, group) => {
+            const optionMarkup = options
+                .sort((a, b) => a.label.localeCompare(b.label))
+                .map(option => `<option value="${option.id}"${option.id === selectedValue ? ' selected' : ''}>${option.label}</option>`)
+                .join('');
+            fragments.push(`<optgroup label="${group}">${optionMarkup}</optgroup>`);
+        });
+
+        if (fragments.length === 0) {
+            return '<option value="" disabled>No parameters</option>';
+        }
+
+        return fragments.join('');
+    }
+
+    renderModeOptions(selectedValue) {
+        const modes = Array.isArray(this.config?.modes) && this.config.modes.length > 0
+            ? this.config.modes
+            : [
+                { value: 'absolute', label: 'Absolute' },
+                { value: 'swing', label: 'Swing' },
+                { value: 'relative', label: 'Relative' }
+            ];
+
+        return modes
+            .map(mode => `<option value="${mode.value}"${mode.value === selectedValue ? ' selected' : ''}>${mode.label}</option>`)
+            .join('');
+    }
+
+    renderSubdivisionOptions(selectedValue) {
+        const subdivisions = Array.isArray(this.tempoConfig?.subdivisions) && this.tempoConfig.subdivisions.length
+            ? this.tempoConfig.subdivisions
+            : DEFAULT_PERFORMANCE_CONFIG.audio.tempo.subdivisions;
+        return subdivisions
+            .map(option => `<option value="${option.value}"${option.value === selectedValue ? ' selected' : ''}>${option.label}</option>`)
+            .join('');
+    }
+
+    renderTempoBandOptions(selectedValue) {
+        const bandKeys = Object.keys(this.settings.bands || {});
+        if (bandKeys.length === 0) {
+            return '<option value="energy">Energy</option>';
+        }
+        return bandKeys
+            .map(band => `<option value="${band}"${band === selectedValue ? ' selected' : ''}>${this.formatBandLabel(band)}</option>`)
+            .join('');
+    }
+
+    renderRoutingToggles() {
+        const toggles = Array.isArray(this.routingConfig?.toggles) && this.routingConfig.toggles.length
+            ? this.routingConfig.toggles
+            : [
+                { key: 'sendToPads', label: 'Drive Touch Pads' },
+                { key: 'sendToPresets', label: 'Influence Presets' },
+                { key: 'broadcastMidiClock', label: 'Broadcast MIDI Clock' }
+            ];
+        return toggles.map(toggle => `
+            <label class="toggle-pill">
+                <input type="checkbox" data-routing-toggle="${toggle.key}" ${this.settings.routing?.[toggle.key] ? 'checked' : ''}>
+                <span>${toggle.label}</span>
+            </label>
+        `).join('');
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-audio-reactivity');
+        if (existing) return existing;
+
+        const section = document.createElement('section');
+        section.id = 'performance-audio-reactivity';
+        section.classList.add('performance-audio');
+        document.body.appendChild(section);
+        return section;
+    }
+
+    buildUI() {
+        this.container.innerHTML = '';
+        this.bandControls.clear();
+
+        const header = document.createElement('header');
+        header.classList.add('performance-section-header');
+        header.innerHTML = `
+            <div>
+                <h3>Audio Reactivity Matrix</h3>
+                <p class="performance-subtitle">Tune frequency bands, sensitivity and dynamic flourishes for synced shows.</p>
+            </div>
+            <label class="toggle-pill">
+                <input type="checkbox" id="audio-master-toggle" ${this.settings.master ? 'checked' : ''}>
+                <span>Audio Reactive</span>
+            </label>
+        `;
+
+        this.container.appendChild(header);
+
+        const globalControls = document.createElement('div');
+        globalControls.classList.add('audio-global-controls');
+        globalControls.innerHTML = `
+            <label>
+                <span>Sensitivity</span>
+                <input type="range" id="audio-sensitivity" min="0.2" max="3" step="0.05" value="${this.settings.globalSensitivity}">
+            </label>
+            <label>
+                <span>Smoothing</span>
+                <input type="range" id="audio-smoothing" min="0" max="0.9" step="0.05" value="${this.settings.smoothing}">
+            </label>
+        `;
+
+        this.container.appendChild(globalControls);
+
+        const bandGrid = document.createElement('div');
+        bandGrid.classList.add('audio-band-grid');
+        this.container.appendChild(bandGrid);
+
+        Object.entries(this.settings.bands).forEach(([band, bandSettings]) => {
+            const bandElement = this.createBandControl(band, bandSettings);
+            bandGrid.appendChild(bandElement);
+        });
+
+        const tempoSection = document.createElement('div');
+        tempoSection.classList.add('audio-tempo');
+        tempoSection.innerHTML = `
+            <div class="tempo-header">
+                <h4>Tempo &amp; Sync</h4>
+                <label class="toggle-pill">
+                    <input type="checkbox" id="tempo-enabled" ${this.settings.tempo.enabled ? 'checked' : ''}>
+                    <span>Enable</span>
+                </label>
+            </div>
+            <div class="tempo-grid">
+                <label>
+                    <span>BPM</span>
+                    <input type="number" id="tempo-bpm" min="40" max="220" step="1" value="${Math.round(this.settings.tempo.bpm)}">
+                </label>
+                <label>
+                    <span>Subdivision</span>
+                    <select id="tempo-subdivision">${this.renderSubdivisionOptions(this.settings.tempo.subdivision)}</select>
+                </label>
+                <label>
+                    <span>Follow Band</span>
+                    <select id="tempo-source-band">${this.renderTempoBandOptions(this.settings.tempo.sourceBand)}</select>
+                </label>
+                <label class="toggle-pill tempo-toggle">
+                    <input type="checkbox" id="tempo-auto" ${this.settings.tempo.autoFollow ? 'checked' : ''}>
+                    <span>Adaptive BPM</span>
+                </label>
+                <label class="toggle-pill tempo-toggle">
+                    <input type="checkbox" id="tempo-link-pads" ${this.settings.tempo.linkToPads ? 'checked' : ''}>
+                    <span>Drive Touch Pads</span>
+                </label>
+                <label class="tempo-nudge">
+                    <span>Nudge</span>
+                    <input type="range" id="tempo-nudge" min="-0.5" max="0.5" step="0.01" value="${this.settings.tempo.nudge}">
+                    <span class="tempo-nudge-value">${this.formatTempoNudge(this.settings.tempo.nudge)}</span>
+                </label>
+                <button id="tempo-tap" class="tempo-tap">Tap Tempo</button>
+            </div>
+        `;
+        this.container.appendChild(tempoSection);
+
+        const routingSection = document.createElement('div');
+        routingSection.classList.add('audio-routing');
+        routingSection.innerHTML = `
+            <h4>Routing</h4>
+            <div class="routing-grid">${this.renderRoutingToggles()}</div>
+        `;
+        this.container.appendChild(routingSection);
+
+        const advancedSection = document.createElement('div');
+        advancedSection.classList.add('audio-advanced');
+        advancedSection.innerHTML = `
+            <h4>Advanced Dynamics</h4>
+            <div class="advanced-grid">
+                <label class="toggle-pill">
+                    <input type="checkbox" id="advanced-freeze" ${this.settings.advanced.freezeOnSilence ? 'checked' : ''}>
+                    <span>Freeze on Silence</span>
+                </label>
+                <label class="toggle-pill">
+                    <input type="checkbox" id="advanced-peaks" ${this.settings.advanced.accentuatePeaks ? 'checked' : ''}>
+                    <span>Accentuate Peaks</span>
+                </label>
+                <label class="advanced-headroom">
+                    <span>Headroom</span>
+                    <input type="range" id="advanced-headroom" min="0" max="0.5" step="0.01" value="${this.settings.advanced.headroom}">
+                    <span class="advanced-headroom-value">${Math.round(this.settings.advanced.headroom * 100)}%</span>
+                </label>
+            </div>
+        `;
+        this.container.appendChild(advancedSection);
+
+        const flourishSection = document.createElement('div');
+        flourishSection.classList.add('audio-flourish');
+        flourishSection.innerHTML = `
+            <div class="flourish-header">
+                <h4>Reactive Flourish</h4>
+                <label class="toggle-pill">
+                    <input type="checkbox" id="flourish-toggle" ${this.settings.flourish.enabled ? 'checked' : ''}>
+                    <span>Enable</span>
+                </label>
+            </div>
+            <div class="flourish-grid">
+                <label>
+                    <span>Trigger Band</span>
+                    <select id="flourish-band">
+                        ${Object.keys(this.settings.bands).map(band => `<option value="${band}">${this.formatBandLabel(band)}</option>`).join('')}
+                    </select>
+                </label>
+                <label>
+                    <span>Parameter</span>
+                    <select id="flourish-parameter">
+                        ${this.renderParameterOptions(this.settings.flourish.parameter)}
+                    </select>
+                </label>
+                <label>
+                    <span>Threshold</span>
+                    <input type="range" id="flourish-threshold" min="0.2" max="0.95" step="0.05" value="${this.settings.flourish.threshold}">
+                </label>
+                <label>
+                    <span>Boost</span>
+                    <input type="range" id="flourish-boost" min="0.1" max="1" step="0.05" value="${this.settings.flourish.boost}">
+                </label>
+                <label>
+                    <span>Duration (ms)</span>
+                    <input type="number" id="flourish-duration" min="200" max="6000" step="100" value="${this.settings.flourish.duration}">
+                </label>
+                <label>
+                    <span>Cooldown (ms)</span>
+                    <input type="number" id="flourish-cooldown" min="200" max="6000" step="100" value="${this.settings.flourish.cooldown}">
+                </label>
+            </div>
+        `;
+
+        this.container.appendChild(flourishSection);
+
+        this.bindGlobalEvents();
+        this.bindTempoEvents();
+        this.bindRoutingEvents();
+        this.bindAdvancedEvents();
+        this.bindFlourishEvents();
+    }
+
+    createBandControl(band, bandSettings) {
+        const bandElement = document.createElement('div');
+        bandElement.classList.add('audio-band');
+        bandElement.dataset.band = band;
+        bandElement.innerHTML = `
+            <div class="band-header">
+                <label class="toggle-pill">
+                    <input type="checkbox" data-band-toggle value="${band}" ${bandSettings.enabled ? 'checked' : ''}>
+                    <span>${this.formatBandLabel(band)}</span>
+                </label>
+                <span class="band-preview" data-band-preview>${this.getParameterLabel(bandSettings.parameter)}</span>
+            </div>
+            <div class="band-control-grid">
+                <label>
+                    <span>Parameter</span>
+                    <select data-band-parameter>
+                        ${this.renderParameterOptions(bandSettings.parameter)}
+                    </select>
+                </label>
+                <label>
+                    <span>Mode</span>
+                    <select data-band-mode>
+                        ${this.renderModeOptions(bandSettings.mode)}
+                    </select>
+                </label>
+                <label>
+                    <span>Depth</span>
+                    <input type="range" data-band-depth min="0" max="1" step="0.05" value="${bandSettings.depth}">
+                </label>
+                <label>
+                    <span>Curve</span>
+                    <input type="range" data-band-curve min="0.5" max="3" step="0.1" value="${bandSettings.curve}">
+                </label>
+            </div>
+        `;
+
+        const controls = {
+            toggle: bandElement.querySelector('[data-band-toggle]'),
+            parameter: bandElement.querySelector('[data-band-parameter]'),
+            mode: bandElement.querySelector('[data-band-mode]'),
+            depth: bandElement.querySelector('[data-band-depth]'),
+            curve: bandElement.querySelector('[data-band-curve]'),
+            preview: bandElement.querySelector('[data-band-preview]')
+        };
+
+        controls.parameter.value = bandSettings.parameter;
+        if (controls.parameter.value !== bandSettings.parameter) {
+            controls.parameter.selectedIndex = 0;
+        }
+        controls.mode.value = bandSettings.mode;
+        if (controls.mode.value !== bandSettings.mode) {
+            controls.mode.selectedIndex = 0;
+            this.settings.bands[band].mode = controls.mode.value;
+        }
+
+        controls.parameter.addEventListener('change', () => {
+            this.settings.bands[band].parameter = controls.parameter.value;
+            controls.preview.textContent = this.getParameterLabel(controls.parameter.value);
+            this.notifyChange();
+        });
+
+        controls.mode.addEventListener('change', () => {
+            this.settings.bands[band].mode = controls.mode.value;
+            this.notifyChange();
+        });
+
+        controls.depth.addEventListener('input', () => {
+            this.settings.bands[band].depth = parseFloat(controls.depth.value);
+            this.notifyChange();
+        });
+
+        controls.curve.addEventListener('input', () => {
+            this.settings.bands[band].curve = parseFloat(controls.curve.value);
+            this.notifyChange();
+        });
+
+        controls.toggle.addEventListener('change', () => {
+            this.settings.bands[band].enabled = controls.toggle.checked;
+            bandElement.classList.toggle('disabled', !controls.toggle.checked);
+            this.notifyChange();
+        });
+
+        bandElement.classList.toggle('disabled', !controls.toggle.checked);
+
+        this.bandControls.set(band, controls);
+        return bandElement;
+    }
+
+    bindGlobalEvents() {
+        const masterToggle = this.container.querySelector('#audio-master-toggle');
+        const sensitivityRange = this.container.querySelector('#audio-sensitivity');
+        const smoothingRange = this.container.querySelector('#audio-smoothing');
+
+        masterToggle.addEventListener('change', () => {
+            this.settings.master = masterToggle.checked;
+            this.notifyChange();
+        });
+
+        sensitivityRange.addEventListener('input', () => {
+            this.settings.globalSensitivity = parseFloat(sensitivityRange.value);
+            this.notifyChange();
+        });
+
+        smoothingRange.addEventListener('input', () => {
+            this.settings.smoothing = parseFloat(smoothingRange.value);
+            this.notifyChange();
+        });
+    }
+
+    bindTempoEvents() {
+        const enabledToggle = this.container.querySelector('#tempo-enabled');
+        const bpmInput = this.container.querySelector('#tempo-bpm');
+        const subdivisionSelect = this.container.querySelector('#tempo-subdivision');
+        const sourceSelect = this.container.querySelector('#tempo-source-band');
+        const autoToggle = this.container.querySelector('#tempo-auto');
+        const linkToggle = this.container.querySelector('#tempo-link-pads');
+        const nudgeInput = this.container.querySelector('#tempo-nudge');
+        const nudgeValue = this.container.querySelector('.tempo-nudge-value');
+        const tapButton = this.container.querySelector('#tempo-tap');
+
+        if (enabledToggle) {
+            enabledToggle.addEventListener('change', () => {
+                this.settings.tempo.enabled = enabledToggle.checked;
+                this.notifyChange();
+            });
+        }
+
+        if (bpmInput) {
+            bpmInput.addEventListener('input', () => {
+                const numeric = parseFloat(bpmInput.value);
+                if (Number.isFinite(numeric)) {
+                    this.settings.tempo.bpm = Math.max(40, Math.min(220, numeric));
+                    this.notifyChange();
+                }
+            });
+        }
+
+        if (subdivisionSelect) {
+            subdivisionSelect.addEventListener('change', () => {
+                this.settings.tempo.subdivision = subdivisionSelect.value;
+                this.notifyChange();
+            });
+        }
+
+        if (sourceSelect) {
+            sourceSelect.addEventListener('change', () => {
+                this.settings.tempo.sourceBand = sourceSelect.value;
+                this.notifyChange();
+            });
+        }
+
+        if (autoToggle) {
+            autoToggle.addEventListener('change', () => {
+                this.settings.tempo.autoFollow = autoToggle.checked;
+                this.notifyChange();
+            });
+        }
+
+        if (linkToggle) {
+            linkToggle.addEventListener('change', () => {
+                this.settings.tempo.linkToPads = linkToggle.checked;
+                this.notifyChange();
+            });
+        }
+
+        if (nudgeInput) {
+            nudgeInput.addEventListener('input', () => {
+                const numeric = parseFloat(nudgeInput.value);
+                if (Number.isFinite(numeric)) {
+                    this.settings.tempo.nudge = Math.max(-0.5, Math.min(0.5, numeric));
+                    if (nudgeValue) {
+                        nudgeValue.textContent = this.formatTempoNudge(this.settings.tempo.nudge);
+                    }
+                    this.notifyChange();
+                }
+            });
+        }
+
+        if (tapButton) {
+            tapButton.addEventListener('click', () => {
+                const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+                this.tapTimestamps = (this.tapTimestamps || []).filter(timestamp => now - timestamp < 4000);
+                this.tapTimestamps.push(now);
+                if (this.tapTimestamps.length >= 2) {
+                    const intervals = [];
+                    for (let index = 1; index < this.tapTimestamps.length; index++) {
+                        intervals.push(this.tapTimestamps[index] - this.tapTimestamps[index - 1]);
+                    }
+                    const average = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+                    const bpm = Math.max(40, Math.min(220, Math.round(60000 / Math.max(average, 1)))) || this.settings.tempo.bpm;
+                    this.settings.tempo.bpm = bpm;
+                    if (bpmInput) {
+                        bpmInput.value = String(bpm);
+                    }
+                    this.notifyChange();
+                }
+            });
+        }
+    }
+
+    bindRoutingEvents() {
+        const routingInputs = this.container.querySelectorAll('[data-routing-toggle]');
+        routingInputs.forEach(input => {
+            input.addEventListener('change', () => {
+                const key = input.dataset.routingToggle;
+                if (!key) return;
+                if (!this.settings.routing) {
+                    this.settings.routing = {};
+                }
+                this.settings.routing[key] = input.checked;
+                this.notifyChange();
+            });
+        });
+    }
+
+    bindAdvancedEvents() {
+        const freezeToggle = this.container.querySelector('#advanced-freeze');
+        const peaksToggle = this.container.querySelector('#advanced-peaks');
+        const headroomRange = this.container.querySelector('#advanced-headroom');
+        const headroomValue = this.container.querySelector('.advanced-headroom-value');
+
+        if (freezeToggle) {
+            freezeToggle.addEventListener('change', () => {
+                this.settings.advanced.freezeOnSilence = freezeToggle.checked;
+                this.notifyChange();
+            });
+        }
+
+        if (peaksToggle) {
+            peaksToggle.addEventListener('change', () => {
+                this.settings.advanced.accentuatePeaks = peaksToggle.checked;
+                this.notifyChange();
+            });
+        }
+
+        if (headroomRange) {
+            headroomRange.addEventListener('input', () => {
+                const numeric = parseFloat(headroomRange.value);
+                if (Number.isFinite(numeric)) {
+                    this.settings.advanced.headroom = Math.max(0, Math.min(0.5, numeric));
+                    if (headroomValue) {
+                        headroomValue.textContent = `${Math.round(this.settings.advanced.headroom * 100)}%`;
+                    }
+                    this.notifyChange();
+                }
+            });
+        }
+    }
+
+    bindFlourishEvents() {
+        const toggle = this.container.querySelector('#flourish-toggle');
+        const bandSelect = this.container.querySelector('#flourish-band');
+        const parameterSelect = this.container.querySelector('#flourish-parameter');
+        const thresholdRange = this.container.querySelector('#flourish-threshold');
+        const boostRange = this.container.querySelector('#flourish-boost');
+        const durationInput = this.container.querySelector('#flourish-duration');
+        const cooldownInput = this.container.querySelector('#flourish-cooldown');
+
+        toggle.addEventListener('change', () => {
+            this.settings.flourish.enabled = toggle.checked;
+            this.notifyChange();
+        });
+
+        bandSelect.value = this.settings.flourish.band;
+        bandSelect.addEventListener('change', () => {
+            this.settings.flourish.band = bandSelect.value;
+            this.notifyChange();
+        });
+
+        parameterSelect.value = this.settings.flourish.parameter;
+        parameterSelect.addEventListener('change', () => {
+            this.settings.flourish.parameter = parameterSelect.value;
+            this.notifyChange();
+        });
+
+        thresholdRange.addEventListener('input', () => {
+            this.settings.flourish.threshold = parseFloat(thresholdRange.value);
+            this.notifyChange();
+        });
+
+        boostRange.addEventListener('input', () => {
+            this.settings.flourish.boost = parseFloat(boostRange.value);
+            this.notifyChange();
+        });
+
+        durationInput.addEventListener('input', () => {
+            this.settings.flourish.duration = parseInt(durationInput.value, 10);
+            this.notifyChange();
+        });
+
+        cooldownInput.addEventListener('input', () => {
+            this.settings.flourish.cooldown = parseInt(cooldownInput.value, 10);
+            this.notifyChange();
+        });
+    }
+
+    applySettingsToControls() {
+        // Ensure controls reflect current settings (for external updates)
+        this.bandControls.forEach((controls, band) => {
+            const bandSettings = this.settings.bands[band];
+            if (!bandSettings) return;
+            controls.toggle.checked = !!bandSettings.enabled;
+            controls.parameter.value = bandSettings.parameter;
+            if (controls.parameter.value !== bandSettings.parameter) {
+                controls.parameter.selectedIndex = 0;
+            }
+            controls.mode.value = bandSettings.mode;
+            if (controls.mode.value !== bandSettings.mode) {
+                controls.mode.selectedIndex = 0;
+                this.settings.bands[band].mode = controls.mode.value;
+            }
+            controls.depth.value = bandSettings.depth;
+            controls.curve.value = bandSettings.curve;
+            controls.preview.textContent = this.getParameterLabel(controls.parameter.value);
+            controls.toggle.dispatchEvent(new Event('change'));
+        });
+
+        const bandSelect = this.container.querySelector('#flourish-band');
+        const parameterSelect = this.container.querySelector('#flourish-parameter');
+        const thresholdRange = this.container.querySelector('#flourish-threshold');
+        const boostRange = this.container.querySelector('#flourish-boost');
+        const durationInput = this.container.querySelector('#flourish-duration');
+        const cooldownInput = this.container.querySelector('#flourish-cooldown');
+        const toggle = this.container.querySelector('#flourish-toggle');
+
+        if (bandSelect) bandSelect.value = this.settings.flourish.band;
+        if (parameterSelect) {
+            parameterSelect.value = this.settings.flourish.parameter;
+            if (parameterSelect.value !== this.settings.flourish.parameter && parameterSelect.options.length > 0) {
+                parameterSelect.selectedIndex = 0;
+            }
+        }
+        if (thresholdRange) thresholdRange.value = this.settings.flourish.threshold;
+        if (boostRange) boostRange.value = this.settings.flourish.boost;
+        if (durationInput) durationInput.value = this.settings.flourish.duration;
+        if (cooldownInput) cooldownInput.value = this.settings.flourish.cooldown;
+        if (toggle) toggle.checked = this.settings.flourish.enabled;
+
+        const tempoEnabled = this.container.querySelector('#tempo-enabled');
+        const tempoBpm = this.container.querySelector('#tempo-bpm');
+        const tempoSubdivision = this.container.querySelector('#tempo-subdivision');
+        const tempoBand = this.container.querySelector('#tempo-source-band');
+        const tempoAuto = this.container.querySelector('#tempo-auto');
+        const tempoLink = this.container.querySelector('#tempo-link-pads');
+        const tempoNudge = this.container.querySelector('#tempo-nudge');
+        const tempoNudgeValue = this.container.querySelector('.tempo-nudge-value');
+        if (tempoEnabled) tempoEnabled.checked = !!this.settings.tempo.enabled;
+        if (tempoBpm && Number.isFinite(this.settings.tempo.bpm)) tempoBpm.value = Math.round(this.settings.tempo.bpm);
+        if (tempoSubdivision) tempoSubdivision.value = this.settings.tempo.subdivision;
+        if (tempoBand) {
+            tempoBand.innerHTML = this.renderTempoBandOptions(this.settings.tempo.sourceBand);
+            tempoBand.value = this.settings.tempo.sourceBand;
+        }
+        if (tempoAuto) tempoAuto.checked = !!this.settings.tempo.autoFollow;
+        if (tempoLink) tempoLink.checked = !!this.settings.tempo.linkToPads;
+        if (tempoNudge && Number.isFinite(this.settings.tempo.nudge)) {
+            tempoNudge.value = String(this.settings.tempo.nudge);
+        }
+        if (tempoNudgeValue) tempoNudgeValue.textContent = this.formatTempoNudge(this.settings.tempo.nudge);
+
+        const routingInputs = this.container.querySelectorAll('[data-routing-toggle]');
+        routingInputs.forEach(input => {
+            const key = input.dataset.routingToggle;
+            input.checked = !!this.settings.routing?.[key];
+        });
+
+        const freezeToggle = this.container.querySelector('#advanced-freeze');
+        const peaksToggle = this.container.querySelector('#advanced-peaks');
+        const headroomRange = this.container.querySelector('#advanced-headroom');
+        const headroomValue = this.container.querySelector('.advanced-headroom-value');
+        if (freezeToggle) freezeToggle.checked = !!this.settings.advanced.freezeOnSilence;
+        if (peaksToggle) peaksToggle.checked = !!this.settings.advanced.accentuatePeaks;
+        if (headroomRange && Number.isFinite(this.settings.advanced.headroom)) {
+            headroomRange.value = String(this.settings.advanced.headroom);
+        }
+        if (headroomValue) headroomValue.textContent = `${Math.round(this.settings.advanced.headroom * 100)}%`;
+    }
+
+    mergeSettings(base, overrides) {
+        const merged = JSON.parse(JSON.stringify(base));
+        if (!overrides) return merged;
+
+        if (typeof overrides.master === 'boolean') merged.master = overrides.master;
+        if (typeof overrides.globalSensitivity === 'number') merged.globalSensitivity = overrides.globalSensitivity;
+        if (typeof overrides.smoothing === 'number') merged.smoothing = overrides.smoothing;
+
+        if (overrides.tempo) {
+            merged.tempo = { ...merged.tempo, ...overrides.tempo };
+        }
+
+        if (overrides.routing) {
+            merged.routing = { ...merged.routing, ...overrides.routing };
+        }
+
+        if (overrides.advanced) {
+            merged.advanced = { ...merged.advanced, ...overrides.advanced };
+        }
+
+        if (overrides.bands) {
+            Object.entries(overrides.bands).forEach(([band, config]) => {
+                merged.bands[band] = { ...merged.bands[band], ...config };
+            });
+        }
+
+        if (overrides.flourish) {
+            merged.flourish = { ...merged.flourish, ...overrides.flourish };
+        }
+
+        return merged;
+    }
+
+    formatBandLabel(band) {
+        return band.charAt(0).toUpperCase() + band.slice(1);
+    }
+
+    getParameterLabel(name) {
+        if (!name || name === 'none') {
+            return 'None';
+        }
+        return this.parameterLabels.get(name)
+            || this.parameterManager?.formatParameterLabel?.(name)
+            || this.formatFallbackName(name);
+    }
+
+    formatFallbackName(name) {
+        return name
+            .replace(/rot4d/gi, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+
+    formatParameterName(name) {
+        return this.getParameterLabel(name);
+    }
+
+    formatTempoNudge(value) {
+        if (!Number.isFinite(value)) return '0%';
+        const percentage = Math.round(value * 100);
+        if (percentage === 0) return '0%';
+        const prefix = percentage > 0 ? '+' : '';
+        return `${prefix}${percentage}%`;
+    }
+
+    getSettings() {
+        return JSON.parse(JSON.stringify(this.settings));
+    }
+
+    notifyChange() {
+        const snapshot = this.getSettings();
+        const payload = JSON.parse(JSON.stringify(snapshot));
+        if (typeof this.onSettingsChange === 'function') {
+            this.onSettingsChange(snapshot);
+        }
+        if (this.hub) {
+            this.hub.emit('audio-settings-change', { settings: payload });
+            if (snapshot.tempo) {
+                this.hub.emit('audio-tempo-change', { tempo: JSON.parse(JSON.stringify(snapshot.tempo)) });
+            }
+            if (snapshot.routing) {
+                this.hub.emit('audio-routing-change', { routing: JSON.parse(JSON.stringify(snapshot.routing)) });
+            }
+            if (snapshot.advanced) {
+                this.hub.emit('audio-advanced-change', { advanced: JSON.parse(JSON.stringify(snapshot.advanced)) });
+            }
+        }
+    }
+
+    setSettings(settings) {
+        this.settings = this.mergeSettings(DEFAULT_SETTINGS, settings || {});
+        this.availableParameters = this.buildParameterOptions();
+        this.parameterLabels = new Map(this.availableParameters.map(meta => [meta.id, meta.label]));
+        this.ensureTempoSourceBand();
+        this.ensureRoutingDefaults();
+        this.tapTimestamps = [];
+        this.buildUI();
+        this.applySettingsToControls();
+        this.notifyChange();
+    }
+
+    exportState() {
+        return this.getSettings();
+    }
+
+    importState(state) {
+        if (!state) return;
+        this.setSettings(state);
+    }
+
+    destroy() {
+        this.bandControls.clear();
+    }
+}

--- a/src/ui/PerformanceConfig.js
+++ b/src/ui/PerformanceConfig.js
@@ -1,0 +1,205 @@
+export const DEFAULT_PERFORMANCE_CONFIG = {
+    touchPads: {
+        pads: {
+            defaultCount: 3,
+            min: 1,
+            max: 6
+        },
+        layout: {
+            minWidth: 220,
+            maxWidth: 420,
+            gap: 16,
+            maxGap: 48,
+            aspectRatio: 1,
+            minAspect: 0.6,
+            maxAspect: 1.4,
+            crosshairSize: 18,
+            columns: 'auto'
+        },
+        layoutPresets: [
+            {
+                id: 'default-stage-balance',
+                name: 'Default Stage Balance',
+                description: 'Balanced spacing for three feature pads with adaptive columns.',
+                layout: {
+                    padCount: 3,
+                    minWidth: 260,
+                    gap: 18,
+                    aspectRatio: 1,
+                    columns: 'auto'
+                }
+            },
+            {
+                id: 'expanded-duo-wings',
+                name: 'Expanded Duo Wings',
+                description: 'Wider pads for duo performances with fixed two-column symmetry.',
+                layout: {
+                    padCount: 2,
+                    minWidth: 320,
+                    gap: 22,
+                    aspectRatio: 1.15,
+                    columns: 2
+                }
+            },
+            {
+                id: 'dense-club-grid',
+                name: 'Dense Club Grid',
+                description: 'Compact four-pad grid tuned for tight club booths and controllers.',
+                layout: {
+                    padCount: 4,
+                    minWidth: 210,
+                    gap: 12,
+                    aspectRatio: 0.9,
+                    columns: 4
+                }
+            }
+        ],
+        axis: {
+            defaultModes: {
+                x: 'absolute',
+                y: 'absolute',
+                gesture: 'bipolar'
+            },
+            modes: [
+                { value: 'absolute', label: 'Absolute (min → max)' },
+                { value: 'bipolar', label: 'Bipolar (center ±)' },
+                { value: 'relative', label: 'Relative (offset)' }
+            ],
+            relativeStrength: 0.4,
+            curves: [
+                { value: 'linear', label: 'Linear' },
+                { value: 'ease-in', label: 'Ease In' },
+                { value: 'ease-out', label: 'Ease Out' },
+                { value: 'ease-in-out', label: 'Ease In-Out' },
+                { value: 'expo', label: 'Exponential' }
+            ],
+            smoothing: {
+                default: 0.15,
+                min: 0,
+                max: 0.6,
+                step: 0.05
+            },
+            defaults: {
+                curve: {
+                    x: 'linear',
+                    y: 'linear',
+                    gesture: 'ease-out'
+                },
+                invert: {
+                    x: false,
+                    y: false,
+                    gesture: false
+                },
+                smoothing: {
+                    x: 0.15,
+                    y: 0.15,
+                    gesture: 0.25
+                }
+            }
+        },
+        gesture: {
+            minimumSpread: 0.05,
+            maximumSpread: 0.65,
+            velocityScale: 2.4,
+            pressureFallback: 0.6,
+            defaultMode: 'spread',
+            modes: [
+                { value: 'spread', label: 'Finger Spread' },
+                { value: 'pressure', label: 'Pressure / Emphasis' },
+                { value: 'velocity', label: 'Swipe Velocity' }
+            ]
+        },
+        defaultMappings: [
+            { x: 'rot4dXW', y: 'rot4dYW', gesture: 'rot4dZW' },
+            { x: 'gridDensity', y: 'morphFactor', gesture: 'chaos' },
+            { x: 'hue', y: 'intensity', gesture: 'speed' }
+        ]
+    },
+    audio: {
+        modes: [
+            { value: 'absolute', label: 'Absolute' },
+            { value: 'swing', label: 'Swing (±)' },
+            { value: 'relative', label: 'Relative' }
+        ],
+        tempo: {
+            defaultBpm: 120,
+            defaultSubdivision: '1/4',
+            subdivisions: [
+                { value: '1/1', label: 'Whole' },
+                { value: '1/2', label: 'Half' },
+                { value: '1/4', label: 'Quarter' },
+                { value: '1/8', label: 'Eighth' },
+                { value: '1/16', label: 'Sixteenth' },
+                { value: '1/8T', label: 'Eighth Triplet' }
+            ]
+        },
+        routing: {
+            toggles: [
+                { key: 'sendToPads', label: 'Drive Touch Pads' },
+                { key: 'sendToPresets', label: 'Influence Presets' },
+                { key: 'broadcastMidiClock', label: 'Broadcast MIDI Clock' }
+            ]
+        },
+        advanced: {
+            defaults: {
+                freezeOnSilence: false,
+                accentuatePeaks: true,
+                headroom: 0.2
+            }
+        }
+    }
+};
+
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(base, override) {
+    if (!isPlainObject(override)) {
+        return override;
+    }
+
+    const output = { ...base };
+    Object.keys(override).forEach(key => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+
+        if (Array.isArray(overrideValue)) {
+            output[key] = overrideValue.slice();
+        } else if (isPlainObject(baseValue) && isPlainObject(overrideValue)) {
+            output[key] = deepMerge(baseValue, overrideValue);
+        } else {
+            output[key] = overrideValue;
+        }
+    });
+
+    return output;
+}
+
+export function mergePerformanceConfig(overrides = {}) {
+    if (!overrides || Object.keys(overrides).length === 0) {
+        return JSON.parse(JSON.stringify(DEFAULT_PERFORMANCE_CONFIG));
+    }
+
+    const cloned = JSON.parse(JSON.stringify(DEFAULT_PERFORMANCE_CONFIG));
+
+    const mergeRecursive = (target, source) => {
+        Object.keys(source).forEach(key => {
+            const targetValue = target[key];
+            const sourceValue = source[key];
+
+            if (Array.isArray(sourceValue)) {
+                target[key] = sourceValue.slice();
+            } else if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+                mergeRecursive(targetValue, sourceValue);
+            } else if (isPlainObject(sourceValue)) {
+                target[key] = deepMerge({}, sourceValue);
+            } else {
+                target[key] = sourceValue;
+            }
+        });
+    };
+
+    mergeRecursive(cloned, overrides);
+    return cloned;
+}

--- a/src/ui/PerformanceHub.js
+++ b/src/ui/PerformanceHub.js
@@ -1,0 +1,149 @@
+export class PerformanceHub {
+    constructor(options = {}) {
+        const { engine = null, parameterManager = null } = options;
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.listeners = new Map();
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.extensions = new Map();
+    }
+
+    on(event, handler) {
+        if (typeof handler !== 'function') {
+            return () => {};
+        }
+
+        if (!this.listeners.has(event)) {
+            this.listeners.set(event, new Set());
+        }
+
+        const handlers = this.listeners.get(event);
+        handlers.add(handler);
+
+        return () => this.off(event, handler);
+    }
+
+    off(event, handler) {
+        const handlers = this.listeners.get(event);
+        if (!handlers) return;
+        handlers.delete(handler);
+        if (handlers.size === 0) {
+            this.listeners.delete(event);
+        }
+    }
+
+    emit(event, payload = {}) {
+        const handlers = this.listeners.get(event);
+        if (!handlers || handlers.size === 0) {
+            return;
+        }
+
+        const snapshot = Array.from(handlers);
+        snapshot.forEach(handler => {
+            try {
+                handler(payload);
+            } catch (error) {
+                console.warn(`PerformanceHub listener for "${event}" failed:`, error);
+            }
+        });
+    }
+
+    registerTouchPadController(controller) {
+        this.touchPadController = controller;
+        this.emit('touchpad-registered', { controller });
+        if (controller?.getMappings) {
+            this.emit('touchpad-mapping-change', { mappings: this.clone(controller.getMappings()) });
+        }
+    }
+
+    registerAudioPanel(panel) {
+        this.audioPanel = panel;
+        this.emit('audio-panel-registered', { panel });
+        if (panel?.getSettings) {
+            this.emit('audio-settings-change', { settings: this.clone(panel.getSettings()) });
+        }
+    }
+
+    registerPresetManager(manager) {
+        this.presetManager = manager;
+        this.emit('preset-manager-registered', { manager });
+        if (manager?.exportState) {
+            const state = manager.exportState();
+            this.emit('preset-list-changed', {
+                presets: this.clone(state.presets),
+                sequence: this.clone(state.sequence),
+                sequenceSettings: this.clone(state.sequenceSettings)
+            });
+        }
+    }
+
+    getState() {
+        return {
+            touchPads: this.clone(this.touchPadController?.getMappings?.()),
+            audio: this.clone(this.audioPanel?.getSettings?.()),
+            presets: this.presetManager?.exportState?.() || { presets: [], sequence: [], sequenceSettings: {} },
+            extensions: this.listExtensions()
+        };
+    }
+
+    applyState(state = {}) {
+        if (state.touchPads && this.touchPadController?.applyMappings) {
+            this.touchPadController.applyMappings(this.clone(state.touchPads));
+        }
+
+        if (state.audio && this.audioPanel?.setSettings) {
+            this.audioPanel.setSettings(this.clone(state.audio));
+        }
+
+        if (state.presets && this.presetManager?.importState) {
+            this.presetManager.importState(this.clone(state.presets));
+        }
+    }
+
+    registerExtension(name, api = {}) {
+        if (!name) return () => {};
+        this.extensions.set(name, api);
+        this.emit('extension-registered', { name, api });
+        return () => {
+            const existing = this.extensions.get(name);
+            if (existing === api) {
+                this.extensions.delete(name);
+                this.emit('extension-unregistered', { name, api });
+            }
+        };
+    }
+
+    unregisterExtension(name) {
+        if (!this.extensions.has(name)) return;
+        const api = this.extensions.get(name);
+        this.extensions.delete(name);
+        this.emit('extension-unregistered', { name, api });
+    }
+
+    getExtension(name) {
+        return this.extensions.get(name);
+    }
+
+    listExtensions() {
+        return Array.from(this.extensions.keys());
+    }
+
+    destroy() {
+        this.listeners.clear();
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.extensions.clear();
+    }
+
+    clone(data) {
+        if (data === null || data === undefined) return data;
+        try {
+            return JSON.parse(JSON.stringify(data));
+        } catch (error) {
+            return data;
+        }
+    }
+}

--- a/src/ui/PerformancePresetManager.js
+++ b/src/ui/PerformancePresetManager.js
@@ -1,0 +1,1087 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+/**
+ * Performance Preset Manager
+ * Handles saving presets and choreographed sequences for live shows
+ */
+
+const STORAGE_KEY = 'vib34d_performance_presets_v1';
+const FLOURISH_CURVES = [
+    { value: 'linear', label: 'Linear' },
+    { value: 'easeIn', label: 'Ease In' },
+    { value: 'easeOut', label: 'Ease Out' },
+    { value: 'easeInOut', label: 'Ease In-Out' }
+];
+
+export class PerformancePresetManager {
+    constructor(options = {}) {
+        const {
+            parameterManager,
+            touchPadController = null,
+            audioPanel = null,
+            container = null,
+            onPresetApply = null,
+            hub = null
+        } = options;
+
+        this.parameterManager = parameterManager;
+        this.touchPadController = touchPadController;
+        this.audioPanel = audioPanel;
+        this.onPresetApply = onPresetApply;
+        this.container = container || this.ensureContainer();
+        this.hub = hub;
+
+        this.parameterOptions = this.buildParameterOptions();
+        this.parameterLabels = new Map(this.parameterOptions.map(option => [option.id, option.label]));
+
+        this.axisModeLabels = new Map();
+        this.axisCurveLabels = new Map();
+        this.gestureModeLabels = new Map();
+        this.axisSmoothingMax = 1;
+        this.axisSmoothingMin = 0;
+        this.initializeAxisMetadata();
+
+        this.presets = this.loadPresets();
+        this.sequence = [];
+        this.sequenceSettings = this.initializeSequenceSettings();
+        this.sequenceAbort = false;
+        this.sequenceWaitTimeout = null;
+        this.sequencePlaying = false;
+        this.currentPresetId = null;
+
+        this.buildUI();
+        this.renderPresetList();
+        this.renderSequence();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-presets');
+        if (existing) return existing;
+
+        const section = document.createElement('section');
+        section.id = 'performance-presets';
+        section.classList.add('performance-presets');
+        document.body.appendChild(section);
+        return section;
+    }
+
+    initializeAxisMetadata() {
+        const axisConfig = this.touchPadController?.config?.axis || {};
+        const fallback = DEFAULT_PERFORMANCE_CONFIG.touchPads.axis;
+        const gestureConfig = this.touchPadController?.config?.gesture || DEFAULT_PERFORMANCE_CONFIG.touchPads.gesture || {};
+
+        const modeConfig = Array.isArray(axisConfig.modes) && axisConfig.modes.length
+            ? axisConfig.modes
+            : fallback.modes;
+        const curveConfig = Array.isArray(axisConfig.curves) && axisConfig.curves.length
+            ? axisConfig.curves
+            : fallback.curves;
+        const smoothingConfig = axisConfig.smoothing || fallback.smoothing || {};
+        const gestureModes = Array.isArray(gestureConfig.modes) && gestureConfig.modes.length
+            ? gestureConfig.modes
+            : (DEFAULT_PERFORMANCE_CONFIG.touchPads.gesture?.modes || []);
+
+        this.axisModeLabels = new Map(modeConfig.map(mode => [mode.value, mode.label]));
+        this.axisCurveLabels = new Map(curveConfig.map(curve => [curve.value, curve.label]));
+        this.gestureModeLabels = new Map(gestureModes.map(mode => [mode.value, mode.label]));
+        this.axisSmoothingMax = smoothingConfig.max ?? 1;
+        this.axisSmoothingMin = smoothingConfig.min ?? 0;
+    }
+
+    initializeSequenceSettings() {
+        const tempo = this.audioPanel?.getSettings?.()?.tempo || {};
+        return {
+            loop: false,
+            syncToTempo: false,
+            subdivision: tempo.subdivision || tempo.defaultSubdivision || DEFAULT_PERFORMANCE_CONFIG.audio.tempo.defaultSubdivision || '1/4',
+            quantize: false
+        };
+    }
+
+    exportState() {
+        return {
+            presets: this.presets.map(preset => this.clonePreset(preset)),
+            sequence: this.cloneSequence(this.sequence),
+            sequenceSettings: { ...this.sequenceSettings }
+        };
+    }
+
+    importState(state = {}) {
+        const presets = Array.isArray(state.presets) ? state.presets : [];
+        const sequence = Array.isArray(state.sequence) ? state.sequence : [];
+        const sequenceSettings = state.sequenceSettings && typeof state.sequenceSettings === 'object'
+            ? state.sequenceSettings
+            : null;
+
+        this.presets = presets
+            .map(preset => this.clonePreset(preset))
+            .filter(Boolean);
+        this.sequence = this.cloneSequence(sequence);
+        if (sequenceSettings) {
+            this.sequenceSettings = {
+                ...this.sequenceSettings,
+                ...sequenceSettings
+            };
+        }
+
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequence();
+        this.renderSequenceOptions();
+        this.applySequenceSettingsToControls();
+        this.updateSequencePlaceholders();
+        this.notifyPresetListChange();
+        this.notifySequenceChange();
+    }
+
+    clonePreset(preset) {
+        if (!preset) return null;
+        return JSON.parse(JSON.stringify(preset));
+    }
+
+    cloneSequence(sequence) {
+        if (!Array.isArray(sequence)) return [];
+        return sequence.map(cue => ({ ...cue }));
+    }
+
+    notifyPresetListChange() {
+        if (this.hub) {
+            const state = this.exportState();
+            this.hub.emit('preset-list-changed', {
+                presets: state.presets,
+                sequence: state.sequence
+            });
+        }
+    }
+
+    notifySequenceChange() {
+        if (this.hub) {
+            this.hub.emit('sequence-changed', {
+                sequence: this.cloneSequence(this.sequence),
+                settings: { ...this.sequenceSettings }
+            });
+        }
+    }
+
+    buildUI() {
+        this.parameterOptions = this.buildParameterOptions();
+        this.parameterLabels = new Map(this.parameterOptions.map(option => [option.id, option.label]));
+        this.container.innerHTML = '';
+        this.container.innerHTML = `
+            <header class="performance-section-header">
+                <div>
+                    <h3>Show Presets & Choreography</h3>
+                    <p class="performance-subtitle">Capture parameter states, pad mappings and audio settings for instant recall.</p>
+                </div>
+            </header>
+            <div class="preset-controls">
+                <div class="preset-create">
+                    <input type="text" id="preset-name" placeholder="Preset name (e.g. "Midnight Drop")">
+                    <div class="preset-actions">
+                        <button id="preset-save">Save Preset</button>
+                        <button id="preset-update" disabled>Update</button>
+                        <button id="preset-reset">Clear</button>
+                    </div>
+                </div>
+                <div class="preset-flourish">
+                    <label>
+                        <span>Flourish Parameter</span>
+                        <select id="preset-flourish-parameter"></select>
+                    </label>
+                    <label>
+                        <span>Flourish Boost</span>
+                        <input type="range" id="preset-flourish-amount" min="0.1" max="1" step="0.05" value="0.5">
+                    </label>
+                    <label>
+                        <span>Flourish Duration (ms)</span>
+                        <input type="number" id="preset-flourish-duration" min="200" max="4000" step="100" value="1200">
+                    </label>
+                    <label>
+                        <span>Flourish Ease</span>
+                        <select id="preset-flourish-curve"></select>
+                    </label>
+                    <label>
+                        <span>Return Ease</span>
+                        <select id="preset-flourish-return"></select>
+                    </label>
+                    <label>
+                        <span>Hold (ms)</span>
+                        <input type="number" id="preset-flourish-hold" min="0" max="4000" step="100" value="400">
+                    </label>
+                </div>
+            </div>
+            <div class="preset-list" id="preset-list"></div>
+            <div class="sequence-builder">
+                <div class="sequence-header">
+                    <h4>Choreography Timeline</h4>
+                    <div class="sequence-actions">
+                        <button id="sequence-play">Play Sequence</button>
+                        <button id="sequence-stop" class="secondary">Stop</button>
+                        <button id="sequence-clear">Clear</button>
+                    </div>
+                </div>
+                <div class="sequence-settings">
+                    <label class="toggle-pill">
+                        <input type="checkbox" id="sequence-loop">
+                        <span>Loop</span>
+                    </label>
+                    <label class="toggle-pill">
+                        <input type="checkbox" id="sequence-sync">
+                        <span>Tempo Sync</span>
+                    </label>
+                    <label class="toggle-pill">
+                        <input type="checkbox" id="sequence-quantize">
+                        <span>Quantize</span>
+                    </label>
+                    <label>
+                        <span>Subdivision</span>
+                        <select id="sequence-subdivision">${this.renderTempoSubdivisionOptions(this.sequenceSettings.subdivision)}</select>
+                    </label>
+                </div>
+                <div class="sequence-form">
+                    <select id="sequence-preset"></select>
+                    <input type="number" id="sequence-transition" placeholder="Transition ms" min="100" value="1800">
+                    <input type="number" id="sequence-hold" placeholder="Hold ms" min="0" value="1200">
+                    <label class="sequence-flourish">
+                        <input type="checkbox" id="sequence-flourish">
+                        <span>Trigger flourish</span>
+                    </label>
+                    <button id="sequence-add">Add Cue</button>
+                </div>
+                <ol class="sequence-list" id="sequence-list"></ol>
+            </div>
+        `;
+
+        this.populateFlourishParameterOptions();
+        this.populateFlourishCurves();
+        this.bindEvents();
+        this.applySequenceSettingsToControls();
+        this.updateSequencePlaceholders();
+    }
+
+    populateFlourishParameterOptions() {
+        const select = this.container.querySelector('#preset-flourish-parameter');
+        if (!select || !this.parameterManager) return;
+
+        const defaultValue = this.parameterOptions[0]?.id || '';
+        select.innerHTML = this.renderParameterOptions(this.parameterOptions, defaultValue);
+        select.value = defaultValue;
+    }
+
+    populateFlourishCurves() {
+        const easeSelect = this.container.querySelector('#preset-flourish-curve');
+        const returnSelect = this.container.querySelector('#preset-flourish-return');
+        if (easeSelect) {
+            easeSelect.innerHTML = this.renderFlourishCurveOptions('easeOut');
+            easeSelect.value = 'easeOut';
+        }
+        if (returnSelect) {
+            returnSelect.innerHTML = this.renderFlourishCurveOptions('easeInOut');
+            returnSelect.value = 'easeInOut';
+        }
+    }
+
+    bindEvents() {
+        const saveBtn = this.container.querySelector('#preset-save');
+        const updateBtn = this.container.querySelector('#preset-update');
+        const resetBtn = this.container.querySelector('#preset-reset');
+        const playBtn = this.container.querySelector('#sequence-play');
+        const clearBtn = this.container.querySelector('#sequence-clear');
+        const addBtn = this.container.querySelector('#sequence-add');
+        const stopBtn = this.container.querySelector('#sequence-stop');
+        const loopToggle = this.container.querySelector('#sequence-loop');
+        const syncToggle = this.container.querySelector('#sequence-sync');
+        const quantizeToggle = this.container.querySelector('#sequence-quantize');
+        const subdivisionSelect = this.container.querySelector('#sequence-subdivision');
+
+        saveBtn.addEventListener('click', () => this.savePreset());
+        updateBtn.addEventListener('click', () => this.updatePreset());
+        resetBtn.addEventListener('click', () => this.resetForm());
+        playBtn.addEventListener('click', () => this.playSequence());
+        clearBtn.addEventListener('click', () => this.clearSequence());
+        addBtn.addEventListener('click', () => this.addSequenceCue());
+        stopBtn.addEventListener('click', () => this.stopSequence());
+
+        loopToggle.addEventListener('change', () => {
+            this.sequenceSettings.loop = loopToggle.checked;
+            this.renderSequence();
+            this.notifySequenceChange();
+        });
+
+        syncToggle.addEventListener('change', () => {
+            this.sequenceSettings.syncToTempo = syncToggle.checked;
+            this.updateSequencePlaceholders();
+            this.renderSequence();
+            this.notifySequenceChange();
+        });
+
+        quantizeToggle.addEventListener('change', () => {
+            this.sequenceSettings.quantize = quantizeToggle.checked;
+            this.notifySequenceChange();
+        });
+
+        subdivisionSelect.addEventListener('change', () => {
+            this.sequenceSettings.subdivision = subdivisionSelect.value;
+            this.renderSequence();
+            this.notifySequenceChange();
+        });
+    }
+
+    applySequenceSettingsToControls() {
+        const loopToggle = this.container.querySelector('#sequence-loop');
+        const syncToggle = this.container.querySelector('#sequence-sync');
+        const quantizeToggle = this.container.querySelector('#sequence-quantize');
+        const subdivisionSelect = this.container.querySelector('#sequence-subdivision');
+        if (loopToggle) loopToggle.checked = !!this.sequenceSettings.loop;
+        if (syncToggle) syncToggle.checked = !!this.sequenceSettings.syncToTempo;
+        if (quantizeToggle) quantizeToggle.checked = !!this.sequenceSettings.quantize;
+        if (subdivisionSelect) subdivisionSelect.value = this.sequenceSettings.subdivision;
+    }
+
+    updateSequencePlaceholders() {
+        const transitionInput = this.container.querySelector('#sequence-transition');
+        const holdInput = this.container.querySelector('#sequence-hold');
+        if (!transitionInput || !holdInput) return;
+        if (this.sequenceSettings.syncToTempo) {
+            transitionInput.placeholder = 'Transition (beats)';
+            holdInput.placeholder = 'Hold (beats)';
+        } else {
+            transitionInput.placeholder = 'Transition ms';
+            holdInput.placeholder = 'Hold ms';
+        }
+    }
+
+    savePreset() {
+        const nameInput = this.container.querySelector('#preset-name');
+        const flourishSelect = this.container.querySelector('#preset-flourish-parameter');
+        const flourishParam = flourishSelect?.value || this.parameterOptions[0]?.id || '';
+        const flourishAmount = parseFloat(this.container.querySelector('#preset-flourish-amount').value);
+        const flourishDuration = parseInt(this.container.querySelector('#preset-flourish-duration').value, 10);
+        const flourishCurve = this.container.querySelector('#preset-flourish-curve')?.value || 'easeOut';
+        const flourishReturn = this.container.querySelector('#preset-flourish-return')?.value || 'easeInOut';
+        const flourishHold = parseInt(this.container.querySelector('#preset-flourish-hold').value, 10) || 0;
+
+        const preset = {
+            id: this.generatePresetId(),
+            name: nameInput.value.trim() || `Preset ${new Date().toLocaleTimeString()}`,
+            createdAt: Date.now(),
+            params: this.parameterManager?.getAllParameters() || {},
+            mappings: this.touchPadController?.getMappings() || [],
+            audio: this.audioPanel?.getSettings() || null,
+            flourish: {
+                parameter: flourishParam,
+                amount: flourishAmount,
+                duration: flourishDuration,
+                curve: flourishCurve,
+                returnCurve: flourishReturn,
+                hold: flourishHold
+            }
+        };
+
+        this.presets.push(preset);
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+        this.resetForm();
+        const snapshot = this.clonePreset(preset);
+        if (this.hub) {
+            this.hub.emit('preset-saved', { preset: snapshot });
+        }
+        this.notifyPresetListChange();
+    }
+
+    updatePreset() {
+        if (!this.currentPresetId) return;
+
+        const preset = this.presets.find(item => item.id === this.currentPresetId);
+        if (!preset) return;
+
+        const flourishSelect = this.container.querySelector('#preset-flourish-parameter');
+        const flourishParam = flourishSelect?.value || this.parameterOptions[0]?.id || '';
+        const flourishAmount = parseFloat(this.container.querySelector('#preset-flourish-amount').value);
+        const flourishDuration = parseInt(this.container.querySelector('#preset-flourish-duration').value, 10);
+        const flourishCurve = this.container.querySelector('#preset-flourish-curve')?.value || 'easeOut';
+        const flourishReturn = this.container.querySelector('#preset-flourish-return')?.value || 'easeInOut';
+        const flourishHold = parseInt(this.container.querySelector('#preset-flourish-hold').value, 10) || 0;
+        const nameInput = this.container.querySelector('#preset-name');
+
+        preset.name = nameInput.value.trim() || preset.name;
+        preset.params = this.parameterManager?.getAllParameters() || preset.params;
+        preset.mappings = this.touchPadController?.getMappings() || preset.mappings;
+        preset.audio = this.audioPanel?.getSettings() || preset.audio;
+        preset.flourish = {
+            parameter: flourishParam,
+            amount: flourishAmount,
+            duration: flourishDuration,
+            curve: flourishCurve,
+            returnCurve: flourishReturn,
+            hold: flourishHold
+        };
+
+        const snapshot = this.clonePreset(preset);
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+        if (this.hub) {
+            this.hub.emit('preset-updated', { preset: snapshot });
+        }
+        this.notifyPresetListChange();
+    }
+
+    resetForm() {
+        this.currentPresetId = null;
+        this.container.querySelector('#preset-name').value = '';
+        this.container.querySelector('#preset-update').disabled = true;
+        const flourishSelect = this.container.querySelector('#preset-flourish-parameter');
+        if (flourishSelect) {
+            flourishSelect.value = this.parameterOptions[0]?.id || '';
+        }
+        const amount = this.container.querySelector('#preset-flourish-amount');
+        if (amount) amount.value = 0.5;
+        const duration = this.container.querySelector('#preset-flourish-duration');
+        if (duration) duration.value = 1200;
+        const curve = this.container.querySelector('#preset-flourish-curve');
+        if (curve) curve.value = 'easeOut';
+        const returnCurve = this.container.querySelector('#preset-flourish-return');
+        if (returnCurve) returnCurve.value = 'easeInOut';
+        const hold = this.container.querySelector('#preset-flourish-hold');
+        if (hold) hold.value = 400;
+    }
+
+    renderPresetList() {
+        const list = this.container.querySelector('#preset-list');
+        if (!list) return;
+
+        if (this.presets.length === 0) {
+            list.innerHTML = '<p class="preset-empty">No presets yet. Dial in a look and save it for instant recall.</p>';
+            this.renderSequenceOptions();
+            return;
+        }
+
+        list.innerHTML = '';
+                this.presets
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .forEach(preset => {
+                const item = document.createElement('div');
+                item.classList.add('preset-item');
+                const mappingSummary = this.describeMappingSummary(preset.mappings);
+                const audioSummary = preset.audio ? 'Audio: custom matrix' : 'Audio: default';
+                const flourishSummary = preset.flourish
+                    ? `Flourish: ${this.getParameterLabel(preset.flourish.parameter)} (${preset.flourish.curve || 'easeOut'} → ${preset.flourish.returnCurve || 'easeInOut'})`
+                    : 'Flourish: none';
+                item.innerHTML = `
+                    <div class="preset-meta">
+                        <h4>${preset.name}</h4>
+                        <span>${new Date(preset.createdAt).toLocaleString()}</span>
+                        <p class="preset-summary">${mappingSummary}</p>
+                        <p class="preset-meta-detail">${audioSummary} • ${flourishSummary}</p>
+                    </div>
+                    <div class="preset-buttons">
+                        <button data-action="apply" data-id="${preset.id}">Apply</button>
+                        <button data-action="flourish" data-id="${preset.id}">Flourish</button>
+                        <button data-action="edit" data-id="${preset.id}">Edit</button>
+                        <button data-action="delete" data-id="${preset.id}">Delete</button>
+                    </div>
+                `;
+
+                item.querySelectorAll('button').forEach(button => {
+                    button.addEventListener('click', () => this.handlePresetAction(button.dataset.action, preset.id));
+                });
+
+                list.appendChild(item);
+            });
+
+        this.renderSequenceOptions();
+    }
+
+    handlePresetAction(action, presetId) {
+        const preset = this.presets.find(item => item.id === presetId);
+        if (!preset) return;
+
+        switch (action) {
+            case 'apply':
+                this.applyPreset(preset);
+                break;
+            case 'flourish':
+                this.triggerFlourish(preset);
+                break;
+            case 'edit':
+                this.populateForm(preset);
+                break;
+            case 'delete':
+                this.deletePreset(presetId);
+                break;
+        }
+    }
+
+    populateForm(preset) {
+        this.currentPresetId = preset.id;
+        this.container.querySelector('#preset-name').value = preset.name;
+        const flourishSelect = this.container.querySelector('#preset-flourish-parameter');
+        const targetParameter = preset.flourish?.parameter || this.parameterOptions[0]?.id || '';
+        if (flourishSelect) {
+            if (!flourishSelect.querySelector(`option[value="${targetParameter}"]`)) {
+                flourishSelect.innerHTML = this.renderParameterOptions(this.parameterOptions, targetParameter);
+            }
+            flourishSelect.value = targetParameter;
+        }
+        this.container.querySelector('#preset-flourish-amount').value = preset.flourish?.amount ?? 0.5;
+        this.container.querySelector('#preset-flourish-duration').value = preset.flourish?.duration ?? 1200;
+        const curveSelect = this.container.querySelector('#preset-flourish-curve');
+        if (curveSelect) {
+            curveSelect.innerHTML = this.renderFlourishCurveOptions(curveSelect.value || 'easeOut');
+            curveSelect.value = preset.flourish?.curve ?? 'easeOut';
+        }
+        const returnSelect = this.container.querySelector('#preset-flourish-return');
+        if (returnSelect) {
+            returnSelect.innerHTML = this.renderFlourishCurveOptions(returnSelect.value || 'easeInOut');
+            returnSelect.value = preset.flourish?.returnCurve ?? 'easeInOut';
+        }
+        const holdInput = this.container.querySelector('#preset-flourish-hold');
+        if (holdInput) {
+            holdInput.value = preset.flourish?.hold ?? 400;
+        }
+        this.container.querySelector('#preset-update').disabled = false;
+    }
+
+    deletePreset(presetId) {
+        this.presets = this.presets.filter(item => item.id !== presetId);
+        this.persistPresets();
+        this.renderPresetList();
+        this.renderSequenceOptions();
+        if (this.hub) {
+            this.hub.emit('preset-deleted', { presetId });
+        }
+        this.notifyPresetListChange();
+    }
+
+    applyPreset(preset, options = {}) {
+        const transition = options.transition || 1800;
+        const snapshot = this.clonePreset(preset);
+        if (this.parameterManager) {
+            this.parameterManager.interpolateTo(preset.params, transition, { source: 'preset' });
+        }
+
+        if (this.touchPadController && preset.mappings) {
+            this.touchPadController.applyMappings(preset.mappings);
+        }
+
+        if (this.audioPanel && preset.audio) {
+            this.audioPanel.setSettings(preset.audio);
+        }
+
+        if (typeof this.onPresetApply === 'function') {
+            this.onPresetApply(preset);
+        }
+        if (this.hub) {
+            this.hub.emit('preset-applied', { preset: snapshot, transition });
+        }
+    }
+
+    triggerFlourish(preset) {
+        if (!preset?.flourish || !this.parameterManager) return;
+
+        const { parameter, amount, duration, hold = 0, curve = 'easeOut', returnCurve = 'easeInOut' } = preset.flourish;
+        const definition = this.parameterManager.getParameterDefinition(parameter);
+        if (!definition) return;
+
+        const baseValue = this.parameterManager.getParameter(parameter);
+        const span = definition.max - definition.min;
+        const target = this.parameterManager.clampToDefinition(parameter, baseValue + span * amount);
+
+        this.parameterManager.animateParameter(parameter, target, duration, {
+            source: 'flourish',
+            easing: curve,
+            onComplete: () => {
+                const resume = () => this.parameterManager.animateParameter(parameter, baseValue, duration, {
+                    source: 'flourish-return',
+                    easing: returnCurve
+                });
+                if (hold > 0) {
+                    setTimeout(resume, hold);
+                } else {
+                    resume();
+                }
+            }
+        });
+        if (this.hub) {
+            this.hub.emit('preset-flourish', {
+                preset: this.clonePreset(preset),
+                parameter,
+                amount,
+                duration,
+                target,
+                hold,
+                curve,
+                returnCurve
+            });
+        }
+    }
+
+    addSequenceCue() {
+        const select = this.container.querySelector('#sequence-preset');
+        const transitionInput = this.container.querySelector('#sequence-transition');
+        const holdInput = this.container.querySelector('#sequence-hold');
+        const flourishToggle = this.container.querySelector('#sequence-flourish');
+
+        if (!select.value) return;
+
+        const resolved = this.resolveCueInput(transitionInput.value, holdInput.value);
+        const cue = {
+            presetId: select.value,
+            transition: resolved.transition,
+            hold: resolved.hold,
+            flourish: flourishToggle.checked,
+            transitionBeats: resolved.transitionBeats,
+            holdBeats: resolved.holdBeats,
+            subdivision: resolved.subdivision,
+            tempoSync: resolved.tempoSync
+        };
+
+        this.sequence.push(cue);
+
+        flourishToggle.checked = false;
+        this.renderSequence();
+        this.notifySequenceChange();
+    }
+
+    renderSequence() {
+        const list = this.container.querySelector('#sequence-list');
+        if (!list) return;
+
+        list.innerHTML = '';
+        this.sequence.forEach((cue, index) => {
+            const preset = this.presets.find(item => item.id === cue.presetId);
+            if (!preset) return;
+
+            const item = document.createElement('li');
+            const durations = this.resolveCueDurations(cue);
+            const transitionLabel = this.formatSequenceDuration(cue, durations, 'transition');
+            const holdLabel = this.formatSequenceDuration(cue, durations, 'hold');
+            const flags = [];
+            if (cue.flourish) flags.push('flourish');
+            if (this.sequenceSettings.syncToTempo || cue.tempoSync) flags.push('tempo-synced');
+            const flagText = flags.length ? ` (${flags.join(', ')})` : '';
+            item.innerHTML = `
+                <span>${index + 1}. ${preset.name} — ${transitionLabel} transition, ${holdLabel} hold${flagText}</span>
+                <button data-index="${index}">Remove</button>
+            `;
+
+            item.querySelector('button').addEventListener('click', () => {
+                this.sequence.splice(index, 1);
+                this.renderSequence();
+                this.notifySequenceChange();
+            });
+
+            list.appendChild(item);
+        });
+    }
+
+    renderSequenceOptions() {
+        const select = this.container.querySelector('#sequence-preset');
+        if (!select) return;
+
+        select.innerHTML = this.presets
+            .map(preset => `<option value="${preset.id}">${preset.name}</option>`)
+            .join('');
+    }
+
+    buildParameterOptions() {
+        if (!this.parameterManager) return [];
+        return this.parameterManager.listParameterMetadata().map(meta => ({
+            id: meta.id,
+            label: meta.label,
+            group: meta.group || 'General'
+        }));
+    }
+
+    renderParameterOptions(options, selectedValue) {
+        const groups = new Map();
+        options.forEach(option => {
+            const group = option.group || 'General';
+            if (!groups.has(group)) {
+                groups.set(group, []);
+            }
+            groups.get(group).push(option);
+        });
+
+        const fragments = [];
+        groups.forEach((groupOptions, group) => {
+            const markup = groupOptions
+                .sort((a, b) => a.label.localeCompare(b.label))
+                .map(option => `<option value="${option.id}"${option.id === selectedValue ? ' selected' : ''}>${option.label}</option>`)
+                .join('');
+            fragments.push(`<optgroup label="${group}">${markup}</optgroup>`);
+        });
+
+        if (fragments.length === 0) {
+            return '<option value="" disabled>No parameters</option>';
+        }
+
+        return fragments.join('');
+    }
+
+    renderFlourishCurveOptions(selectedValue) {
+        return FLOURISH_CURVES
+            .map(curve => `<option value="${curve.value}"${curve.value === selectedValue ? ' selected' : ''}>${curve.label}</option>`)
+            .join('');
+    }
+
+    renderTempoSubdivisionOptions(selectedValue) {
+        const tempoConfig = this.audioPanel?.config?.tempo || DEFAULT_PERFORMANCE_CONFIG.audio.tempo;
+        const subdivisions = Array.isArray(tempoConfig?.subdivisions) && tempoConfig.subdivisions.length
+            ? tempoConfig.subdivisions
+            : DEFAULT_PERFORMANCE_CONFIG.audio.tempo.subdivisions;
+        return subdivisions
+            .map(option => `<option value="${option.value}"${option.value === selectedValue ? ' selected' : ''}>${option.label}</option>`)
+            .join('');
+    }
+
+    normalizeMappingsForSummary(mappings) {
+        if (!mappings) {
+            return { padCount: 0, pads: [] };
+        }
+
+        if (Array.isArray(mappings)) {
+            return {
+                padCount: mappings.length,
+                pads: mappings.map((pad, index) => ({
+                    id: pad.id ?? index,
+                    bindings: pad.bindings || pad.axisBindings || {},
+                    modes: pad.modes || pad.axisModes || {},
+                    settings: pad.settings || pad.axisSettings || {},
+                    gestureMode: pad.gestureMode || pad.gesture?.mode
+                }))
+            };
+        }
+
+        const pads = Array.isArray(mappings.pads)
+            ? mappings.pads
+            : Array.isArray(mappings.padStates)
+                ? mappings.padStates
+                : [];
+
+        return {
+            padCount: mappings.padCount ?? pads.length,
+            pads: pads.map((pad, index) => ({
+                id: pad.id ?? index,
+                bindings: pad.bindings || pad.axisBindings || {},
+                modes: pad.modes || pad.axisModes || {},
+                settings: pad.settings || pad.axisSettings || {},
+                gestureMode: pad.gestureMode || pad.gesture?.mode
+            }))
+        };
+    }
+
+    describeMappingSummary(mappings) {
+        const normalized = this.normalizeMappingsForSummary(mappings);
+        if (!normalized.pads.length) {
+            return 'No pad mappings set';
+        }
+
+        return normalized.pads
+            .map(pad => {
+                const parts = ['x', 'y', 'gesture']
+                    .map(axis => this.describeAxisMapping(axis, pad))
+                    .filter(Boolean);
+                return `Pad ${(pad.id ?? 0) + 1}: ${parts.join(' • ')}`;
+            })
+            .join(' • ');
+    }
+
+    describeAxisMapping(axis, pad) {
+        const label = axis === 'x' ? 'X' : axis === 'y' ? 'Y' : 'Gesture';
+        const binding = pad.bindings?.[axis];
+        const parameterLabel = this.getParameterLabel(binding);
+
+        if (!binding || binding === 'none') {
+            return `${label} → None`;
+        }
+
+        const details = [];
+        if (axis === 'gesture' && pad.gestureMode) {
+            const interpretation = this.gestureModeLabels.get(pad.gestureMode) || pad.gestureMode;
+            if (interpretation) {
+                details.push(interpretation);
+            }
+        }
+        const mode = pad.modes?.[axis];
+        const modeLabel = this.axisModeLabels.get(mode) || mode;
+        if (modeLabel) {
+            details.push(modeLabel);
+        }
+
+        const curve = pad.settings?.curve?.[axis];
+        const curveLabel = this.axisCurveLabels.get(curve);
+        if (curve && curveLabel && curve !== 'linear') {
+            details.push(curveLabel);
+        }
+
+        if (pad.settings?.invert?.[axis]) {
+            details.push('Invert');
+        }
+
+        const smoothing = pad.settings?.smoothing?.[axis];
+        if (typeof smoothing === 'number' && smoothing > (this.axisSmoothingMin ?? 0)) {
+            const max = this.axisSmoothingMax || 1;
+            const percentage = Math.round((smoothing / max) * 100);
+            details.push(`Smooth ${percentage}%`);
+        }
+
+        const detailText = details.length ? ` (${details.join(' · ')})` : '';
+        return `${label} → ${parameterLabel}${detailText}`;
+    }
+
+    getTempoSettings() {
+        const audioSettings = this.audioPanel?.getSettings?.() || {};
+        const tempo = audioSettings.tempo || {};
+        const baseBpm = Math.max(40, tempo.bpm ?? DEFAULT_PERFORMANCE_CONFIG.audio.tempo.defaultBpm);
+        const nudge = Number.isFinite(tempo.nudge) ? tempo.nudge : 0;
+        const effectiveBpm = Math.max(40, baseBpm * (1 + nudge));
+        return {
+            bpm: effectiveBpm,
+            rawBpm: baseBpm,
+            subdivision: tempo.subdivision || tempo.defaultSubdivision || DEFAULT_PERFORMANCE_CONFIG.audio.tempo.defaultSubdivision || '1/4'
+        };
+    }
+
+    getSubdivisionMultiplier(subdivision) {
+        if (typeof subdivision !== 'string') return 1;
+        const isTriplet = subdivision.endsWith('T');
+        const fraction = isTriplet ? subdivision.slice(0, -1) : subdivision;
+        const [numerator, denominator] = fraction.split('/').map(value => parseFloat(value));
+        if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) {
+            return 1;
+        }
+        let beats = (4 / denominator) * numerator;
+        if (isTriplet) {
+            beats *= 2 / 3;
+        }
+        return beats;
+    }
+
+    beatsToMs(beats, bpm) {
+        const safeBpm = Math.max(1, bpm || 120);
+        return (60000 / safeBpm) * beats;
+    }
+
+    msToBeats(ms, bpm) {
+        const safeBpm = Math.max(1, bpm || 120);
+        return ms / (60000 / safeBpm);
+    }
+
+    applyQuantization(value) {
+        if (!Number.isFinite(value)) return 0;
+        return Math.max(0, Math.round(value * 4) / 4);
+    }
+
+    resolveCueInput(transitionValue, holdValue) {
+        const tempo = this.getTempoSettings();
+        const subdivision = this.sequenceSettings.subdivision || tempo.subdivision;
+        const multiplier = this.getSubdivisionMultiplier(subdivision);
+
+        if (this.sequenceSettings.syncToTempo) {
+            let transitionBeats = parseFloat(transitionValue);
+            if (!Number.isFinite(transitionBeats)) transitionBeats = 1;
+            let holdBeats = parseFloat(holdValue);
+            if (!Number.isFinite(holdBeats)) holdBeats = 0;
+            if (this.sequenceSettings.quantize) {
+                transitionBeats = this.applyQuantization(transitionBeats);
+                holdBeats = this.applyQuantization(holdBeats);
+            }
+            const transitionMs = this.beatsToMs(transitionBeats * multiplier, tempo.bpm);
+            const holdMs = this.beatsToMs(holdBeats * multiplier, tempo.bpm);
+            return {
+                transition: Math.round(transitionMs),
+                hold: Math.round(holdMs),
+                transitionBeats,
+                holdBeats,
+                subdivision,
+                tempoSync: true
+            };
+        }
+
+        const transitionMs = parseInt(transitionValue, 10) || 0;
+        const holdMs = parseInt(holdValue, 10) || 0;
+        const transitionBeats = this.msToBeats(transitionMs, tempo.bpm) / multiplier;
+        const holdBeats = this.msToBeats(holdMs, tempo.bpm) / multiplier;
+        return {
+            transition: transitionMs,
+            hold: holdMs,
+            transitionBeats,
+            holdBeats,
+            subdivision,
+            tempoSync: false
+        };
+    }
+
+    resolveCueDurations(cue) {
+        const tempo = this.getTempoSettings();
+        const subdivision = cue.subdivision || this.sequenceSettings.subdivision || tempo.subdivision;
+        const multiplier = this.getSubdivisionMultiplier(subdivision);
+        if (this.sequenceSettings.syncToTempo || cue.tempoSync) {
+            const transitionBeats = Number.isFinite(cue.transitionBeats)
+                ? cue.transitionBeats
+                : this.msToBeats(cue.transition, tempo.bpm) / multiplier;
+            const holdBeats = Number.isFinite(cue.holdBeats)
+                ? cue.holdBeats
+                : this.msToBeats(cue.hold, tempo.bpm) / multiplier;
+            const transitionMs = this.beatsToMs(transitionBeats * multiplier, tempo.bpm);
+            const holdMs = this.beatsToMs(holdBeats * multiplier, tempo.bpm);
+            return {
+                transition: Math.round(transitionMs),
+                hold: Math.round(holdMs)
+            };
+        }
+        return {
+            transition: cue.transition,
+            hold: cue.hold
+        };
+    }
+
+    formatSequenceDuration(cue, durations, type) {
+        const tempo = this.getTempoSettings();
+        const subdivision = cue.subdivision || this.sequenceSettings.subdivision || tempo.subdivision;
+        const multiplier = this.getSubdivisionMultiplier(subdivision);
+        const msValue = type === 'transition' ? durations.transition : durations.hold;
+        const beats = type === 'transition'
+            ? (Number.isFinite(cue.transitionBeats) ? cue.transitionBeats : this.msToBeats(durations.transition, tempo.bpm) / multiplier)
+            : (Number.isFinite(cue.holdBeats) ? cue.holdBeats : this.msToBeats(durations.hold, tempo.bpm) / multiplier);
+        if (this.sequenceSettings.syncToTempo || cue.tempoSync) {
+            return `${msValue}ms (${beats.toFixed(2)}×${subdivision})`;
+        }
+        return `${msValue}ms`;
+    }
+
+    async playSequence() {
+        if (this.sequencePlaying || this.sequence.length === 0) return;
+
+        this.sequencePlaying = true;
+        this.sequenceAbort = false;
+        if (this.hub) {
+            this.hub.emit('sequence-play-started', {
+                sequence: this.cloneSequence(this.sequence)
+            });
+        }
+        const runOnce = async () => {
+            for (const cue of this.sequence) {
+                if (this.sequenceAbort) break;
+                const preset = this.presets.find(item => item.id === cue.presetId);
+                if (!preset) continue;
+
+                const durations = this.resolveCueDurations(cue);
+                this.applyPreset(preset, { transition: durations.transition });
+                if (this.hub) {
+                    this.hub.emit('sequence-play-step', {
+                        preset: this.clonePreset(preset),
+                        cue: { ...cue },
+                        durations
+                    });
+                }
+                if (cue.flourish) {
+                    setTimeout(() => this.triggerFlourish(preset), Math.max(0, durations.transition / 2));
+                }
+
+                await this.wait(durations.transition + durations.hold);
+                if (this.sequenceAbort) break;
+            }
+        };
+
+        do {
+            await runOnce();
+        } while (this.sequenceSettings.loop && !this.sequenceAbort);
+
+        this.sequencePlaying = false;
+        this.sequenceAbort = false;
+        this.sequenceWaitTimeout = null;
+        if (this.hub) {
+            this.hub.emit('sequence-play-complete', {});
+        }
+    }
+
+    clearSequence() {
+        this.sequence = [];
+        this.sequenceAbort = false;
+        this.sequencePlaying = false;
+        if (this.sequenceWaitTimeout) {
+            clearTimeout(this.sequenceWaitTimeout);
+            this.sequenceWaitTimeout = null;
+        }
+        this.renderSequence();
+        this.notifySequenceChange();
+    }
+
+    wait(duration) {
+        return new Promise(resolve => {
+            if (this.sequenceAbort) {
+                resolve();
+                return;
+            }
+            this.sequenceWaitTimeout = setTimeout(() => {
+                this.sequenceWaitTimeout = null;
+                resolve();
+            }, duration);
+        });
+    }
+
+    stopSequence() {
+        if (!this.sequencePlaying) return;
+        this.sequenceAbort = true;
+        if (this.sequenceWaitTimeout) {
+            clearTimeout(this.sequenceWaitTimeout);
+            this.sequenceWaitTimeout = null;
+        }
+    }
+
+    generatePresetId() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+        return `preset-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    }
+
+    loadPresets() {
+        try {
+            const data = window.localStorage.getItem(STORAGE_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (error) {
+            console.warn('Unable to load performance presets:', error);
+            return [];
+        }
+    }
+
+    persistPresets() {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.presets));
+        } catch (error) {
+            console.warn('Unable to persist presets:', error);
+        }
+    }
+
+    clearSequenceOptions() {
+        const select = this.container.querySelector('#sequence-preset');
+        if (select) select.innerHTML = '';
+    }
+
+    getParameterLabel(name) {
+        if (!name || name === 'none') {
+            return 'None';
+        }
+        return this.parameterLabels?.get(name)
+            || this.parameterManager?.formatParameterLabel?.(name)
+            || this.formatFallbackName(name);
+    }
+
+    formatParameterName(name) {
+        return this.getParameterLabel(name);
+    }
+
+    formatFallbackName(name) {
+        return name
+            .replace(/rot4d/gi, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+}

--- a/src/ui/PerformanceSuite.js
+++ b/src/ui/PerformanceSuite.js
@@ -1,0 +1,236 @@
+import { TouchPadController } from './TouchPadController.js';
+import { AudioReactivityPanel } from './AudioReactivityPanel.js';
+import { PerformancePresetManager } from './PerformancePresetManager.js';
+import { PerformanceHub } from './PerformanceHub.js';
+import { DEFAULT_PERFORMANCE_CONFIG, mergePerformanceConfig } from './PerformanceConfig.js';
+
+/**
+ * PerformanceSuite orchestrates live performance controls for the engine.
+ */
+export class PerformanceSuite {
+    constructor(options = {}) {
+        const { engine, parameterManager, config = {} } = options;
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.config = mergePerformanceConfig(config);
+
+        this.root = null;
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.hub = new PerformanceHub({
+            engine: this.engine,
+            parameterManager: this.parameterManager
+        });
+        this.mappingSnapshot = [];
+        this.audioSettings = null;
+        this.unsubscribe = null;
+        this.layoutSettings = { ...this.config.touchPads.layout };
+        this.eventUnsubscribers = [];
+        this.extensionUnregister = null;
+
+        this.init();
+    }
+
+    init() {
+        this.createLayout();
+        this.touchPadController = new TouchPadController({
+            parameterManager: this.parameterManager,
+            container: this.touchpadContainer,
+            config: this.config.touchPads,
+            hub: this.hub,
+            onMappingChange: (mappings) => {
+                this.mappingSnapshot = mappings;
+            },
+            onLayoutChange: (layout) => {
+                this.layoutSettings = layout;
+                this.applyTouchPadLayout(layout);
+            }
+        });
+
+        this.audioPanel = new AudioReactivityPanel({
+            parameterManager: this.parameterManager,
+            container: this.audioContainer,
+            config: this.config.audio,
+            hub: this.hub,
+            onSettingsChange: (settings) => this.handleAudioSettingsChange(settings)
+        });
+
+        this.presetManager = new PerformancePresetManager({
+            parameterManager: this.parameterManager,
+            touchPadController: this.touchPadController,
+            audioPanel: this.audioPanel,
+            container: this.presetsContainer,
+            hub: this.hub,
+            onPresetApply: (preset) => this.handlePresetApplied(preset)
+        });
+
+        this.bindHubEvents();
+        this.hub.registerTouchPadController(this.touchPadController);
+        this.hub.registerAudioPanel(this.audioPanel);
+        this.hub.registerPresetManager(this.presetManager);
+        this.extensionUnregister = this.hub.registerExtension('performance-suite', {
+            getState: () => this.getState(),
+            applyState: (state) => this.applyState(state),
+            getModules: () => ({
+                touchPads: this.touchPadController,
+                audio: this.audioPanel,
+                presets: this.presetManager
+            })
+        });
+
+        this.mappingSnapshot = this.touchPadController.getMappings();
+        this.audioSettings = this.audioPanel.getSettings();
+        this.applyAudioSettingsToEngine();
+
+        if (this.parameterManager) {
+            this.unsubscribe = this.parameterManager.addChangeListener(() => {
+                // Could be used for analytics or additional behaviours.
+            });
+        }
+
+        window.performanceSuite = this;
+        window.performanceHub = this.hub;
+    }
+
+    bindHubEvents() {
+        const subscriptions = [
+            this.hub.on('touchpad-mapping-change', ({ mappings }) => {
+                this.mappingSnapshot = mappings;
+            }),
+            this.hub.on('touchpad-layout-change', ({ layout }) => {
+                if (!layout) return;
+                this.layoutSettings = { ...this.layoutSettings, ...layout };
+                this.applyTouchPadLayout(this.layoutSettings);
+            }),
+            this.hub.on('audio-settings-change', ({ settings }) => {
+                if (!settings) return;
+                this.audioSettings = settings;
+                this.applyAudioSettingsToEngine();
+            }),
+            this.hub.on('preset-applied', ({ preset }) => {
+                if (!preset) return;
+                this.handlePresetApplied(preset);
+            })
+        ];
+
+        this.eventUnsubscribers.push(...subscriptions);
+    }
+
+    createLayout() {
+        const host = document.getElementById('controlPanel') || document.body;
+
+        this.root = document.createElement('section');
+        this.root.classList.add('performance-suite');
+        this.applyTouchPadLayout(this.layoutSettings);
+
+        const columns = document.createElement('div');
+        columns.classList.add('performance-columns');
+
+        this.touchpadContainer = document.createElement('section');
+        this.touchpadContainer.classList.add('performance-column', 'performance-column--touchpads');
+
+        this.audioContainer = document.createElement('section');
+        this.audioContainer.classList.add('performance-column', 'performance-column--audio');
+
+        this.presetsContainer = document.createElement('section');
+        this.presetsContainer.classList.add('performance-column', 'performance-column--presets');
+
+        columns.appendChild(this.touchpadContainer);
+        columns.appendChild(this.audioContainer);
+        columns.appendChild(this.presetsContainer);
+
+        this.root.appendChild(columns);
+        host.appendChild(this.root);
+    }
+
+    handleAudioSettingsChange(settings) {
+        this.audioSettings = settings;
+        this.applyAudioSettingsToEngine();
+    }
+
+    applyTouchPadLayout(layout = DEFAULT_PERFORMANCE_CONFIG.touchPads.layout) {
+        if (!this.root || !layout) return;
+
+        const target = this.touchpadContainer || this.root;
+        if (!target) return;
+
+        if (layout.minWidth) {
+            target.style.setProperty('--touchpad-min-width', `${layout.minWidth}px`);
+        }
+        if (layout.gap !== undefined) {
+            target.style.setProperty('--touchpad-gap', `${layout.gap}px`);
+        }
+        if (layout.aspectRatio) {
+            target.style.setProperty('--touchpad-aspect-ratio', layout.aspectRatio);
+        }
+        if (layout.crosshairSize) {
+            target.style.setProperty('--touchpad-crosshair-size', `${layout.crosshairSize}px`);
+        }
+        if (layout.columns && layout.columns !== 'auto') {
+            target.style.setProperty('--touchpad-columns', layout.columns);
+        } else {
+            target.style.removeProperty('--touchpad-columns');
+        }
+    }
+
+    applyAudioSettingsToEngine() {
+        if (!this.engine) return;
+        this.engine.liveAudioSettings = this.audioSettings;
+    }
+
+    handlePresetApplied(preset) {
+        if (!preset) return;
+        this.mappingSnapshot = preset.mappings || this.mappingSnapshot;
+        if (preset.audio) {
+            this.audioSettings = preset.audio;
+            this.applyAudioSettingsToEngine();
+        }
+    }
+
+    getAudioSettings() {
+        return this.audioSettings;
+    }
+
+    getState() {
+        return this.hub.getState();
+    }
+
+    applyState(state) {
+        this.hub.applyState(state);
+    }
+
+    destroy() {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+        }
+        this.eventUnsubscribers.forEach(unsub => {
+            try {
+                unsub?.();
+            } catch (error) {
+                console.warn('Failed to unsubscribe hub listener:', error);
+            }
+        });
+        this.eventUnsubscribers = [];
+        this.touchPadController?.destroy();
+        this.audioPanel?.destroy();
+        this.root?.remove();
+        if (typeof this.extensionUnregister === 'function') {
+            try {
+                this.extensionUnregister();
+            } catch (error) {
+                console.warn('Failed to unregister hub extension:', error);
+            }
+            this.extensionUnregister = null;
+        }
+        this.hub?.destroy();
+        if (typeof window !== 'undefined') {
+            if (window.performanceSuite === this) {
+                window.performanceSuite = null;
+            }
+            if (window.performanceHub === this.hub) {
+                window.performanceHub = null;
+            }
+        }
+    }
+}

--- a/src/ui/TouchPadController.js
+++ b/src/ui/TouchPadController.js
@@ -1,0 +1,1872 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+const AXES = ['x', 'y', 'gesture'];
+
+const LAYOUT_KEYS = ['minWidth', 'gap', 'aspectRatio', 'columns'];
+const LAYOUT_TOLERANCES = {
+    minWidth: 0.5,
+    gap: 0.5,
+    aspectRatio: 0.01
+};
+
+const DEFAULT_CURVE_OPTIONS = [
+    { value: 'linear', label: 'Linear' },
+    { value: 'ease-in', label: 'Ease In' },
+    { value: 'ease-out', label: 'Ease Out' },
+    { value: 'ease-in-out', label: 'Ease In-Out' },
+    { value: 'expo', label: 'Exponential' }
+];
+
+const CURVE_FUNCTIONS = {
+    linear: value => value,
+    'ease-in': value => value * value,
+    'ease-out': value => 1 - Math.pow(1 - value, 2),
+    'ease-in-out': value => (value < 0.5)
+        ? 2 * value * value
+        : 1 - Math.pow(-2 * value + 2, 2) / 2,
+    expo: value => Math.pow(value, 3)
+};
+
+function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+}
+
+export class TouchPadController {
+    constructor(options = {}) {
+        const {
+            parameterManager,
+            container = null,
+            config = DEFAULT_PERFORMANCE_CONFIG.touchPads,
+            onMappingChange = null,
+            onLayoutChange = null,
+            padCount = null,
+            defaultMappings = null,
+            hub = null
+        } = options;
+
+        this.parameterManager = parameterManager;
+        this.onMappingChange = onMappingChange;
+        this.onLayoutChange = onLayoutChange;
+        this.hub = hub;
+        this.config = JSON.parse(JSON.stringify(config || DEFAULT_PERFORMANCE_CONFIG.touchPads));
+        this.availableParameters = this.buildParameterOptions();
+        this.parameterLabels = new Map(this.availableParameters.map(meta => [meta.id, meta.label]));
+        this.modeLabelMap = new Map(this.config.axis.modes.map(mode => [mode.value, mode.label]));
+        this.curveOptions = Array.isArray(this.config.axis?.curves) && this.config.axis.curves.length
+            ? this.config.axis.curves
+            : DEFAULT_CURVE_OPTIONS;
+        this.curveLabelMap = new Map(this.curveOptions.map(curve => [curve.value, curve.label]));
+        const smoothingConfig = this.config.axis?.smoothing || {};
+        this.smoothingConfig = {
+            min: smoothingConfig.min ?? 0,
+            max: smoothingConfig.max ?? 0.6,
+            step: smoothingConfig.step ?? 0.05,
+            default: smoothingConfig.default ?? 0
+        };
+        this.gestureConfig = this.config.gesture || {};
+        this.availableGestureModes = Array.isArray(this.gestureConfig.modes)
+            ? this.gestureConfig.modes
+            : [];
+        this.gestureModeMap = new Map(this.availableGestureModes.map(mode => [mode.value, mode.label]));
+        this.defaultGestureMode = this.normalizeGestureMode(this.gestureConfig.defaultMode);
+        this.gestureVelocityScale = Number.isFinite(this.gestureConfig.velocityScale)
+            ? this.gestureConfig.velocityScale
+            : 2.4;
+        this.gesturePressureFallback = Number.isFinite(this.gestureConfig.pressureFallback)
+            ? this.gestureConfig.pressureFallback
+            : 0.6;
+
+        this.container = container || this.ensureContainer();
+        this.padGrid = null;
+        this.layoutControls = null;
+        this.layoutControlRefs = {};
+
+        const resolvedMappings = Array.isArray(defaultMappings) && defaultMappings.length
+            ? defaultMappings
+            : this.config.defaultMappings;
+
+        const defaultPadCount = padCount ?? this.config.pads?.defaultCount ?? resolvedMappings.length ?? 3;
+        this.padCount = this.normalizePadCount(defaultPadCount);
+
+        this.layoutSettings = {
+            ...this.config.layout
+        };
+
+        this.layoutPresetStorageKey = 'vib34d_touchpad_layout_presets_v1';
+        this.layoutPresetRefs = { select: null, deleteButton: null, hint: null };
+        this.baseLayoutPresets = this.normalizeLayoutPresets(this.config.layoutPresets || [], true);
+        this.customLayoutPresets = this.loadCustomLayoutPresets();
+        this.composeLayoutPresets();
+        this.activeLayoutPresetId = null;
+        this.suspendPresetDetection = false;
+
+        this.padStates = [];
+        this.suspendNotify = false;
+
+        this.buildUI();
+        this.renderPads(resolvedMappings);
+        this.applyLayoutToContainer();
+        this.syncLayoutControls();
+        this.refreshLayoutPresetSelection();
+        this.emitLayoutChange();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-touchpads');
+        if (existing) {
+            existing.classList.add('performance-touchpads');
+            return existing;
+        }
+
+        const element = document.createElement('section');
+        element.id = 'performance-touchpads';
+        element.classList.add('performance-touchpads');
+        document.body.appendChild(element);
+        return element;
+    }
+
+    buildParameterOptions() {
+        if (!this.parameterManager) return [];
+        const metadata = this.parameterManager.listParameterMetadata();
+        return metadata.map(meta => ({
+            id: meta.id,
+            label: meta.label,
+            group: meta.group,
+            min: meta.min,
+            max: meta.max,
+            type: meta.type,
+            step: meta.step,
+            tags: meta.tags
+        }));
+    }
+
+    normalizeGestureMode(mode) {
+        if (mode && this.gestureModeMap.has(mode)) {
+            return mode;
+        }
+        if (mode && typeof mode === 'string') {
+            const normalized = this.availableGestureModes.find(candidate => candidate.value === mode);
+            if (normalized) {
+                return normalized.value;
+            }
+        }
+        return this.availableGestureModes[0]?.value || 'spread';
+    }
+
+    groupParametersByGroup() {
+        const groups = new Map();
+        this.availableParameters.forEach(meta => {
+            const group = meta.group || 'General';
+            if (!groups.has(group)) {
+                groups.set(group, []);
+            }
+            groups.get(group).push(meta);
+        });
+
+        return Array.from(groups.entries())
+            .map(([group, options]) => ({
+                group,
+                options: options.sort((a, b) => a.label.localeCompare(b.label))
+            }))
+            .sort((a, b) => a.group.localeCompare(b.group));
+    }
+
+    buildUI() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-touchpads');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.classList.add('performance-section-header');
+        header.innerHTML = `
+            <div>
+                <h3>Multi-Touch Control Pads</h3>
+                <p class="performance-subtitle">Assign any parameter to expressive XY pads and capture live gestures.</p>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        this.layoutControls = this.createLayoutControls();
+        this.container.appendChild(this.layoutControls);
+
+        this.padGrid = document.createElement('div');
+        this.padGrid.classList.add('touchpad-grid');
+        this.container.appendChild(this.padGrid);
+    }
+
+    createLayoutControls() {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('touchpad-layout-controls');
+
+        const presetControls = this.createLayoutPresetControls();
+        if (presetControls) {
+            wrapper.appendChild(presetControls);
+        }
+
+        const padCountControl = document.createElement('label');
+        padCountControl.classList.add('layout-control');
+        padCountControl.innerHTML = `
+            <span class="layout-control-label">Pads</span>
+            <input type="number" class="layout-control-input" min="${this.config.pads?.min ?? 1}" max="${this.config.pads?.max ?? 8}" step="1">
+        `;
+        const padCountInput = padCountControl.querySelector('input');
+        padCountInput.value = this.padCount;
+        padCountInput.addEventListener('change', () => {
+            this.setPadCount(parseInt(padCountInput.value, 10));
+        });
+        padCountInput.addEventListener('input', () => {
+            this.updateLayoutDisplay('padCount', parseInt(padCountInput.value, 10));
+        });
+        this.layoutControlRefs.padCount = { input: padCountInput, display: null };
+        wrapper.appendChild(padCountControl);
+
+        const padSizeControl = this.createSliderControl({
+            label: 'Pad Size',
+            key: 'minWidth',
+            min: this.config.layout?.minWidth ?? 160,
+            max: this.config.layout?.maxWidth ?? 420,
+            step: 10,
+            unit: 'px',
+            format: value => `${Math.round(value)}px`
+        });
+        wrapper.appendChild(padSizeControl);
+
+        const gapControl = this.createSliderControl({
+            label: 'Pad Gap',
+            key: 'gap',
+            min: 6,
+            max: 48,
+            step: 2,
+            unit: 'px',
+            format: value => `${Math.round(value)}px`
+        });
+        wrapper.appendChild(gapControl);
+
+        const aspectControl = this.createSliderControl({
+            label: 'Aspect',
+            key: 'aspectRatio',
+            min: 0.6,
+            max: 1.4,
+            step: 0.05,
+            format: value => value.toFixed(2)
+        });
+        wrapper.appendChild(aspectControl);
+
+        const columnsControl = document.createElement('label');
+        columnsControl.classList.add('layout-control');
+        columnsControl.innerHTML = `
+            <span class="layout-control-label">Columns</span>
+            <select class="layout-control-input">
+                <option value="auto">Auto</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+            </select>
+        `;
+        const columnsSelect = columnsControl.querySelector('select');
+        columnsSelect.value = this.layoutSettings.columns ? String(this.layoutSettings.columns) : 'auto';
+        columnsSelect.addEventListener('change', () => {
+            const raw = columnsSelect.value;
+            const value = raw === 'auto' ? 'auto' : parseInt(raw, 10);
+            this.updateLayoutSetting('columns', value);
+        });
+        this.layoutControlRefs.columns = { input: columnsSelect };
+        wrapper.appendChild(columnsControl);
+
+        return wrapper;
+    }
+
+    createSliderControl({ label, key, min, max, step, unit = '', format = value => value }) {
+        const control = document.createElement('label');
+        control.classList.add('layout-control');
+        control.innerHTML = `
+            <span class="layout-control-label">${label}</span>
+            <div class="layout-control-slider">
+                <input type="range" min="${min}" max="${max}" step="${step}">
+                <span class="layout-control-value"></span>
+            </div>
+        `;
+
+        const input = control.querySelector('input');
+        const valueLabel = control.querySelector('.layout-control-value');
+
+        input.addEventListener('input', event => {
+            const numericValue = parseFloat(event.target.value);
+            this.updateLayoutSetting(key, numericValue);
+        });
+
+        this.layoutControlRefs[key] = { input, display: valueLabel, format, unit };
+
+        const currentValue = this.layoutSettings[key] ?? min;
+        input.value = currentValue;
+        valueLabel.textContent = `${format(currentValue)}${unit}`;
+
+        return control;
+    }
+
+    createLayoutPresetControls() {
+        const container = document.createElement('div');
+        container.classList.add('layout-preset-controls');
+
+        const selectWrapper = document.createElement('label');
+        selectWrapper.classList.add('layout-control', 'layout-preset-select-wrap');
+
+        const label = document.createElement('span');
+        label.classList.add('layout-control-label');
+        label.textContent = 'Layout Preset';
+
+        const select = document.createElement('select');
+        select.classList.add('layout-control-input', 'layout-preset-select');
+        select.addEventListener('change', () => {
+            const value = select.value;
+            if (!value || value === '__custom') {
+                this.activeLayoutPresetId = null;
+                this.updateLayoutPresetHintAndActions();
+                return;
+            }
+            if (value === this.activeLayoutPresetId) {
+                return;
+            }
+            this.applyLayoutPreset(value);
+        });
+
+        selectWrapper.appendChild(label);
+        selectWrapper.appendChild(select);
+        container.appendChild(selectWrapper);
+
+        const actions = document.createElement('div');
+        actions.classList.add('layout-preset-actions');
+
+        const saveButton = document.createElement('button');
+        saveButton.type = 'button';
+        saveButton.classList.add('layout-preset-save');
+        saveButton.textContent = 'Save Layout';
+        saveButton.addEventListener('click', () => this.promptSaveLayoutPreset());
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.classList.add('layout-preset-delete');
+        deleteButton.textContent = 'Delete Preset';
+        deleteButton.disabled = true;
+        deleteButton.addEventListener('click', () => this.deleteActiveLayoutPreset());
+
+        actions.appendChild(saveButton);
+        actions.appendChild(deleteButton);
+        container.appendChild(actions);
+
+        const hint = document.createElement('p');
+        hint.classList.add('layout-preset-hint');
+        hint.textContent = 'Capture stage-specific pad layouts for quick recall.';
+        container.appendChild(hint);
+
+        this.layoutPresetRefs.select = select;
+        this.layoutPresetRefs.deleteButton = deleteButton;
+        this.layoutPresetRefs.hint = hint;
+
+        this.updateLayoutPresetControlsState();
+
+        return container;
+    }
+
+    populateLayoutPresetSelect() {
+        const select = this.layoutPresetRefs.select;
+        if (!select) return;
+
+        this.composeLayoutPresets();
+
+        const previousValue = select.value;
+        select.innerHTML = '';
+
+        const customOption = document.createElement('option');
+        customOption.value = '__custom';
+        customOption.textContent = 'Custom Layout';
+        select.appendChild(customOption);
+
+        if (this.baseLayoutPresets.length > 0) {
+            const factoryGroup = document.createElement('optgroup');
+            factoryGroup.label = 'Stage Layouts';
+            this.baseLayoutPresets.forEach(preset => {
+                factoryGroup.appendChild(this.createLayoutPresetOption(preset));
+            });
+            select.appendChild(factoryGroup);
+        }
+
+        if (this.customLayoutPresets.length > 0) {
+            const customGroup = document.createElement('optgroup');
+            customGroup.label = 'Saved Layouts';
+            this.customLayoutPresets.forEach(preset => {
+                customGroup.appendChild(this.createLayoutPresetOption(preset));
+            });
+            select.appendChild(customGroup);
+        }
+
+        const desiredValue = (this.activeLayoutPresetId && select.querySelector(`option[value="${this.activeLayoutPresetId}"]`))
+            ? this.activeLayoutPresetId
+            : (select.querySelector(`option[value="${previousValue}"]`) ? previousValue : '__custom');
+
+        select.value = desiredValue;
+    }
+
+    createLayoutPresetOption(preset) {
+        const option = document.createElement('option');
+        option.value = preset.id;
+        const summary = this.formatLayoutSummary(preset.layout);
+        option.textContent = summary ? `${preset.name} — ${summary}` : preset.name;
+        return option;
+    }
+
+    updateLayoutPresetSelect() {
+        const select = this.layoutPresetRefs.select;
+        if (!select) return;
+        const target = this.activeLayoutPresetId && select.querySelector(`option[value="${this.activeLayoutPresetId}"]`)
+            ? this.activeLayoutPresetId
+            : '__custom';
+        if (select.value !== target) {
+            select.value = target;
+        }
+    }
+
+    updateLayoutPresetHintAndActions() {
+        const preset = this.layoutPresets?.find(item => item.id === this.activeLayoutPresetId) || null;
+
+        if (this.layoutPresetRefs.deleteButton) {
+            const deletable = Boolean(preset) && !preset.builtIn;
+            this.layoutPresetRefs.deleteButton.disabled = !deletable;
+            this.layoutPresetRefs.deleteButton.title = deletable
+                ? 'Remove this saved layout preset'
+                : 'Only custom layouts can be deleted';
+        }
+
+        if (this.layoutPresetRefs.hint) {
+            const summarySource = preset?.layout || this.getCurrentLayoutDefinition();
+            const summary = this.formatLayoutSummary(summarySource);
+            if (preset) {
+                const description = preset.description && preset.description.length ? preset.description : null;
+                this.layoutPresetRefs.hint.textContent = description
+                    ? `${description}${summary ? ` (${summary})` : ''}`
+                    : summary || 'Preset layout applied.';
+            } else {
+                this.layoutPresetRefs.hint.textContent = summary
+                    ? `Custom layout — ${summary}`
+                    : 'Custom layout — adjust controls to suit the venue.';
+            }
+        }
+    }
+
+    updateLayoutPresetControlsState() {
+        this.populateLayoutPresetSelect();
+        this.updateLayoutPresetSelect();
+        this.updateLayoutPresetHintAndActions();
+    }
+
+    formatLayoutSummary(layout = {}) {
+        if (!layout) return '';
+        const parts = [];
+        const padCount = Number.isFinite(layout.padCount) ? layout.padCount : this.padCount;
+        if (Number.isFinite(padCount)) {
+            parts.push(`${padCount} ${padCount === 1 ? 'pad' : 'pads'}`);
+        }
+        const columns = layout.columns ?? this.layoutSettings.columns ?? 'auto';
+        if (columns === 'auto') {
+            parts.push('Auto columns');
+        } else if (Number.isFinite(columns)) {
+            parts.push(`${columns} ${columns === 1 ? 'column' : 'columns'}`);
+        }
+        if (Number.isFinite(layout.minWidth)) {
+            parts.push(`${Math.round(layout.minWidth)}px`);
+        }
+        if (Number.isFinite(layout.gap)) {
+            parts.push(`${Math.round(layout.gap)}px gap`);
+        }
+        if (Number.isFinite(layout.aspectRatio)) {
+            parts.push(`AR ${layout.aspectRatio.toFixed(2)}`);
+        }
+        return parts.join(' · ');
+    }
+
+    getCurrentLayoutDefinition() {
+        return {
+            padCount: this.padCount,
+            minWidth: this.layoutSettings.minWidth,
+            gap: this.layoutSettings.gap,
+            aspectRatio: this.layoutSettings.aspectRatio,
+            columns: this.layoutSettings.columns ?? 'auto'
+        };
+    }
+
+    generateSuggestedLayoutPresetName() {
+        const padCount = this.padCount;
+        const columns = this.layoutSettings.columns ?? 'auto';
+        const columnLabel = columns === 'auto' ? 'Auto Grid' : `${columns} Col`;
+        return `${padCount} Pads · ${columnLabel}`;
+    }
+
+    promptSaveLayoutPreset() {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        const suggested = this.generateSuggestedLayoutPresetName();
+        const name = window.prompt('Name for this layout preset?', suggested);
+        if (!name) return;
+        this.saveLayoutPreset(name);
+    }
+
+    saveLayoutPreset(name) {
+        const trimmed = typeof name === 'string' ? name.trim() : '';
+        if (!trimmed) return;
+
+        const layout = this.normalizeLayoutDefinition(this.getCurrentLayoutDefinition());
+        const existing = this.customLayoutPresets.find(preset => preset.name.toLowerCase() === trimmed.toLowerCase());
+
+        if (existing) {
+            existing.layout = layout;
+            this.activeLayoutPresetId = existing.id;
+        } else {
+            const id = this.generateLayoutPresetId(trimmed);
+            const preset = {
+                id,
+                name: trimmed,
+                description: '',
+                layout,
+                builtIn: false
+            };
+            this.customLayoutPresets.push(preset);
+            this.activeLayoutPresetId = id;
+        }
+
+        this.persistCustomLayoutPresets();
+        this.composeLayoutPresets();
+        this.updateLayoutPresetControlsState();
+        this.refreshLayoutPresetSelection();
+    }
+
+    deleteActiveLayoutPreset() {
+        if (!this.activeLayoutPresetId) return;
+        const preset = this.customLayoutPresets.find(item => item.id === this.activeLayoutPresetId);
+        if (!preset) return;
+
+        if (typeof window !== 'undefined') {
+            const confirmed = window.confirm(`Delete layout preset "${preset.name}"?`);
+            if (!confirmed) return;
+        }
+
+        this.customLayoutPresets = this.customLayoutPresets.filter(item => item.id !== this.activeLayoutPresetId);
+        this.persistCustomLayoutPresets();
+        this.composeLayoutPresets();
+        this.activeLayoutPresetId = null;
+        this.updateLayoutPresetControlsState();
+        this.refreshLayoutPresetSelection();
+    }
+
+    applyLayoutPreset(presetId) {
+        const preset = this.layoutPresets.find(item => item.id === presetId);
+        if (!preset) return;
+
+        this.withPresetRefreshSuspended(() => {
+            LAYOUT_KEYS.forEach(key => {
+                if (preset.layout[key] !== undefined) {
+                    this.updateLayoutSetting(key, preset.layout[key], { notify: false });
+                }
+            });
+            if (preset.layout.padCount !== undefined) {
+                this.setPadCount(preset.layout.padCount, { notify: false });
+            }
+        });
+
+        this.activeLayoutPresetId = presetId;
+        this.syncLayoutControls();
+        this.updateLayoutPresetControlsState();
+        this.emitLayoutChange();
+    }
+
+    withPresetRefreshSuspended(callback) {
+        const previous = this.suspendPresetDetection;
+        this.suspendPresetDetection = true;
+        try {
+            callback();
+        } finally {
+            this.suspendPresetDetection = previous;
+        }
+        if (!previous) {
+            this.refreshLayoutPresetSelection();
+        }
+    }
+
+    refreshLayoutPresetSelection() {
+        if (this.suspendPresetDetection) return;
+        const match = this.matchLayoutToPreset(this.layoutSettings, this.padCount);
+        this.activeLayoutPresetId = match;
+        this.updateLayoutPresetControlsState();
+    }
+
+    matchLayoutToPreset(layout, padCount) {
+        if (!Array.isArray(this.layoutPresets) || this.layoutPresets.length === 0) {
+            return null;
+        }
+
+        for (const preset of this.layoutPresets) {
+            if (this.layoutsAreEquivalent(preset.layout, layout, padCount)) {
+                return preset.id;
+            }
+        }
+        return null;
+    }
+
+    layoutsAreEquivalent(presetLayout = {}, layout = {}, padCount = this.padCount) {
+        if (presetLayout.padCount !== undefined) {
+            if (this.normalizePadCount(presetLayout.padCount) !== this.normalizePadCount(padCount)) {
+                return false;
+            }
+        }
+
+        for (const key of LAYOUT_KEYS) {
+            if (presetLayout[key] === undefined) continue;
+            if (key === 'columns') {
+                const presetColumns = presetLayout[key] === 'auto'
+                    ? 'auto'
+                    : parseInt(presetLayout[key], 10);
+                let currentColumns;
+                if (layout[key] === undefined) {
+                    currentColumns = this.layoutSettings.columns ?? 'auto';
+                } else if (layout[key] === 'auto') {
+                    currentColumns = 'auto';
+                } else {
+                    currentColumns = parseInt(layout[key], 10);
+                }
+                if (presetColumns !== currentColumns) {
+                    return false;
+                }
+                continue;
+            }
+
+            const tolerance = LAYOUT_TOLERANCES[key] ?? 0;
+            const currentValue = layout[key];
+            if (!this.numbersAreClose(presetLayout[key], currentValue, tolerance)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    numbersAreClose(a, b, tolerance = 0.0001) {
+        if (!Number.isFinite(a) || !Number.isFinite(b)) {
+            return false;
+        }
+        return Math.abs(a - b) <= tolerance;
+    }
+
+    normalizeLayoutDefinition(definition = {}) {
+        if (!definition || typeof definition !== 'object') {
+            return {};
+        }
+
+        const normalized = {};
+
+        if (definition.padCount !== undefined) {
+            normalized.padCount = this.normalizePadCount(definition.padCount);
+        }
+
+        LAYOUT_KEYS.forEach(key => {
+            if (definition[key] === undefined) return;
+            const value = this.normalizeLayoutValue(key, definition[key]);
+            if (value !== undefined) {
+                normalized[key] = value;
+            }
+        });
+
+        return normalized;
+    }
+
+    normalizeLayoutValue(key, value) {
+        if (value === undefined || value === null) return undefined;
+
+        if (key === 'columns') {
+            if (value === 'auto') {
+                return 'auto';
+            }
+            const numeric = parseInt(value, 10);
+            return Number.isFinite(numeric) && numeric > 0 ? numeric : 'auto';
+        }
+
+        const numeric = parseFloat(value);
+        if (!Number.isFinite(numeric)) {
+            return undefined;
+        }
+
+        if (key === 'minWidth') {
+            const minBound = this.config.layout?.minWidth ?? 160;
+            const maxBound = this.config.layout?.maxWidth ?? Math.max(minBound, numeric);
+            return Math.max(minBound, Math.min(maxBound, numeric));
+        }
+
+        if (key === 'gap') {
+            const minGap = 0;
+            const maxGap = this.config.layout?.maxGap ?? 96;
+            return Math.max(minGap, Math.min(maxGap, numeric));
+        }
+
+        if (key === 'aspectRatio') {
+            const minAspect = this.config.layout?.minAspect ?? 0.5;
+            const maxAspect = this.config.layout?.maxAspect ?? 2;
+            return Math.max(minAspect, Math.min(maxAspect, numeric));
+        }
+
+        return numeric;
+    }
+
+    normalizeLayoutPresets(presets, builtIn = false) {
+        if (!Array.isArray(presets)) return [];
+        return presets
+            .map((preset, index) => {
+                if (!preset) return null;
+                const name = typeof preset.name === 'string' && preset.name.trim().length
+                    ? preset.name.trim()
+                    : `Layout ${index + 1}`;
+                const id = typeof preset.id === 'string' && preset.id.trim().length
+                    ? preset.id.trim()
+                    : `${builtIn ? 'builtin' : 'user'}-${index}`;
+                const description = typeof preset.description === 'string'
+                    ? preset.description.trim()
+                    : '';
+                const layout = this.normalizeLayoutDefinition(preset.layout || preset.settings || {});
+                return {
+                    id,
+                    name,
+                    description,
+                    layout,
+                    builtIn
+                };
+            })
+            .filter(Boolean);
+    }
+
+    composeLayoutPresets() {
+        this.layoutPresets = [
+            ...(Array.isArray(this.baseLayoutPresets) ? this.baseLayoutPresets : []),
+            ...(Array.isArray(this.customLayoutPresets) ? this.customLayoutPresets : [])
+        ];
+        return this.layoutPresets;
+    }
+
+    loadCustomLayoutPresets() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return [];
+        }
+        try {
+            const stored = window.localStorage.getItem(this.layoutPresetStorageKey);
+            if (!stored) return [];
+            const parsed = JSON.parse(stored);
+            return this.normalizeLayoutPresets(parsed, false);
+        } catch (error) {
+            console.warn('TouchPadController: unable to load layout presets', error);
+            return [];
+        }
+    }
+
+    persistCustomLayoutPresets() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+        try {
+            const payload = this.customLayoutPresets.map(preset => ({
+                id: preset.id,
+                name: preset.name,
+                description: preset.description,
+                layout: preset.layout
+            }));
+            window.localStorage.setItem(this.layoutPresetStorageKey, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('TouchPadController: unable to persist layout presets', error);
+        }
+    }
+
+    generateLayoutPresetId(name) {
+        const base = typeof name === 'string' && name.trim().length ? name.trim().toLowerCase() : 'layout';
+        const slug = base.replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'layout';
+        const existing = new Set((this.layoutPresets || []).map(preset => preset.id));
+        let candidate = `user-${slug}`;
+        let attempt = 1;
+        while (existing.has(candidate)) {
+            candidate = `user-${slug}-${attempt++}`;
+        }
+        return candidate;
+    }
+
+    renderPads(padSeeds = null) {
+        if (!this.padGrid) return;
+
+        const seeds = this.buildPadSeeds(padSeeds);
+        this.padGrid.innerHTML = '';
+        this.padStates = [];
+
+        for (let index = 0; index < this.padCount; index++) {
+            const seed = seeds[index] || {};
+            const padState = this.createPadState(index, seed.bindings, seed.modes, seed.settings, seed);
+            this.padStates.push(padState);
+            this.padGrid.appendChild(padState.element);
+        }
+
+        this.updatePadSummaries();
+        this.notifyMappingChange();
+    }
+    buildPadSeeds(padSeeds) {
+        if (Array.isArray(padSeeds)) {
+            return padSeeds.map(seed => {
+                if (!seed) {
+                    return { bindings: {}, modes: {}, settings: null, gestureMode: this.defaultGestureMode };
+                }
+
+                const bindings = seed.bindings || seed.axisBindings || this.extractBindingsFromSeed(seed);
+                const modes = seed.modes || seed.axisModes || {};
+                const settings = this.extractAxisSettings(seed);
+                const gestureMode = this.resolveGestureModeFromSeed(seed);
+
+                return {
+                    bindings: bindings || {},
+                    modes: modes || {},
+                    settings,
+                    gestureMode
+                };
+            });
+        }
+
+        return this.padStates.map(state => ({
+            bindings: { ...state.axisBindings },
+            modes: { ...state.axisModes },
+            settings: this.cloneAxisSettings(state.axisSettings),
+            gestureMode: state.gestureMode
+        }));
+    }
+
+    extractBindingsFromSeed(seed) {
+        const bindings = {};
+        AXES.forEach(axis => {
+            if (axis in seed) {
+                bindings[axis] = seed[axis];
+            }
+        });
+        return Object.keys(bindings).length ? bindings : {};
+    }
+
+    extractAxisSettings(seed) {
+        if (!seed) return null;
+        const source = seed.settings || seed.axisSettings || null;
+        const categories = ['curve', 'invert', 'smoothing'];
+        const output = {};
+
+        categories.forEach(category => {
+            const candidate = source?.[category] ?? seed?.[category];
+            if (candidate !== undefined) {
+                if (candidate && typeof candidate === 'object') {
+                    output[category] = { ...candidate };
+                } else {
+                    output[category] = candidate;
+                }
+            }
+        });
+
+        return Object.keys(output).length ? output : null;
+    }
+
+    resolveGestureModeFromSeed(seed = {}) {
+        const candidate = seed?.gestureMode
+            || seed?.gesture?.mode
+            || seed?.settings?.gestureMode
+            || this.gestureConfig.defaultMode
+            || this.defaultGestureMode;
+        return this.normalizeGestureMode(candidate);
+    }
+
+    cloneAxisSettings(settings = {}) {
+        const cloneCategory = (category) => {
+            const source = settings?.[category] || {};
+            const result = {};
+            AXES.forEach(axis => {
+                result[axis] = source[axis];
+            });
+            return result;
+        };
+
+        return {
+            curve: cloneCategory('curve'),
+            invert: cloneCategory('invert'),
+            smoothing: cloneCategory('smoothing')
+        };
+    }
+
+    resolveAxisSetting(category, axis, overrides = {}, defaults = {}, fallback) {
+        const overrideCategory = overrides?.[category];
+        if (overrideCategory !== undefined) {
+            if (typeof overrideCategory === 'object' && overrideCategory !== null && axis in overrideCategory) {
+                return overrideCategory[axis];
+            }
+            if (typeof overrideCategory !== 'object') {
+                return overrideCategory;
+            }
+        }
+
+        const defaultCategory = defaults?.[category];
+        if (defaultCategory !== undefined) {
+            if (typeof defaultCategory === 'object' && defaultCategory !== null && axis in defaultCategory) {
+                return defaultCategory[axis];
+            }
+            if (typeof defaultCategory !== 'object') {
+                return defaultCategory;
+            }
+        }
+
+        return fallback;
+    }
+
+    buildAxisSettings(overrides = {}) {
+        const defaults = this.config.axis?.defaults || {};
+        const smoothingDefault = this.smoothingConfig?.default ?? 0;
+
+        const settings = {
+            curve: {},
+            invert: {},
+            smoothing: {}
+        };
+
+        AXES.forEach(axis => {
+            const curve = this.resolveAxisSetting('curve', axis, overrides, defaults, 'linear');
+            const invert = this.resolveAxisSetting('invert', axis, overrides, defaults, false);
+            const smoothing = this.resolveAxisSetting('smoothing', axis, overrides, defaults, smoothingDefault);
+
+            settings.curve[axis] = (typeof curve === 'string') ? curve : 'linear';
+            settings.invert[axis] = Boolean(invert);
+
+            const numericSmoothing = typeof smoothing === 'number' ? smoothing : smoothingDefault;
+            const min = this.smoothingConfig?.min ?? 0;
+            const max = this.smoothingConfig?.max ?? 1;
+            settings.smoothing[axis] = Math.min(Math.max(numericSmoothing, min), max);
+        });
+
+        return settings;
+    }
+
+    createPadState(index, bindings = {}, modes = {}, settings = {}, extras = {}) {
+        const padWrapper = document.createElement('div');
+        padWrapper.classList.add('touchpad-wrapper');
+
+        const header = document.createElement('div');
+        header.classList.add('touchpad-header');
+        const title = document.createElement('div');
+        title.classList.add('touchpad-title');
+        title.textContent = `Pad ${index + 1}`;
+        const summary = document.createElement('div');
+        summary.classList.add('touchpad-summary');
+        header.appendChild(title);
+        header.appendChild(summary);
+        padWrapper.appendChild(header);
+
+        const mappingContainer = document.createElement('div');
+        mappingContainer.classList.add('touchpad-mapping');
+        padWrapper.appendChild(mappingContainer);
+
+        const padSurface = document.createElement('div');
+        padSurface.classList.add('touchpad-surface');
+        padSurface.setAttribute('tabindex', '0');
+        padSurface.dataset.padIndex = String(index);
+
+        const crosshair = document.createElement('div');
+        crosshair.classList.add('touchpad-crosshair');
+        padSurface.appendChild(crosshair);
+
+        const readout = this.createReadout();
+        padWrapper.appendChild(padSurface);
+        padWrapper.appendChild(readout.container);
+
+        const padMapping = this.getDefaultMapping(index);
+        const axisSettings = this.buildAxisSettings(settings);
+        const gestureMode = this.normalizeGestureMode(
+            extras?.gestureMode
+            || extras?.gesture?.mode
+            || settings?.gestureMode
+            || this.gestureConfig.defaultMode
+        );
+        const axisBindings = {
+            x: bindings?.x || padMapping.x,
+            y: bindings?.y || padMapping.y,
+            gesture: bindings?.gesture || padMapping.gesture || 'none'
+        };
+
+        const axisModes = {
+            x: modes?.x || this.config.axis.defaultModes?.x || 'absolute',
+            y: modes?.y || this.config.axis.defaultModes?.y || 'absolute',
+            gesture: modes?.gesture || this.config.axis.defaultModes?.gesture || 'bipolar'
+        };
+
+        const padState = {
+            id: index,
+            element: padWrapper,
+            surface: padSurface,
+            crosshair,
+            summary,
+            readout,
+            axisBindings,
+            axisModes,
+            axisSettings,
+            axisBaselines: { x: null, y: null, gesture: null },
+            axisSmoothed: { x: null, y: null, gesture: null },
+            activePointers: new Map(),
+            controls: {},
+            centroid: { x: 0.5, y: 0.5 },
+            previousCentroid: null,
+            previousTimestamp: null,
+            gestureMode
+        };
+
+        padState.controls.x = this.createAxisControl('X Axis', 'x', padState);
+        padState.controls.y = this.createAxisControl('Y Axis', 'y', padState);
+        padState.controls.gesture = this.createAxisControl('Gesture', 'gesture', padState, true);
+
+        mappingContainer.appendChild(padState.controls.x.container);
+        mappingContainer.appendChild(padState.controls.y.container);
+        mappingContainer.appendChild(padState.controls.gesture.container);
+
+        this.attachPadEvents(padState);
+        this.updateReadout(padState, 'x', null);
+        this.updateReadout(padState, 'y', null);
+        this.updateReadout(padState, 'gesture', null);
+
+        return padState;
+    }
+
+    getDefaultMapping(index) {
+        if (!Array.isArray(this.config.defaultMappings) || this.config.defaultMappings.length === 0) {
+            return { x: 'rot4dXW', y: 'rot4dYW', gesture: 'none' };
+        }
+        if (index < this.config.defaultMappings.length) {
+            return this.config.defaultMappings[index];
+        }
+        return this.config.defaultMappings[this.config.defaultMappings.length - 1];
+    }
+
+    createAxisControl(label, axisKey, padState, allowNone = false) {
+        const container = document.createElement('div');
+        container.classList.add('axis-control');
+
+        const labelEl = document.createElement('span');
+        labelEl.classList.add('axis-control-label');
+        labelEl.textContent = label;
+        container.appendChild(labelEl);
+
+        const row = document.createElement('div');
+        row.classList.add('axis-control-row');
+        container.appendChild(row);
+
+        const select = document.createElement('select');
+        select.classList.add('axis-select');
+        this.populateParameterSelect(select, padState.axisBindings[axisKey], allowNone);
+        select.addEventListener('change', () => {
+            this.updateAxisBinding(padState, axisKey, select.value);
+        });
+
+        const modeSelect = document.createElement('select');
+        modeSelect.classList.add('axis-mode-select');
+        this.populateModeSelect(modeSelect, padState.axisModes[axisKey]);
+        modeSelect.addEventListener('change', () => {
+            this.updateAxisMode(padState, axisKey, modeSelect.value);
+        });
+
+        row.appendChild(select);
+        row.appendChild(modeSelect);
+
+        const advancedRow = document.createElement('div');
+        advancedRow.classList.add('axis-advanced-row');
+        let gestureSelect = null;
+        if (axisKey === 'gesture' && this.availableGestureModes.length > 0) {
+            const gestureWrapper = document.createElement('label');
+            gestureWrapper.classList.add('axis-advanced-label', 'axis-gesture-mode');
+            const gestureLabel = document.createElement('span');
+            gestureLabel.textContent = 'Interpret';
+            gestureSelect = document.createElement('select');
+            gestureSelect.classList.add('axis-gesture-select');
+            this.populateGestureModeSelect(gestureSelect, padState.gestureMode);
+            gestureSelect.addEventListener('change', () => {
+                this.updateGestureInterpretation(padState, gestureSelect.value);
+            });
+            gestureWrapper.appendChild(gestureLabel);
+            gestureWrapper.appendChild(gestureSelect);
+            advancedRow.appendChild(gestureWrapper);
+        }
+
+        const curveWrapper = document.createElement('label');
+        curveWrapper.classList.add('axis-advanced-label');
+        const curveLabel = document.createElement('span');
+        curveLabel.textContent = 'Curve';
+        const curveSelect = document.createElement('select');
+        curveSelect.classList.add('axis-curve-select');
+        this.populateCurveSelect(curveSelect, padState.axisSettings.curve[axisKey]);
+        curveSelect.addEventListener('change', () => {
+            this.updateAxisCurve(padState, axisKey, curveSelect.value);
+        });
+        curveWrapper.appendChild(curveLabel);
+        curveWrapper.appendChild(curveSelect);
+
+        const invertWrapper = document.createElement('label');
+        invertWrapper.classList.add('axis-invert-toggle');
+        const invertInput = document.createElement('input');
+        invertInput.type = 'checkbox';
+        invertInput.checked = Boolean(padState.axisSettings.invert[axisKey]);
+        invertInput.addEventListener('change', () => {
+            this.updateAxisInvert(padState, axisKey, invertInput.checked);
+        });
+        const invertText = document.createElement('span');
+        invertText.textContent = 'Invert';
+        invertWrapper.appendChild(invertInput);
+        invertWrapper.appendChild(invertText);
+
+        const smoothingWrapper = document.createElement('div');
+        smoothingWrapper.classList.add('axis-smoothing-wrapper');
+        const smoothingLabel = document.createElement('span');
+        smoothingLabel.textContent = 'Smooth';
+        const smoothingInput = document.createElement('input');
+        smoothingInput.type = 'range';
+        smoothingInput.classList.add('axis-smoothing');
+        smoothingInput.min = String(this.smoothingConfig.min);
+        smoothingInput.max = String(this.smoothingConfig.max);
+        smoothingInput.step = String(this.smoothingConfig.step);
+        smoothingInput.value = String(padState.axisSettings.smoothing[axisKey]);
+        const smoothingValue = document.createElement('span');
+        smoothingValue.classList.add('axis-smoothing-value');
+        smoothingValue.textContent = this.formatSmoothingLabel(padState.axisSettings.smoothing[axisKey]);
+        smoothingInput.addEventListener('input', () => {
+            const numeric = parseFloat(smoothingInput.value);
+            this.updateAxisSmoothing(padState, axisKey, numeric);
+            smoothingValue.textContent = this.formatSmoothingLabel(numeric);
+        });
+        smoothingWrapper.appendChild(smoothingLabel);
+        smoothingWrapper.appendChild(smoothingInput);
+        smoothingWrapper.appendChild(smoothingValue);
+
+        advancedRow.appendChild(curveWrapper);
+        advancedRow.appendChild(invertWrapper);
+        advancedRow.appendChild(smoothingWrapper);
+
+        container.appendChild(advancedRow);
+
+        return {
+            container,
+            select,
+            mode: modeSelect,
+            curve: curveSelect,
+            invert: invertInput,
+            smoothing: {
+                input: smoothingInput,
+                display: smoothingValue
+            },
+            gestureMode: gestureSelect
+        };
+    }
+
+    populateParameterSelect(select, selectedValue, allowNone) {
+        select.innerHTML = '';
+
+        if (allowNone) {
+            const noneOption = document.createElement('option');
+            noneOption.value = 'none';
+            noneOption.textContent = '— None —';
+            select.appendChild(noneOption);
+        }
+
+        const groups = this.groupParametersByGroup();
+        groups.forEach(({ group, options }) => {
+            const optgroup = document.createElement('optgroup');
+            optgroup.label = group;
+            options.forEach(option => {
+                const opt = document.createElement('option');
+                opt.value = option.id;
+                opt.textContent = option.label;
+                optgroup.appendChild(opt);
+            });
+            select.appendChild(optgroup);
+        });
+
+        if (selectedValue && select.querySelector(`option[value="${selectedValue}"]`)) {
+            select.value = selectedValue;
+        } else if (allowNone) {
+            select.value = 'none';
+        } else if (this.availableParameters.length > 0) {
+            select.value = this.availableParameters[0].id;
+        }
+    }
+
+    populateModeSelect(select, selectedValue) {
+        select.innerHTML = '';
+        this.config.axis.modes.forEach(mode => {
+            const option = document.createElement('option');
+            option.value = mode.value;
+            option.textContent = mode.label;
+            select.appendChild(option);
+        });
+        if (selectedValue && select.querySelector(`option[value="${selectedValue}"]`)) {
+            select.value = selectedValue;
+        }
+    }
+
+    populateCurveSelect(select, selectedValue) {
+        select.innerHTML = '';
+        this.curveOptions.forEach(curve => {
+            const option = document.createElement('option');
+            option.value = curve.value;
+            option.textContent = curve.label;
+            select.appendChild(option);
+        });
+        if (selectedValue && select.querySelector(`option[value="${selectedValue}"]`)) {
+            select.value = selectedValue;
+        }
+    }
+
+    populateGestureModeSelect(select, selectedValue) {
+        select.innerHTML = '';
+        this.availableGestureModes.forEach(mode => {
+            const option = document.createElement('option');
+            option.value = mode.value;
+            option.textContent = mode.label;
+            select.appendChild(option);
+        });
+        const normalized = this.normalizeGestureMode(selectedValue);
+        if (select.querySelector(`option[value="${normalized}"]`)) {
+            select.value = normalized;
+        }
+    }
+
+    updateAxisCurve(padState, axis, curve) {
+        const normalized = this.curveLabelMap.has(curve) ? curve : 'linear';
+        padState.axisSettings.curve[axis] = normalized;
+        if (padState.activePointers.size > 0) {
+            this.updatePadFromPointers(padState);
+        }
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    updateAxisInvert(padState, axis, invert) {
+        padState.axisSettings.invert[axis] = Boolean(invert);
+        if (padState.activePointers.size > 0) {
+            this.updatePadFromPointers(padState);
+        }
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    updateAxisSmoothing(padState, axis, value) {
+        const min = this.smoothingConfig.min ?? 0;
+        const max = this.smoothingConfig.max ?? 1;
+        const clamped = Math.min(Math.max(value, min), max);
+        padState.axisSettings.smoothing[axis] = clamped;
+        padState.axisSmoothed[axis] = null;
+        if (padState.activePointers.size > 0) {
+            this.updatePadFromPointers(padState);
+        }
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    formatSmoothingLabel(value) {
+        if (value <= 0) return 'Off';
+        const max = this.smoothingConfig.max || 1;
+        const percentage = Math.round((value / max) * 100);
+        return `${percentage}%`;
+    }
+
+    formatGestureModeLabel(mode) {
+        if (!mode) return '';
+        if (this.gestureModeMap.has(mode)) {
+            return this.gestureModeMap.get(mode);
+        }
+        return mode.charAt(0).toUpperCase() + mode.slice(1);
+    }
+
+    createReadout() {
+        const container = document.createElement('div');
+        container.classList.add('touchpad-readout');
+
+        const createLine = (label, axis) => {
+            const line = document.createElement('div');
+            line.classList.add('touchpad-readout-line');
+            if (axis === 'gesture') {
+                line.classList.add('touchpad-gesture');
+            }
+            const labelEl = document.createElement('span');
+            labelEl.textContent = `${label}:`;
+            const valueEl = document.createElement('strong');
+            valueEl.dataset.axisValue = axis;
+            valueEl.textContent = '—';
+            line.appendChild(labelEl);
+            line.appendChild(valueEl);
+            return { line, valueEl };
+        };
+
+        const xLine = createLine('X', 'x');
+        const yLine = createLine('Y', 'y');
+        const gestureLine = createLine('Gesture', 'gesture');
+
+        container.appendChild(xLine.line);
+        container.appendChild(yLine.line);
+        container.appendChild(gestureLine.line);
+
+        return {
+            container,
+            values: {
+                x: xLine.valueEl,
+                y: yLine.valueEl,
+                gesture: gestureLine.valueEl
+            }
+        };
+    }
+
+    attachPadEvents(padState) {
+        const { surface } = padState;
+
+        surface.addEventListener('pointerdown', event => this.handlePointerStart(padState, event));
+        surface.addEventListener('pointermove', event => this.handlePointerMove(padState, event));
+        ['pointerup', 'pointercancel', 'pointerleave', 'lostpointercapture'].forEach(type => {
+            surface.addEventListener(type, event => this.handlePointerEnd(padState, event));
+        });
+    }
+
+    handlePointerStart(padState, event) {
+        event.preventDefault();
+        padState.surface.setPointerCapture?.(event.pointerId);
+        const point = this.eventToPoint(event, padState.surface);
+        padState.activePointers.set(event.pointerId, point);
+
+        if (padState.activePointers.size === 1) {
+            padState.previousCentroid = { ...point };
+            padState.previousTimestamp = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        }
+
+        AXES.forEach(axis => {
+            if (padState.axisModes[axis] === 'relative' && padState.axisBaselines[axis] === null) {
+                const binding = padState.axisBindings[axis];
+                if (binding && binding !== 'none') {
+                    padState.axisBaselines[axis] = this.parameterManager?.getParameter(binding) ?? 0;
+                }
+            }
+        });
+
+        this.updatePadFromPointers(padState);
+    }
+
+    handlePointerMove(padState, event) {
+        if (!padState.activePointers.has(event.pointerId)) return;
+        const point = this.eventToPoint(event, padState.surface);
+        padState.activePointers.set(event.pointerId, point);
+        this.updatePadFromPointers(padState);
+    }
+
+    handlePointerEnd(padState, event) {
+        if (padState.activePointers.has(event.pointerId)) {
+            padState.activePointers.delete(event.pointerId);
+        }
+
+        if (padState.activePointers.size === 0) {
+            AXES.forEach(axis => {
+                if (padState.axisModes[axis] === 'relative') {
+                    padState.axisBaselines[axis] = null;
+                }
+            });
+            padState.previousCentroid = null;
+            padState.previousTimestamp = null;
+        } else {
+            this.updatePadFromPointers(padState);
+        }
+    }
+
+    eventToPoint(event, surface) {
+        const rect = surface.getBoundingClientRect();
+        const x = clamp01((event.clientX - rect.left) / rect.width);
+        const y = clamp01((event.clientY - rect.top) / rect.height);
+        const fallback = Number.isFinite(this.gesturePressureFallback) ? this.gesturePressureFallback : 0.6;
+        const pressureFallback = event.pointerType === 'mouse'
+            ? (event.buttons ? Math.min(1, fallback + 0.2) : fallback)
+            : fallback;
+        const pressure = (typeof event.pressure === 'number' && event.pressure > 0)
+            ? event.pressure
+            : pressureFallback;
+        return { x, y, pressure };
+    }
+
+    updatePadFromPointers(padState) {
+        if (padState.activePointers.size === 0) return;
+
+        const points = Array.from(padState.activePointers.values());
+        const centroid = this.calculateCentroid(points);
+        padState.centroid = centroid;
+
+        padState.crosshair.style.setProperty('--x', `${(centroid.x * 100).toFixed(2)}%`);
+        padState.crosshair.style.setProperty('--y', `${(centroid.y * 100).toFixed(2)}%`);
+
+        const normalizedX = centroid.x;
+        const normalizedY = 1 - centroid.y;
+        const gestureValue = this.calculateGestureValue(padState, points, centroid);
+
+        this.applyAxisValue(padState, 'x', normalizedX);
+        this.applyAxisValue(padState, 'y', normalizedY);
+        this.applyAxisValue(padState, 'gesture', gestureValue);
+    }
+
+    calculateCentroid(points) {
+        const total = points.reduce((acc, point) => {
+            acc.x += point.x;
+            acc.y += point.y;
+            return acc;
+        }, { x: 0, y: 0 });
+
+        return {
+            x: clamp01(total.x / points.length),
+            y: clamp01(total.y / points.length)
+        };
+    }
+
+    calculateGestureValue(padState, points, centroid) {
+        const mode = padState.gestureMode || this.defaultGestureMode;
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+        if (mode === 'pressure') {
+            const fallback = Number.isFinite(this.gesturePressureFallback) ? this.gesturePressureFallback : 0.6;
+            const total = points.reduce((sum, point) => sum + (typeof point.pressure === 'number' ? point.pressure : fallback), 0);
+            const average = total / Math.max(points.length, 1);
+            padState.previousCentroid = { ...centroid };
+            padState.previousTimestamp = now;
+            return clamp01(average);
+        }
+
+        if (mode === 'velocity') {
+            const previous = padState.previousCentroid || centroid;
+            const deltaTime = Math.max(1, now - (padState.previousTimestamp ?? now));
+            const dx = centroid.x - previous.x;
+            const dy = centroid.y - previous.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            const seconds = deltaTime / 1000;
+            const speed = seconds > 0 ? distance / seconds : 0;
+            const scaled = speed * (this.gestureVelocityScale || 1);
+            padState.previousCentroid = { ...centroid };
+            padState.previousTimestamp = now;
+            return clamp01(scaled);
+        }
+
+        if (points.length <= 1) {
+            const fallback = Number.isFinite(this.gesturePressureFallback) ? this.gesturePressureFallback : 0.5;
+            const pressure = points[0]?.pressure ?? fallback;
+            padState.previousCentroid = { ...centroid };
+            padState.previousTimestamp = now;
+            return clamp01(pressure);
+        }
+
+        const distances = points.map(point => {
+            const dx = point.x - centroid.x;
+            const dy = point.y - centroid.y;
+            return Math.sqrt(dx * dx + dy * dy);
+        });
+
+        const average = distances.reduce((sum, distance) => sum + distance, 0) / distances.length;
+        const { minimumSpread = 0.05, maximumSpread = 0.65 } = this.gestureConfig || {};
+        const normalized = (average - minimumSpread) / (maximumSpread - minimumSpread || 1);
+        padState.previousCentroid = { ...centroid };
+        padState.previousTimestamp = now;
+        return clamp01(normalized);
+    }
+
+    applyAxisValue(padState, axis, normalizedValue) {
+        const processedValue = this.processNormalizedValue(padState, axis, normalizedValue);
+        const binding = padState.axisBindings[axis];
+        if (!binding || binding === 'none') {
+            this.updateReadout(padState, axis, processedValue, true);
+            return;
+        }
+
+        const def = this.parameterManager?.getParameterDefinition(binding);
+        if (!def) {
+            this.updateReadout(padState, axis, processedValue, true);
+            return;
+        }
+
+        const mode = padState.axisModes[axis];
+        let value;
+
+        if (mode === 'absolute') {
+            value = def.min + (def.max - def.min) * processedValue;
+        } else if (mode === 'bipolar') {
+            const center = (def.min + def.max) / 2;
+            const amplitude = (def.max - def.min) / 2;
+            value = center + (processedValue - 0.5) * 2 * amplitude;
+        } else if (mode === 'relative') {
+            const baseline = padState.axisBaselines[axis] ?? this.parameterManager.getParameter(binding) ?? ((def.min + def.max) / 2);
+            const range = def.max - def.min;
+            const strength = this.config.axis.relativeStrength ?? 0.4;
+            const offset = (processedValue - 0.5) * range * strength;
+            value = baseline + offset;
+        } else {
+            value = def.min + (def.max - def.min) * processedValue;
+        }
+
+        const clamped = this.parameterManager.clampToDefinition(binding, value);
+        this.parameterManager.setParameter(binding, clamped, 'touchpad');
+        this.updateReadout(padState, axis, clamped);
+    }
+
+    processNormalizedValue(padState, axis, rawValue) {
+        if (!padState?.axisSettings) {
+            return clamp01(rawValue);
+        }
+
+        let value = clamp01(rawValue);
+
+        if (padState.axisSettings.invert[axis]) {
+            value = 1 - value;
+        }
+
+        value = this.applyCurveTransform(value, padState.axisSettings.curve[axis]);
+
+        const smoothing = padState.axisSettings.smoothing[axis];
+        if (typeof smoothing === 'number' && smoothing > 0) {
+            const max = this.smoothingConfig.max || 1;
+            const normalizedSmoothing = Math.min(Math.max(smoothing / max, 0), 0.95);
+            const previous = padState.axisSmoothed[axis];
+            if (previous === null || previous === undefined) {
+                padState.axisSmoothed[axis] = value;
+            } else {
+                value = previous + (value - previous) * (1 - normalizedSmoothing);
+                padState.axisSmoothed[axis] = value;
+            }
+        } else {
+            padState.axisSmoothed[axis] = value;
+        }
+
+        return clamp01(value);
+    }
+
+    applyCurveTransform(value, curveType) {
+        const fn = CURVE_FUNCTIONS[curveType] || CURVE_FUNCTIONS.linear;
+        const result = fn(clamp01(value));
+        return clamp01(result);
+    }
+
+    updateReadout(padState, axis, value, normalizedOnly = false) {
+        const target = padState.readout.values[axis];
+        if (!target) return;
+
+        if (value === null || value === undefined) {
+            target.textContent = '—';
+            return;
+        }
+
+        if (normalizedOnly) {
+            target.textContent = value.toFixed(2);
+            return;
+        }
+
+        const def = this.parameterManager?.getParameterDefinition(padState.axisBindings[axis]);
+        if (def?.type === 'int') {
+            target.textContent = Math.round(value).toString();
+        } else {
+            target.textContent = value.toFixed(2);
+        }
+    }
+    updateAxisBinding(padState, axis, value) {
+        padState.axisBindings[axis] = value;
+        if (value !== 'none') {
+            padState.axisBaselines[axis] = null;
+        }
+        padState.axisSmoothed[axis] = null;
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    updateAxisMode(padState, axis, mode) {
+        padState.axisModes[axis] = mode;
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    updateGestureInterpretation(padState, mode) {
+        const normalized = this.normalizeGestureMode(mode);
+        padState.gestureMode = normalized;
+        padState.previousCentroid = null;
+        padState.previousTimestamp = null;
+        if (padState.controls?.gesture?.gestureMode) {
+            const select = padState.controls.gesture.gestureMode;
+            if (select && select.value !== normalized && select.querySelector(`option[value="${normalized}"]`)) {
+                select.value = normalized;
+            }
+        }
+        if (padState.activePointers.size > 0) {
+            this.updatePadFromPointers(padState);
+        }
+        this.updatePadSummary(padState);
+        this.notifyMappingChange();
+    }
+
+    updatePadSummaries() {
+        this.padStates.forEach(padState => this.updatePadSummary(padState));
+    }
+
+    updatePadSummary(padState) {
+        if (!padState?.summary) return;
+        const fragments = AXES.map(axis => {
+            const label = axis === 'x' ? 'X' : axis === 'y' ? 'Y' : 'Gesture';
+            const binding = padState.axisBindings[axis];
+            const bindingLabel = this.getParameterLabel(binding);
+            const modeLabel = padState.axisModes[axis];
+            const modeText = this.modeLabelMap.get(modeLabel) || modeLabel;
+            const details = [];
+
+            if (axis === 'gesture') {
+                const interpretation = this.formatGestureModeLabel(padState.gestureMode);
+                if (interpretation) {
+                    details.push(interpretation);
+                }
+            }
+
+            if (binding && binding !== 'none') {
+                details.push(modeText);
+            }
+
+            const curve = padState.axisSettings.curve[axis];
+            const curveLabel = this.curveLabelMap.get(curve);
+            if (curve && curveLabel && curve !== 'linear') {
+                details.push(curveLabel);
+            }
+
+            if (padState.axisSettings.invert[axis]) {
+                details.push('Invert');
+            }
+
+            const smoothingValue = padState.axisSettings.smoothing[axis];
+            if (typeof smoothingValue === 'number' && smoothingValue > (this.smoothingConfig.min ?? 0)) {
+                details.push(`Smooth ${this.formatSmoothingLabel(smoothingValue)}`);
+            }
+
+            const detailText = details.length ? ` (${details.join(' · ')})` : '';
+            return `${label}: ${bindingLabel}${detailText}`;
+        });
+        padState.summary.textContent = fragments.join(' · ');
+    }
+
+    getParameterLabel(parameter) {
+        if (!parameter || parameter === 'none') {
+            return 'None';
+        }
+        return this.parameterLabels.get(parameter) || this.parameterManager?.formatParameterLabel(parameter) || parameter;
+    }
+
+    normalizePadCount(count) {
+        const min = this.config.pads?.min ?? 1;
+        const max = this.config.pads?.max ?? Math.max(min, 6);
+        const numeric = Number.isFinite(count) ? count : min;
+        return Math.min(Math.max(Math.round(numeric), min), max);
+    }
+
+    setPadCount(count, options = {}) {
+        const { notify = true } = options;
+        const normalized = this.normalizePadCount(count);
+        if (normalized === this.padCount) {
+            this.syncLayoutControls();
+            this.refreshLayoutPresetSelection();
+            return;
+        }
+        this.padCount = normalized;
+        this.renderPads();
+        this.syncLayoutControls();
+        this.refreshLayoutPresetSelection();
+        if (notify) {
+            this.emitLayoutChange();
+        }
+    }
+
+    updateLayoutSetting(key, value, options = {}) {
+        const { notify = true } = options;
+        const normalized = this.normalizeLayoutValue(key, value);
+        if (normalized === undefined) return;
+
+        this.layoutSettings[key] = normalized;
+        this.updateLayoutDisplay(key, normalized);
+        this.applyLayoutToContainer();
+
+        if (!this.suspendPresetDetection) {
+            this.refreshLayoutPresetSelection();
+        }
+
+        if (notify) {
+            this.emitLayoutChange();
+        }
+    }
+
+    updateLayoutDisplay(key, value, formatted = null) {
+        const ref = this.layoutControlRefs[key];
+        if (!ref) return;
+        if (ref.input && key !== 'padCount') {
+            ref.input.value = value;
+        }
+        if (ref.display) {
+            const formatter = ref.format || (val => val);
+            const valueText = formatted ?? formatter(value);
+            const unit = ref.unit || '';
+            ref.display.textContent = `${valueText}${unit}`;
+        }
+        if (key === 'padCount' && this.layoutControlRefs.padCount?.input) {
+            this.layoutControlRefs.padCount.input.value = value;
+        }
+        if (key === 'columns' && this.layoutControlRefs.columns?.input) {
+            const raw = value === 'auto' ? 'auto' : String(value);
+            this.layoutControlRefs.columns.input.value = raw;
+        }
+    }
+
+    applyLayoutToContainer() {
+        if (!this.container) return;
+        const layout = this.layoutSettings;
+        if (layout.minWidth) {
+            this.container.style.setProperty('--touchpad-min-width', `${layout.minWidth}px`);
+        }
+        if (layout.gap !== undefined) {
+            this.container.style.setProperty('--touchpad-gap', `${layout.gap}px`);
+        }
+        if (layout.aspectRatio) {
+            this.container.style.setProperty('--touchpad-aspect-ratio', layout.aspectRatio);
+        }
+        if (layout.crosshairSize) {
+            this.container.style.setProperty('--touchpad-crosshair-size', `${layout.crosshairSize}px`);
+        }
+        if (layout.columns && layout.columns !== 'auto') {
+            this.container.style.setProperty('--touchpad-columns', layout.columns);
+        } else {
+            this.container.style.removeProperty('--touchpad-columns');
+        }
+    }
+
+    syncLayoutControls() {
+        this.updateLayoutDisplay('padCount', this.padCount);
+        ['minWidth', 'gap', 'aspectRatio'].forEach(key => {
+            const value = this.layoutSettings[key];
+            if (value !== undefined) {
+                this.updateLayoutDisplay(key, value);
+            }
+        });
+        const columnsValue = this.layoutSettings.columns ?? 'auto';
+        this.updateLayoutDisplay('columns', columnsValue);
+    }
+
+    notifyMappingChange() {
+        if (this.suspendNotify) return;
+        const snapshot = this.getMappings();
+        if (typeof this.onMappingChange === 'function') {
+            this.onMappingChange(snapshot);
+        }
+        if (this.hub) {
+            this.hub.emit('touchpad-mapping-change', { mappings: JSON.parse(JSON.stringify(snapshot)) });
+        }
+    }
+
+    emitLayoutChange() {
+        if (typeof this.onLayoutChange === 'function') {
+            this.onLayoutChange({ ...this.layoutSettings, padCount: this.padCount });
+        }
+        if (this.hub) {
+            this.hub.emit('touchpad-layout-change', {
+                layout: { ...this.layoutSettings, padCount: this.padCount }
+            });
+        }
+    }
+
+    getMappings() {
+        return {
+            padCount: this.padCount,
+            layout: { ...this.layoutSettings },
+            pads: this.padStates.map(padState => ({
+                id: padState.id,
+                bindings: { ...padState.axisBindings },
+                modes: { ...padState.axisModes },
+                settings: this.cloneAxisSettings(padState.axisSettings),
+                gestureMode: padState.gestureMode
+            }))
+        };
+    }
+
+    exportState() {
+        return this.cloneMappings();
+    }
+
+    importState(state) {
+        if (!state) return;
+        this.applyMappings(state);
+    }
+
+    applyMappings(mappings = []) {
+        const normalized = this.normalizeMappingsInput(mappings);
+        this.suspendNotify = true;
+
+        if (normalized.layout) {
+            const layoutDefinition = this.normalizeLayoutDefinition(normalized.layout);
+            this.layoutSettings = {
+                ...this.layoutSettings,
+                ...layoutDefinition
+            };
+            this.applyLayoutToContainer();
+        }
+
+        if (normalized.padCount !== undefined) {
+            this.padCount = this.normalizePadCount(normalized.padCount);
+        }
+
+        this.renderPads(normalized.padSeeds);
+        this.suspendNotify = false;
+        this.syncLayoutControls();
+        this.refreshLayoutPresetSelection();
+        this.emitLayoutChange();
+        this.notifyMappingChange();
+    }
+
+    normalizeMappingsInput(mappings) {
+        if (!mappings) {
+            return {
+                padCount: this.padCount,
+                padSeeds: this.buildPadSeeds()
+            };
+        }
+
+        if (Array.isArray(mappings)) {
+            return {
+                padCount: mappings.length,
+                padSeeds: mappings
+            };
+        }
+
+        const padSeeds = Array.isArray(mappings.pads)
+            ? mappings.pads
+            : Array.isArray(mappings.padStates)
+                ? mappings.padStates
+                : [];
+
+        return {
+            layout: mappings.layout || null,
+            padCount: mappings.padCount ?? padSeeds.length ?? this.padCount,
+            padSeeds
+        };
+    }
+
+    destroy() {
+        this.padStates.forEach(padState => {
+            padState.activePointers.clear();
+        });
+        this.padStates = [];
+        if (this.container) {
+            this.container.style.removeProperty('--touchpad-min-width');
+            this.container.style.removeProperty('--touchpad-gap');
+            this.container.style.removeProperty('--touchpad-aspect-ratio');
+            this.container.style.removeProperty('--touchpad-crosshair-size');
+            this.container.style.removeProperty('--touchpad-columns');
+        }
+    }
+
+    cloneMappings() {
+        return JSON.parse(JSON.stringify(this.getMappings()));
+    }
+}

--- a/styles/performance.css
+++ b/styles/performance.css
@@ -1,0 +1,722 @@
+.performance-suite {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(10, 20, 40, 0.85), rgba(5, 10, 30, 0.85));
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+}
+
+.performance-touchpads {
+    --touchpad-min-width: 220px;
+    --touchpad-gap: 1rem;
+    --touchpad-aspect-ratio: 1;
+    --touchpad-crosshair-size: 16px;
+}
+
+.performance-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.performance-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(12, 20, 40, 0.65);
+    border: 1px solid rgba(0, 255, 255, 0.1);
+}
+
+.performance-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.performance-section-header h3 {
+    font-size: 1.1rem;
+    letter-spacing: 0.05em;
+    color: #7ef9ff;
+}
+
+.performance-subtitle {
+    font-size: 0.75rem;
+    opacity: 0.75;
+    margin-top: 0.25rem;
+}
+
+.toggle-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(0, 255, 255, 0.1);
+    border: 1px solid rgba(0, 255, 255, 0.3);
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.toggle-pill input {
+    accent-color: #00e6ff;
+}
+
+.touchpad-grid {
+    display: grid;
+    gap: var(--touchpad-gap, 1rem);
+    grid-template-columns: repeat(var(--touchpad-columns, auto-fit), minmax(var(--touchpad-min-width, 220px), 1fr));
+}
+
+.touchpad-wrapper {
+    background: rgba(6, 15, 30, 0.8);
+    border-radius: 16px;
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.touchpad-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.touchpad-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: #9effff;
+}
+
+.touchpad-mapping {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+}
+
+.axis-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.7rem;
+}
+
+.axis-control label {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.axis-select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 25, 0.6);
+    color: #e8f8ff;
+}
+
+.axis-control-row .axis-select {
+    flex: 2;
+}
+
+.axis-control-row {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.axis-mode-select {
+    flex: 1;
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 40, 60, 0.45);
+    color: #bdfcff;
+}
+
+.axis-advanced-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) auto minmax(0, 1.5fr);
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.axis-advanced-label.axis-gesture-mode {
+    min-width: 140px;
+}
+
+.axis-gesture-select {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 16, 28, 0.7);
+    color: #cdefff;
+    padding: 0.3rem 0.4rem;
+    font-size: 0.7rem;
+}
+
+.axis-advanced-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(189, 252, 255, 0.8);
+}
+
+.axis-curve-select {
+    padding: 0.3rem 0.45rem;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 28, 48, 0.6);
+    color: #dffbff;
+}
+
+.axis-invert-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(189, 252, 255, 0.85);
+}
+
+.axis-invert-toggle input {
+    accent-color: #00e1ff;
+    width: 0.9rem;
+    height: 0.9rem;
+}
+
+.axis-smoothing-wrapper {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.25rem;
+    align-items: center;
+    font-size: 0.65rem;
+    color: rgba(189, 252, 255, 0.85);
+}
+
+.axis-smoothing {
+    width: 100%;
+    accent-color: #00e1ff;
+}
+
+.axis-smoothing-value {
+    font-variant-numeric: tabular-nums;
+    min-width: 2.8ch;
+    text-align: right;
+}
+
+.touchpad-surface {
+    position: relative;
+    width: 100%;
+    aspect-ratio: var(--touchpad-aspect-ratio, 1);
+    border-radius: 14px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: radial-gradient(circle at center, rgba(0, 255, 255, 0.1), rgba(0, 20, 40, 0.8));
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.touchpad-crosshair {
+    position: absolute;
+    top: var(--y, 50%);
+    left: var(--x, 50%);
+    width: var(--touchpad-crosshair-size, 16px);
+    height: var(--touchpad-crosshair-size, 16px);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.6);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
+
+.touchpad-layout-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.layout-preset-controls {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.15);
+    background: rgba(6, 24, 40, 0.45);
+}
+
+.layout-preset-select-wrap {
+    width: 100%;
+}
+
+.layout-preset-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.layout-preset-hint {
+    margin: 0;
+    font-size: 0.65rem;
+    color: rgba(190, 240, 255, 0.75);
+}
+
+.layout-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.layout-control-label {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: #aefaff;
+}
+
+.layout-control-input,
+.layout-control-slider input,
+.layout-control-slider select {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 16, 32, 0.6);
+    color: #e6fdff;
+    padding: 0.35rem 0.5rem;
+}
+
+.layout-control-slider {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.layout-control-slider input[type="range"] {
+    flex: 1;
+    accent-color: #00e6ff;
+}
+
+.layout-control-value {
+    min-width: 3ch;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.touchpad-readout {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.75rem;
+    font-size: 0.7rem;
+    color: rgba(200, 240, 255, 0.9);
+}
+
+.touchpad-readout span {
+    opacity: 0.7;
+    margin-right: 0.25rem;
+}
+
+.preset-summary {
+    margin: 0.25rem 0 0;
+    font-size: 0.7rem;
+    color: #b4f8ff;
+}
+
+.preset-meta-detail {
+    margin: 0;
+    font-size: 0.65rem;
+    color: rgba(190, 235, 255, 0.7);
+}
+
+.audio-global-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.75rem;
+}
+
+.audio-global-controls label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+}
+
+.audio-global-controls input[type="range"] {
+    accent-color: #00e6ff;
+}
+
+.audio-band-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.audio-band {
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(6, 18, 40, 0.65);
+}
+
+.audio-band.disabled {
+    opacity: 0.5;
+}
+
+.band-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.band-preview {
+    font-size: 0.75rem;
+    opacity: 0.8;
+}
+
+.band-control-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.band-control-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.band-control-grid select,
+.band-control-grid input {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.6);
+    color: #e8f8ff;
+    padding: 0.35rem 0.5rem;
+}
+
+.audio-tempo,
+.audio-routing,
+.audio-advanced {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.16);
+    background: rgba(6, 20, 30, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.tempo-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.tempo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.tempo-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.tempo-grid input,
+.tempo-grid select {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.6);
+    color: #e8f8ff;
+    padding: 0.35rem 0.5rem;
+}
+
+.tempo-tap {
+    align-self: end;
+    justify-self: start;
+    padding: 0.4rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 200, 0.35);
+    background: rgba(0, 40, 40, 0.55);
+    color: #a8ffee;
+    cursor: pointer;
+    font-size: 0.72rem;
+}
+
+.tempo-nudge {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.tempo-nudge-value {
+    font-size: 0.65rem;
+    opacity: 0.7;
+}
+
+.routing-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.74rem;
+}
+
+.routing-grid .toggle-pill,
+.tempo-grid .toggle-pill {
+    justify-content: space-between;
+    padding: 0.35rem 0.5rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.15);
+    background: rgba(0, 18, 28, 0.65);
+}
+
+.advanced-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.advanced-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.advanced-grid input[type="range"] {
+    width: 100%;
+}
+
+.advanced-headroom-value {
+    font-size: 0.65rem;
+    opacity: 0.7;
+}
+
+.audio-flourish {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 120, 255, 0.2);
+    background: rgba(40, 12, 40, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.flourish-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.flourish-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.flourish-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.performance-presets .preset-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.preset-create {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.preset-create input {
+    padding: 0.5rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 15, 25, 0.6);
+    color: #e8f8ff;
+}
+
+.preset-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.preset-actions button,
+.preset-buttons button,
+.sequence-actions button,
+.sequence-form button,
+.layout-preset-actions button {
+    padding: 0.45rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.3);
+    background: rgba(0, 40, 60, 0.6);
+    color: #9effff;
+    cursor: pointer;
+    font-size: 0.75rem;
+}
+
+.layout-preset-delete {
+    border-color: rgba(255, 140, 140, 0.45);
+    color: #ffc4c4;
+}
+
+.layout-preset-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.preset-buttons {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.preset-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.15);
+    background: rgba(8, 18, 35, 0.6);
+    margin-bottom: 0.5rem;
+}
+
+.preset-meta h4 {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+}
+
+.preset-meta span {
+    font-size: 0.7rem;
+    opacity: 0.6;
+}
+
+.preset-empty {
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
+
+.sequence-builder {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    background: rgba(6, 18, 30, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sequence-actions button.secondary {
+    border-color: rgba(255, 200, 120, 0.35);
+    background: rgba(60, 40, 10, 0.55);
+    color: #ffe9c4;
+}
+
+.sequence-settings {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.72rem;
+}
+
+.sequence-settings label {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.sequence-settings select {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.55);
+    color: #e8f8ff;
+    padding: 0.35rem 0.5rem;
+}
+
+.sequence-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.sequence-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.5rem;
+}
+
+.sequence-form select,
+.sequence-form input {
+    border-radius: 8px;
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    background: rgba(0, 10, 20, 0.55);
+    color: #e8f8ff;
+    padding: 0.4rem 0.5rem;
+}
+
+.sequence-flourish {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.sequence-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sequence-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(4, 12, 24, 0.7);
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    font-size: 0.75rem;
+}
+
+.sequence-list button {
+    border: 1px solid rgba(255, 120, 120, 0.35);
+    background: rgba(60, 10, 10, 0.55);
+    color: #ffdede;
+}
+
+@media (max-width: 960px) {
+    .performance-suite {
+        margin-top: 1rem;
+        padding: 1rem;
+    }
+
+    .performance-columns {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- add default stage, duo, and dense layout presets to the performance configuration
- extend the touchpad controller with layout preset selection, saving, deletion, and normalization that syncs with hub layout updates
- style the layout preset controls and buttons to match the performance suite aesthetics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc05caa6508329ab27b723e3f7b18c