### PR TITLE
Enhance touchpad controller with pad actions and parameter recents

### DIFF
--- a/index-clean.html
+++ b/index-clean.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/reactivity.css">
     <link rel="stylesheet" href="styles/mobile.css">
     <link rel="stylesheet" href="styles/animations.css">
+    <link rel="stylesheet" href="styles/performance.css">
 </head>
 <body class="loading">
     <!-- Top Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VIB34D Engine - Canvas Explosion FIXED</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/performance.css">
     <style>
         * {
             margin: 0;

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -11,6 +11,7 @@ import { GallerySystem } from '../gallery/GallerySystem.js';
 import { ExportManager } from '../export/ExportManager.js';
 // InteractionHandler removed - each system handles its own interactions
 import { StatusManager } from '../ui/StatusManager.js';
+import { PerformanceSuite } from '../ui/PerformanceSuite.js';
 
 export class VIB34DIntegratedEngine {
     constructor() {
@@ -22,6 +23,12 @@ export class VIB34DIntegratedEngine {
         this.exportManager = new ExportManager(this);
         // Each system handles its own interactions - no central handler needed
         this.statusManager = new StatusManager();
+
+        // Live performance controls
+        this.performanceSuite = null;
+        this.liveAudioSettings = null;
+        this.audioSmoothingState = {};
+        this.lastFlourishTrigger = 0;
         
         // Active state for reactivity
         this.isActive = false;
@@ -59,6 +66,7 @@ export class VIB34DIntegratedEngine {
             this.setupInteractions();
             this.loadCustomVariations();
             this.populateVariationGrid();
+            this.initializePerformanceSuite();
             this.startRenderLoop();
             
             this.statusManager.setStatus('VIB34D Engine initialized successfully', 'success');
@@ -142,7 +150,38 @@ export class VIB34DIntegratedEngine {
             });
         });
     }
-    
+
+    initializePerformanceSuite() {
+        if (typeof document === 'undefined') return;
+
+        try {
+            if (this.performanceSuite) {
+                this.performanceSuite.destroy();
+            }
+            this.performanceSuite = new PerformanceSuite({
+                engine: this,
+                parameterManager: this.parameterManager
+            });
+        } catch (error) {
+            console.warn('⚠️ Performance suite initialization failed:', error);
+        }
+    }
+
+    setLiveAudioSettings(settings) {
+        if (!settings) {
+            this.liveAudioSettings = null;
+            return;
+        }
+
+        try {
+            this.liveAudioSettings = JSON.parse(JSON.stringify(settings));
+        } catch (error) {
+            this.liveAudioSettings = settings;
+        }
+
+        this.audioSmoothingState = {};
+    }
+
     /**
      * Set up mouse/touch interactions
      */
@@ -605,88 +644,141 @@ export class VIB34DIntegratedEngine {
     /**
      * Apply audio reactivity grid settings (similar to holographic system)
      */
-    applyAudioReactivityGrid(audioData) {
-        const settings = this.audioReactivitySettings || window.audioReactivitySettings;
-        if (!settings) return;
-        
-        // Get sensitivity multiplier
-        const sensitivityMultiplier = settings.sensitivity[settings.activeSensitivity];
-        
-        // Apply audio changes to different visual modes based on grid selection
-        settings.activeVisualModes.forEach(modeKey => {
-            const [sensitivity, visualMode] = modeKey.split('-');
-            
-            if (visualMode === 'color') {
-                // COLOR MODE: Affect hue, saturation, intensity
-                const audioIntensity = (audioData.energy * sensitivityMultiplier);
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const rhythmIntensity = (audioData.rhythm * sensitivityMultiplier);
-                
-                // Modulate hue based on audio frequency spread
-                if (audioData.mid > 0.2) {
-                    const currentHue = this.parameterManager.getParameter('hue') || 180;
-                    const hueShift = audioData.mid * sensitivityMultiplier * 30;
-                    this.parameterManager.setParameter('hue', (currentHue + hueShift) % 360);
-                }
-                
-                // Boost intensity on energy spikes
-                if (audioIntensity > 0.3) {
-                    this.parameterManager.setParameter('intensity', Math.min(1.0, 0.5 + audioIntensity * 0.8));
-                }
-                
-                // Boost saturation on bass hits
-                if (bassIntensity > 0.4) {
-                    this.parameterManager.setParameter('saturation', Math.min(1.0, 0.7 + bassIntensity * 0.3));
-                }
-                
-            } else if (visualMode === 'geometry') {
-                // GEOMETRY MODE: Affect morphFactor, gridDensity, chaos
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const highIntensity = (audioData.high * sensitivityMultiplier);
-                
-                // Bass affects grid density
-                if (bassIntensity > 0.3) {
-                    const currentDensity = this.parameterManager.getParameter('gridDensity') || 15;
-                    this.parameterManager.setParameter('gridDensity', Math.min(100, currentDensity + bassIntensity * 25));
-                }
-                
-                // Mid frequencies affect morph factor
-                if (audioData.mid > 0.2) {
-                    const morphBoost = audioData.mid * sensitivityMultiplier * 0.5;
-                    this.parameterManager.setParameter('morphFactor', Math.min(2.0, morphBoost));
-                }
-                
-                // High frequencies add chaos
-                if (highIntensity > 0.4) {
-                    this.parameterManager.setParameter('chaos', Math.min(1.0, highIntensity * 0.6));
-                }
-                
-            } else if (visualMode === 'movement') {
-                // MOVEMENT MODE: Affect speed, 4D rotations
-                const energyIntensity = (audioData.energy * sensitivityMultiplier);
-                
-                // Energy affects animation speed
-                if (energyIntensity > 0.2) {
-                    this.parameterManager.setParameter('speed', Math.min(3.0, 0.5 + energyIntensity * 1.5));
-                }
-                
-                // Audio frequencies affect 4D rotations
-                if (audioData.bass > 0.3) {
-                    const currentXW = this.parameterManager.getParameter('rot4dXW') || 0;
-                    this.parameterManager.setParameter('rot4dXW', currentXW + audioData.bass * sensitivityMultiplier * 0.1);
-                }
-                
-                if (audioData.mid > 0.3) {
-                    const currentYW = this.parameterManager.getParameter('rot4dYW') || 0;
-                    this.parameterManager.setParameter('rot4dYW', currentYW + audioData.mid * sensitivityMultiplier * 0.08);
-                }
-                
-                if (audioData.high > 0.3) {
-                    const currentZW = this.parameterManager.getParameter('rot4dZW') || 0;
-                    this.parameterManager.setParameter('rot4dZW', currentZW + audioData.high * sensitivityMultiplier * 0.06);
-                }
+    applyAudioReactivityGrid(audioData = {}) {
+        const settings = this.liveAudioSettings;
+        if (!settings || !settings.enabled || !this.parameterManager) return;
+
+        const sensitivity = this.clamp01(typeof settings.sensitivity === 'number' ? settings.sensitivity : 0.75);
+        const smoothing = this.clamp01(typeof settings.smoothing === 'number' ? settings.smoothing : 0.3);
+
+        const readBand = (bandName, defaultValue = 0) => {
+            const value = typeof audioData?.[bandName] === 'number' ? audioData[bandName] : defaultValue;
+            return this.smoothBandValue(bandName, value, smoothing);
+        };
+
+        const resolveBand = (bandName) => {
+            const raw = settings.bands?.[bandName];
+            if (typeof raw === 'object' && raw !== null) {
+                return {
+                    enabled: raw.enabled !== undefined ? Boolean(raw.enabled) : true,
+                    weight: this.clamp01(typeof raw.weight === 'number' ? raw.weight / 2 : 0.5) * 2
+                };
             }
-        });
+            if (typeof raw === 'number') {
+                return {
+                    enabled: raw > 0,
+                    weight: this.clamp01(raw / 2) * 2
+                };
+            }
+            if (typeof raw === 'boolean') {
+                return {
+                    enabled: raw,
+                    weight: raw ? 1 : 0
+                };
+            }
+            return { enabled: false, weight: 0 };
+        };
+
+        const sampleBand = (bandName, alias = bandName) => {
+            const config = resolveBand(bandName);
+            if (!config.enabled) return { value: 0, config };
+            const rawValue = readBand(alias);
+            const weighted = Math.min(1, Math.max(0, rawValue * Math.max(0, config.weight)));
+            return { value: weighted, config };
+        };
+
+        const { value: bass, config: bassConfig } = sampleBand('bass');
+        const { value: mid, config: midConfig } = sampleBand('mid');
+        const { value: treble, config: trebleConfig } = sampleBand('treble', 'high');
+        const { value: energy, config: energyConfig } = sampleBand('energy');
+
+        if (bassConfig.enabled) {
+            this.setParameterNormalized('gridDensity', 0.25 + bass * sensitivity, 'audio');
+            this.setParameterNormalized('morphFactor', 0.2 + bass * sensitivity, 'audio');
+        }
+
+        if (midConfig.enabled) {
+            const baseHue = this.parameterManager.getParameter('hue') || 0;
+            const hueShift = (mid - 0.5) * 120 * sensitivity;
+            const nextHue = (baseHue + hueShift + 360) % 360;
+            this.parameterManager.setParameter('hue', nextHue, 'audio');
+        }
+
+        if (trebleConfig.enabled) {
+            this.setParameterNormalized('intensity', 0.4 + treble * 0.6 * sensitivity, 'audio');
+            this.setParameterNormalized('saturation', 0.45 + treble * 0.5 * sensitivity, 'audio');
+        }
+
+        if (energyConfig.enabled) {
+            this.setParameterNormalized('speed', 0.35 + energy * 0.65 * sensitivity, 'audio');
+        }
+
+        if (settings.beatSync && energy > 0.4) {
+            const wobble = (energy - 0.4) * 0.15 * sensitivity;
+            const base = this.parameterManager.getParameter('rot4dXW') || 0;
+            this.parameterManager.setParameter('rot4dXW', base + wobble, 'audio');
+        }
+
+        this.triggerFlourish(settings, energy);
+    }
+
+    smoothBandValue(band, value, smoothing) {
+        if (!Number.isFinite(value)) return 0;
+        if (!smoothing) {
+            this.audioSmoothingState[band] = value;
+            return value;
+        }
+
+        const blend = this.clamp01(smoothing);
+        const previous = this.audioSmoothingState[band];
+        const smoothed = previous === undefined ? value : previous * blend + value * (1 - blend);
+        this.audioSmoothingState[band] = smoothed;
+        return smoothed;
+    }
+
+    setParameterNormalized(name, normalized, source = 'audio') {
+        const definition = this.parameterManager.getParameterDefinition(name);
+        if (!definition) return;
+        const value = definition.min + (definition.max - definition.min) * this.clamp01(normalized);
+        this.parameterManager.setParameter(name, value, source);
+    }
+
+    triggerFlourish(settings, energyLevel) {
+        const flourish = settings.flourish;
+        if (!flourish?.enabled) return;
+
+        const threshold = typeof flourish.threshold === 'number' ? flourish.threshold : 0.65;
+        if (energyLevel < threshold) return;
+
+        const now = performance.now();
+        if (now - this.lastFlourishTrigger < 800) return;
+
+        const parameter = flourish.parameter || 'intensity';
+        const definition = this.parameterManager.getParameterDefinition(parameter);
+        if (!definition) return;
+
+        const current = this.parameterManager.getParameter(parameter) ?? definition.min;
+        const span = definition.max - definition.min;
+        const boost = this.clamp01(typeof flourish.amount === 'number' ? flourish.amount : 0.35);
+        const boosted = Math.min(definition.max, current + span * boost);
+
+        this.parameterManager.setParameter(parameter, boosted, 'audio-flourish');
+
+        setTimeout(() => {
+            const relaxed = current + (boosted - current) * 0.35;
+            this.parameterManager.setParameter(parameter, this.clampToRange(relaxed, definition), 'audio-flourish-return');
+        }, 420);
+
+        this.lastFlourishTrigger = now;
+    }
+
+    clampToRange(value, definition) {
+        if (!definition) return value;
+        return Math.max(definition.min, Math.min(definition.max, value));
+    }
+
+    clamp01(value) {
+        return Math.max(0, Math.min(1, value));
     }
     
     /**
@@ -730,7 +822,12 @@ export class VIB34DIntegratedEngine {
         if (window.universalReactivity) {
             window.universalReactivity.disconnectSystem('faceted');
         }
-        
+
+        if (this.performanceSuite) {
+            this.performanceSuite.destroy();
+            this.performanceSuite = null;
+        }
+
         if (this.animationId) {
             cancelAnimationFrame(this.animationId);
         }

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -3,131 +3,250 @@
  * Unified parameter control for both holographic and polytopal systems
  */
 
+const PARAMETER_GROUPS = {
+    show: 'Show Control',
+    rotation: '4D Rotation',
+    structure: 'Structure',
+    dynamics: 'Dynamics',
+    color: 'Color'
+};
+
 export class ParameterManager {
     constructor() {
         // Default parameter set combining both systems
         this.params = {
             // Current variation
             variation: 0,
-            
+
             // 4D Polytopal Mathematics
             rot4dXW: 0.0,      // X-W plane rotation (-2 to 2)
-            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2) 
+            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2)
             rot4dZW: 0.0,      // Z-W plane rotation (-2 to 2)
             dimension: 3.5,    // Dimensional level (3.0 to 4.5)
-            
+
             // Holographic Visualization
-            gridDensity: 15,   // Geometric detail (4 to 30)
+            gridDensity: 15,   // Geometric detail (4 to 100)
             morphFactor: 1.0,  // Shape transformation (0 to 2)
             chaos: 0.2,        // Randomization level (0 to 1)
             speed: 1.0,        // Animation speed (0.1 to 3)
             hue: 200,          // Color rotation (0 to 360)
             intensity: 0.5,    // Visual intensity (0 to 1)
             saturation: 0.8,   // Color saturation (0 to 1)
-            
+
             // Geometry selection
             geometry: 0        // Current geometry type (0-7)
         };
-        
+
         // Parameter definitions for validation and UI
         this.parameterDefs = {
-            variation: { min: 0, max: 99, step: 1, type: 'int' },
-            rot4dXW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dYW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dZW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            dimension: { min: 3.0, max: 4.5, step: 0.01, type: 'float' },
-            gridDensity: { min: 4, max: 100, step: 0.1, type: 'float' },
-            morphFactor: { min: 0, max: 2, step: 0.01, type: 'float' },
-            chaos: { min: 0, max: 1, step: 0.01, type: 'float' },
-            speed: { min: 0.1, max: 3, step: 0.01, type: 'float' },
-            hue: { min: 0, max: 360, step: 1, type: 'int' },
-            intensity: { min: 0, max: 1, step: 0.01, type: 'float' },
-            saturation: { min: 0, max: 1, step: 0.01, type: 'float' },
-            geometry: { min: 0, max: 7, step: 1, type: 'int' }
+            variation: {
+                min: 0,
+                max: 99,
+                step: 1,
+                type: 'int',
+                label: 'Variation Index',
+                group: PARAMETER_GROUPS.show,
+                tags: ['variation', 'preset']
+            },
+            rot4dXW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation X↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            rot4dYW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Y↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            rot4dZW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Z↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            dimension: {
+                min: 3.0,
+                max: 4.5,
+                step: 0.01,
+                type: 'float',
+                label: 'Dimensional Blend',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['geometry', 'morph']
+            },
+            gridDensity: {
+                min: 4,
+                max: 100,
+                step: 0.1,
+                type: 'float',
+                label: 'Grid Density',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['structure', 'resolution', 'audio']
+            },
+            morphFactor: {
+                min: 0,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Morph Factor',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['morph', 'performance']
+            },
+            chaos: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Chaos',
+                group: PARAMETER_GROUPS.dynamics,
+                tags: ['randomness', 'audio']
+            },
+            speed: {
+                min: 0.1,
+                max: 3,
+                step: 0.01,
+                type: 'float',
+                label: 'Animation Speed',
+                group: PARAMETER_GROUPS.dynamics,
+                tags: ['tempo', 'audio', 'performance']
+            },
+            hue: {
+                min: 0,
+                max: 360,
+                step: 1,
+                type: 'int',
+                label: 'Hue Rotation',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color', 'audio']
+            },
+            intensity: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Light Intensity',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color', 'dynamics', 'audio']
+            },
+            saturation: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Saturation',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color']
+            },
+            geometry: {
+                min: 0,
+                max: 7,
+                step: 1,
+                type: 'int',
+                label: 'Geometry Index',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['structure', 'preset']
+            }
         };
-        
+
         // Default parameter backup for reset
         this.defaults = { ...this.params };
+
+        // Registered listeners for live control modules
+        this.listeners = new Set();
     }
-    
+
     /**
      * Get all current parameters
      */
     getAllParameters() {
         return { ...this.params };
     }
-    
-    /**
-     * Set a specific parameter with validation
-     */
-    setParameter(name, value) {
-        if (this.parameterDefs[name]) {
-            const def = this.parameterDefs[name];
-            
-            // Clamp value to valid range
-            value = Math.max(def.min, Math.min(def.max, value));
-            
-            // Apply type conversion
-            if (def.type === 'int') {
-                value = Math.round(value);
-            }
-            
-            this.params[name] = value;
-            return true;
-        }
-        
-        console.warn(`Unknown parameter: ${name}`);
-        return false;
-    }
-    
-    /**
-     * Set multiple parameters at once
-     */
-    setParameters(paramObj) {
-        for (const [name, value] of Object.entries(paramObj)) {
-            this.setParameter(name, value);
-        }
-    }
-    
+
     /**
      * Get a specific parameter value
      */
     getParameter(name) {
         return this.params[name];
     }
-    
+
     /**
-     * Set geometry type with validation
+     * Retrieve the definition for a parameter
      */
-    setGeometry(geometryType) {
-        this.setParameter('geometry', geometryType);
+    getParameterDefinition(name) {
+        return this.parameterDefs[name] || null;
     }
-    
+
+    /**
+     * Set a specific parameter with validation
+     */
+    setParameter(name, value, source = 'manual') {
+        if (!this.parameterDefs[name]) {
+            console.warn(`Unknown parameter: ${name}`);
+            return false;
+        }
+
+        const def = this.parameterDefs[name];
+        const clampedValue = this.clampToDefinition(def, value);
+        const previousValue = this.params[name];
+
+        if (!this.hasMeaningfulChange(previousValue, clampedValue, def)) {
+            return false;
+        }
+
+        this.params[name] = clampedValue;
+        this.emitChange(name, clampedValue, source);
+        return true;
+    }
+
+    /**
+     * Set multiple parameters at once
+     */
+    setParameters(paramObj, options = {}) {
+        if (!paramObj || typeof paramObj !== 'object') return;
+        const { source = 'manual' } = options;
+
+        Object.entries(paramObj).forEach(([name, value]) => {
+            this.setParameter(name, value, source);
+        });
+    }
+
+    /**
+     * Helper used by geometry button controls
+     */
+    setGeometry(geometryType, source = 'manual') {
+        this.setParameter('geometry', geometryType, source);
+    }
+
     /**
      * Update parameters from UI controls
      */
     updateFromControls() {
         const controlIds = [
             'variationSlider', 'rot4dXW', 'rot4dYW', 'rot4dZW', 'dimension',
-            'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue'
+            'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue',
+            'intensity', 'saturation'
         ];
-        
+
         controlIds.forEach(id => {
             const element = document.getElementById(id);
-            if (element) {
-                const value = parseFloat(element.value);
-                
-                // Map slider IDs to parameter names
-                let paramName = id;
-                if (id === 'variationSlider') {
-                    paramName = 'variation';
-                }
-                
-                this.setParameter(paramName, value);
-            }
+            if (!element) return;
+
+            const value = parseFloat(element.value);
+            const paramName = id === 'variationSlider' ? 'variation' : id;
+            this.setParameter(paramName, value, 'ui');
         });
     }
-    
+
     /**
      * Update UI display values from current parameters
      */
@@ -143,7 +262,9 @@ export class ParameterManager {
         this.updateSliderValue('chaos', this.params.chaos);
         this.updateSliderValue('speed', this.params.speed);
         this.updateSliderValue('hue', this.params.hue);
-        
+        this.updateSliderValue('intensity', this.params.intensity);
+        this.updateSliderValue('saturation', this.params.saturation);
+
         // Update display texts
         this.updateDisplayText('rot4dXWDisplay', this.params.rot4dXW.toFixed(2));
         this.updateDisplayText('rot4dYWDisplay', this.params.rot4dYW.toFixed(2));
@@ -153,219 +274,207 @@ export class ParameterManager {
         this.updateDisplayText('morphFactorDisplay', this.params.morphFactor.toFixed(2));
         this.updateDisplayText('chaosDisplay', this.params.chaos.toFixed(2));
         this.updateDisplayText('speedDisplay', this.params.speed.toFixed(2));
-        this.updateDisplayText('hueDisplay', this.params.hue + '°');
-        
+        this.updateDisplayText('hueDisplay', `${this.params.hue}°`);
+
         // Update variation info
         this.updateVariationInfo();
-        
+
         // Update geometry preset buttons
         this.updateGeometryButtons();
     }
-    
+
     updateSliderValue(id, value) {
         const element = document.getElementById(id);
         if (element) {
             element.value = value;
         }
     }
-    
+
     updateDisplayText(id, text) {
         const element = document.getElementById(id);
         if (element) {
             element.textContent = text;
         }
     }
-    
+
     updateVariationInfo() {
         const variationDisplay = document.getElementById('currentVariationDisplay');
-        if (variationDisplay) {
-            const geometryNames = [
-                'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
-                'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
-            ];
-            
-            const geometryType = Math.floor(this.params.variation / 4);
-            const geometryLevel = (this.params.variation % 4) + 1;
-            const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
-            
-            variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
-            
-            if (this.params.variation < 30) {
-                variationDisplay.textContent += ` ${geometryLevel}`;
-            }
+        if (!variationDisplay) return;
+
+        const geometryNames = [
+            'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
+            'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
+        ];
+
+        const geometryType = Math.floor(this.params.variation / 4);
+        const geometryLevel = (this.params.variation % 4) + 1;
+        const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
+
+        variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
+
+        if (this.params.variation < 30) {
+            variationDisplay.textContent += ` ${geometryLevel}`;
         }
     }
-    
+
     updateGeometryButtons() {
         document.querySelectorAll('[data-geometry]').forEach(btn => {
-            btn.classList.toggle('active', parseInt(btn.dataset.geometry) === this.params.geometry);
+            btn.classList.toggle('active', parseInt(btn.dataset.geometry, 10) === this.params.geometry);
         });
     }
-    
+
     /**
      * Randomize all parameters
      */
     randomizeAll() {
-        this.params.rot4dXW = Math.random() * 4 - 2;
-        this.params.rot4dYW = Math.random() * 4 - 2;
-        this.params.rot4dZW = Math.random() * 4 - 2;
-        this.params.dimension = 3.0 + Math.random() * 1.5;
-        this.params.gridDensity = 4 + Math.random() * 26;
-        this.params.morphFactor = Math.random() * 2;
-        this.params.chaos = Math.random();
-        this.params.speed = 0.1 + Math.random() * 2.9;
-        this.params.hue = Math.random() * 360;
-        this.params.geometry = Math.floor(Math.random() * 8);
+        this.setParameter('rot4dXW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('rot4dYW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('rot4dZW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('dimension', 3.0 + Math.random() * 1.5, 'randomize');
+        this.setParameter('gridDensity', 4 + Math.random() * 96, 'randomize');
+        this.setParameter('morphFactor', Math.random() * 2, 'randomize');
+        this.setParameter('chaos', Math.random(), 'randomize');
+        this.setParameter('speed', 0.1 + Math.random() * 2.9, 'randomize');
+        this.setParameter('hue', Math.random() * 360, 'randomize');
+        this.setParameter('geometry', Math.floor(Math.random() * 8), 'randomize');
     }
-    
+
     /**
      * Reset to default parameters
      */
     resetToDefaults() {
-        this.params = { ...this.defaults };
+        this.setParameters(this.defaults, { source: 'reset' });
     }
-    
+
     /**
      * Load parameter configuration
      */
-    loadConfiguration(config) {
-        if (config && typeof config === 'object') {
-            // Validate and apply configuration
-            for (const [key, value] of Object.entries(config)) {
-                if (this.parameterDefs[key]) {
-                    this.setParameter(key, value);
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-    
-    /**
-     * Export current configuration
-     */
-    exportConfiguration() {
-        return {
-            type: 'vib34d-integrated-config',
-            version: '1.0.0',
-            timestamp: new Date().toISOString(),
-            name: `VIB34D Config ${new Date().toLocaleDateString()}`,
-            parameters: { ...this.params }
-        };
-    }
-    
-    /**
-     * Generate variation-specific parameters
-     */
-    generateVariationParameters(variationIndex) {
-        if (variationIndex < 30) {
-            // Default variations with consistent patterns
-            const geometryType = Math.floor(variationIndex / 4);
-            const level = variationIndex % 4;
-            
-            return {
-                geometry: geometryType,
-                gridDensity: 8 + (level * 4),
-                morphFactor: 0.5 + (level * 0.3),
-                chaos: level * 0.15,
-                speed: 0.8 + (level * 0.2),
-                hue: (geometryType * 45 + level * 15) % 360,
-                rot4dXW: (level - 1.5) * 0.5,
-                rot4dYW: (geometryType % 2) * 0.3,
-                rot4dZW: ((geometryType + level) % 3) * 0.2,
-                dimension: 3.2 + (level * 0.2)
-            };
-        } else {
-            // Custom variations - return current parameters
-            return { ...this.params };
-        }
-    }
-    
-    /**
-     * Apply variation to current parameters
-     */
-    applyVariation(variationIndex) {
-        const variationParams = this.generateVariationParameters(variationIndex);
-        this.setParameters(variationParams);
-        this.params.variation = variationIndex;
-    }
-    
-    /**
-     * Get HSV color values for current hue
-     */
-    getColorHSV() {
-        return {
-            h: this.params.hue,
-            s: 0.8, // Fixed saturation
-            v: 0.9  // Fixed value
-        };
-    }
-    
-    /**
-     * Get RGB color values for current hue
-     */
-    getColorRGB() {
-        const hsv = this.getColorHSV();
-        return this.hsvToRgb(hsv.h, hsv.s, hsv.v);
-    }
-    
-    /**
-     * Convert HSV to RGB
-     */
-    hsvToRgb(h, s, v) {
-        h = h / 60;
-        const c = v * s;
-        const x = c * (1 - Math.abs((h % 2) - 1));
-        const m = v - c;
-        
-        let r, g, b;
-        if (h < 1) {
-            [r, g, b] = [c, x, 0];
-        } else if (h < 2) {
-            [r, g, b] = [x, c, 0];
-        } else if (h < 3) {
-            [r, g, b] = [0, c, x];
-        } else if (h < 4) {
-            [r, g, b] = [0, x, c];
-        } else if (h < 5) {
-            [r, g, b] = [x, 0, c];
-        } else {
-            [r, g, b] = [c, 0, x];
-        }
-        
-        return {
-            r: Math.round((r + m) * 255),
-            g: Math.round((g + m) * 255),
-            b: Math.round((b + m) * 255)
-        };
-    }
-    
-    /**
-     * Validate parameter configuration
-     */
-    validateConfiguration(config) {
+    loadConfiguration(config, options = {}) {
         if (!config || typeof config !== 'object') {
-            return { valid: false, error: 'Configuration must be an object' };
+            return false;
         }
-        
-        if (config.type !== 'vib34d-integrated-config') {
-            return { valid: false, error: 'Invalid configuration type' };
-        }
-        
-        if (!config.parameters) {
-            return { valid: false, error: 'Missing parameters object' };
-        }
-        
-        // Validate individual parameters
-        for (const [key, value] of Object.entries(config.parameters)) {
+
+        const { source = 'import' } = options;
+        Object.entries(config).forEach(([key, value]) => {
             if (this.parameterDefs[key]) {
-                const def = this.parameterDefs[key];
-                if (typeof value !== 'number' || value < def.min || value > def.max) {
-                    return { valid: false, error: `Invalid value for parameter ${key}: ${value}` };
-                }
+                this.setParameter(key, value, source);
             }
+        });
+        return true;
+    }
+
+    /**
+     * Register a listener that fires whenever a parameter changes.
+     */
+    addChangeListener(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
         }
-        
-        return { valid: true };
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    emitChange(name, value, source) {
+        const payload = { name, value, source };
+        this.listeners.forEach(listener => {
+            try {
+                listener(payload);
+            } catch (error) {
+                console.warn('Parameter listener error', error);
+            }
+        });
+    }
+
+    /**
+     * List parameter keys for UI builders
+     */
+    listParameters() {
+        return Object.keys(this.parameterDefs);
+    }
+
+    /**
+     * Retrieve metadata for a parameter key
+     */
+    getParameterMetadata(name) {
+        const def = this.parameterDefs[name];
+        if (!def) return null;
+
+        return {
+            id: name,
+            key: name,
+            label: def.label || this.formatParameterLabel(name),
+            group: def.group || 'General',
+            min: def.min,
+            max: def.max,
+            step: def.step,
+            type: def.type,
+            tags: Array.isArray(def.tags) ? [...def.tags] : []
+        };
+    }
+
+    /**
+     * List parameter metadata for UI builders with optional filtering
+     */
+    listParameterMetadata(filter = {}) {
+        const { groups = null, tags = null } = filter;
+        const groupFilter = Array.isArray(groups) && groups.length ? new Set(groups) : null;
+        const tagFilter = Array.isArray(tags) && tags.length ? new Set(tags) : null;
+
+        return Object.keys(this.parameterDefs)
+            .map(name => this.getParameterMetadata(name))
+            .filter(meta => {
+                if (!meta) return false;
+                if (groupFilter && !groupFilter.has(meta.group)) return false;
+                if (tagFilter) {
+                    const hasTag = meta.tags.some(tag => tagFilter.has(tag));
+                    if (!hasTag) return false;
+                }
+                return true;
+            })
+            .sort((a, b) => {
+                if (a.group === b.group) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.group.localeCompare(b.group);
+            });
+    }
+
+    /**
+     * Format a readable parameter label from its key
+     */
+    formatParameterLabel(name) {
+        if (!name) return '';
+        return name
+            .replace(/rot4d/gi, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .replace(/^./, char => char.toUpperCase());
+    }
+
+    /**
+     * Clamp a value according to its parameter definition
+     */
+    clampToDefinition(def, value) {
+        if (!def) return value;
+
+        let clampedValue = Math.max(def.min, Math.min(def.max, value));
+        if (def.type === 'int') {
+            clampedValue = Math.round(clampedValue);
+        }
+        return clampedValue;
+    }
+
+    /**
+     * Determine if a change is meaningful (prevents micro-noise)
+     */
+    hasMeaningfulChange(previousValue, nextValue, def) {
+        if (previousValue === undefined) return true;
+        if (def?.type === 'int') {
+            return previousValue !== nextValue;
+        }
+        const epsilon = def?.step ? def.step / 10 : 1e-4;
+        return Math.abs(previousValue - nextValue) > epsilon;
     }
 }

--- a/src/ui/AudioReactivityPanel.js
+++ b/src/ui/AudioReactivityPanel.js
@@ -1,0 +1,349 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+export class AudioReactivityPanel {
+    constructor({
+        parameterManager = null,
+        container = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.audio,
+        hub = null,
+        onSettingsChange = null,
+        settings = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.audio, ...(config || {}) };
+        this.hub = hub;
+        this.onSettingsChange = typeof onSettingsChange === 'function' ? onSettingsChange : () => {};
+
+        this.container = container || this.ensureContainer();
+        this.settings = this.mergeSettings(this.config.defaults, settings || {});
+        this.bandOrder = ['bass', 'mid', 'treble', 'energy'];
+        this.normalizeBandSettings();
+        this.bandControls = {};
+
+        this.render();
+        this.applySettingsToForm();
+        this.notifyChange();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-audio');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-audio';
+        return section;
+    }
+
+    mergeSettings(defaults, overrides) {
+        const merged = JSON.parse(JSON.stringify(defaults || {}));
+        if (!overrides || typeof overrides !== 'object') {
+            return merged;
+        }
+        Object.keys(overrides).forEach(key => {
+            if (typeof overrides[key] === 'object' && overrides[key] !== null && !(overrides[key] instanceof Array)) {
+                merged[key] = this.mergeSettings(merged[key] || {}, overrides[key]);
+            } else {
+                merged[key] = overrides[key];
+            }
+        });
+        return merged;
+    }
+
+    render() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Audio Reactivity</h3>
+                <p class="performance-block__subtitle">Dial in how the engine listens to the crowd. Toggle frequency bands, beat sync and flourishes.</p>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        const form = document.createElement('form');
+        form.className = 'audio-form';
+        form.addEventListener('submit', (event) => event.preventDefault());
+
+        form.appendChild(this.renderMasterControls());
+        form.appendChild(this.renderBandControls());
+        form.appendChild(this.renderFlourishControls());
+
+        this.container.appendChild(form);
+        this.form = form;
+    }
+
+    renderMasterControls() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-fieldset';
+        fieldset.innerHTML = `
+            <legend>Master</legend>
+            <label class="toggle-pill">
+                <input type="checkbox" name="enabled">
+                <span>Enable audio reactivity</span>
+            </label>
+            <label class="toggle-pill">
+                <input type="checkbox" name="beatSync">
+                <span>Beat sync</span>
+            </label>
+            <label class="slider-control">
+                <span>Sensitivity</span>
+                <input type="range" name="sensitivity" min="0" max="1" step="0.05">
+            </label>
+            <label class="slider-control">
+                <span>Smoothing</span>
+                <input type="range" name="smoothing" min="0" max="0.9" step="0.05">
+            </label>
+        `;
+
+        fieldset.querySelectorAll('input').forEach(input => {
+            input.addEventListener('input', () => this.handleMasterChange());
+            input.addEventListener('change', () => this.handleMasterChange());
+        });
+
+        return fieldset;
+    }
+
+    renderBandControls() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-fieldset';
+        fieldset.innerHTML = '<legend>Bands</legend>';
+
+        this.bandOrder.forEach(band => {
+            const control = this.createBandControl(band);
+            this.bandControls[band] = control;
+            fieldset.appendChild(control.wrapper);
+        });
+
+        const selectWrapper = document.createElement('label');
+        selectWrapper.className = 'audio-select';
+        selectWrapper.innerHTML = `
+            <span>Flourish parameter</span>
+            <select name="flourishParameter"></select>
+        `;
+
+        this.populateParameterOptions(selectWrapper.querySelector('select'));
+        selectWrapper.querySelector('select').addEventListener('change', (event) => {
+            this.settings.flourish.parameter = event.target.value;
+            this.notifyChange();
+        });
+
+        fieldset.appendChild(selectWrapper);
+        return fieldset;
+    }
+
+    renderFlourishControls() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-fieldset';
+        fieldset.innerHTML = `
+            <legend>Flourish</legend>
+            <label class="toggle-pill">
+                <input type="checkbox" name="flourishEnabled">
+                <span>Enable flourish boost</span>
+            </label>
+            <label class="slider-control">
+                <span>Trigger threshold</span>
+                <input type="range" name="flourishThreshold" min="0" max="1" step="0.05">
+            </label>
+            <label class="slider-control">
+                <span>Boost amount</span>
+                <input type="range" name="flourishAmount" min="0" max="1" step="0.05">
+            </label>
+        `;
+
+        fieldset.querySelectorAll('input').forEach(input => {
+            input.addEventListener('input', () => this.handleFlourishChange());
+            input.addEventListener('change', () => this.handleFlourishChange());
+        });
+
+        return fieldset;
+    }
+
+    populateParameterOptions(select) {
+        if (!select) return;
+
+        const options = this.parameterManager?.listParameterMetadata({ tags: ['color', 'dynamics', 'performance'] })
+            || this.parameterManager?.listParameterMetadata()
+            || [];
+
+        select.innerHTML = options.map(meta => `<option value="${meta.id}">${meta.label}</option>`).join('');
+    }
+
+    handleMasterChange() {
+        const formData = new FormData(this.form);
+        this.settings.enabled = formData.get('enabled') === 'on';
+        this.settings.beatSync = formData.get('beatSync') === 'on';
+        this.settings.sensitivity = Number(formData.get('sensitivity'));
+        this.settings.smoothing = Number(formData.get('smoothing'));
+        this.notifyChange();
+    }
+
+    handleBandToggle(band, enabled) {
+        const bandSetting = this.ensureBandSetting(band);
+        bandSetting.enabled = enabled;
+        this.updateBandControlUI(band);
+        this.notifyChange();
+    }
+
+    handleBandWeightChange(band, weight) {
+        const bandSetting = this.ensureBandSetting(band);
+        bandSetting.weight = this.clampBandWeight(weight);
+        this.updateBandControlUI(band);
+        this.notifyChange();
+    }
+
+    handleFlourishChange() {
+        const formData = new FormData(this.form);
+        this.settings.flourish.enabled = formData.get('flourishEnabled') === 'on';
+        this.settings.flourish.threshold = Number(formData.get('flourishThreshold'));
+        this.settings.flourish.amount = Number(formData.get('flourishAmount'));
+        this.notifyChange();
+    }
+
+    applySettingsToForm() {
+        if (!this.form) return;
+        this.form.querySelector('input[name="enabled"]').checked = Boolean(this.settings.enabled);
+        this.form.querySelector('input[name="beatSync"]').checked = Boolean(this.settings.beatSync);
+        this.form.querySelector('input[name="sensitivity"]').value = Number(this.settings.sensitivity ?? 0.75);
+        this.form.querySelector('input[name="smoothing"]').value = Number(this.settings.smoothing ?? 0.35);
+
+        this.bandOrder.forEach(band => this.updateBandControlUI(band));
+
+        this.form.querySelector('input[name="flourishEnabled"]').checked = Boolean(this.settings.flourish?.enabled);
+        this.form.querySelector('input[name="flourishThreshold"]').value = Number(this.settings.flourish?.threshold ?? 0.65);
+        this.form.querySelector('input[name="flourishAmount"]').value = Number(this.settings.flourish?.amount ?? 0.4);
+
+        const flourishSelect = this.form.querySelector('select[name="flourishParameter"]');
+        if (flourishSelect && this.settings.flourish?.parameter) {
+            flourishSelect.value = this.settings.flourish.parameter;
+        }
+    }
+
+    notifyChange() {
+        this.onSettingsChange(this.getSettings());
+        if (this.hub) {
+            this.hub.emit('audio-settings-change', { settings: this.getSettings() });
+        }
+    }
+
+    getSettings() {
+        return this.mergeSettings({}, this.settings);
+    }
+
+    normalizeBandSettings() {
+        if (!this.settings.bands || typeof this.settings.bands !== 'object') {
+            this.settings.bands = {};
+        }
+        this.bandOrder.forEach(band => {
+            this.ensureBandSetting(band);
+        });
+    }
+
+    ensureBandSetting(band) {
+        if (!this.settings.bands) {
+            this.settings.bands = {};
+        }
+        const raw = this.settings.bands[band];
+        if (raw && typeof raw === 'object') {
+            const normalized = {
+                enabled: raw.enabled !== undefined ? Boolean(raw.enabled) : true,
+                weight: this.clampBandWeight(raw.weight !== undefined ? raw.weight : 1)
+            };
+            this.settings.bands[band] = normalized;
+            return normalized;
+        }
+        if (typeof raw === 'number') {
+            const normalized = {
+                enabled: raw > 0,
+                weight: this.clampBandWeight(raw)
+            };
+            this.settings.bands[band] = normalized;
+            return normalized;
+        }
+        const normalized = {
+            enabled: Boolean(raw),
+            weight: Boolean(raw) ? 1 : 0
+        };
+        this.settings.bands[band] = normalized;
+        return normalized;
+    }
+
+    clampBandWeight(value) {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return 0;
+        return Math.max(0, Math.min(2, numeric));
+    }
+
+    createBandControl(band) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'audio-band';
+
+        const toggle = document.createElement('label');
+        toggle.className = 'toggle-pill';
+        toggle.innerHTML = `
+            <input type="checkbox" name="band-${band}-enabled">
+            <span>${band.charAt(0).toUpperCase() + band.slice(1)}</span>
+        `;
+
+        const sliderWrapper = document.createElement('div');
+        sliderWrapper.className = 'audio-band__weight';
+
+        const sliderLabel = document.createElement('span');
+        sliderLabel.textContent = 'Weight';
+
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.name = `band-${band}-weight`;
+        slider.min = '0';
+        slider.max = '2';
+        slider.step = '0.1';
+
+        const valueLabel = document.createElement('span');
+        valueLabel.className = 'audio-band__value';
+
+        sliderWrapper.appendChild(sliderLabel);
+        sliderWrapper.appendChild(slider);
+        sliderWrapper.appendChild(valueLabel);
+
+        toggle.querySelector('input').addEventListener('change', (event) => {
+            this.handleBandToggle(band, event.target.checked);
+        });
+
+        slider.addEventListener('input', () => {
+            this.handleBandWeightChange(band, Number(slider.value));
+        });
+
+        wrapper.appendChild(toggle);
+        wrapper.appendChild(sliderWrapper);
+
+        return {
+            wrapper,
+            toggle: toggle.querySelector('input'),
+            slider,
+            valueLabel
+        };
+    }
+
+    updateBandControlUI(band) {
+        const control = this.bandControls?.[band];
+        if (!control) return;
+        const setting = this.ensureBandSetting(band);
+        control.toggle.checked = Boolean(setting.enabled);
+        control.slider.value = String(setting.weight);
+        control.valueLabel.textContent = `${Number(setting.weight).toFixed(1)}x`;
+        control.slider.disabled = !control.toggle.checked;
+        control.wrapper.classList.toggle('audio-band--disabled', !control.toggle.checked);
+    }
+
+    applySettings(settings) {
+        this.settings = this.mergeSettings(this.config.defaults, settings || {});
+        this.applySettingsToForm();
+        this.notifyChange();
+    }
+}

--- a/src/ui/PerformanceConfig.js
+++ b/src/ui/PerformanceConfig.js
@@ -1,0 +1,266 @@
+const DEFAULT_TOUCHPAD_MAPPINGS = [
+    {
+        id: 'pad-1',
+        label: 'Orbit',
+        templateId: 'orbital-sculpt',
+        xParam: 'rot4dXW',
+        yParam: 'rot4dYW',
+        spreadParam: 'speed',
+        xCurve: 'ease-in-out',
+        yCurve: 'ease-in-out',
+        spreadCurve: 'ease-out',
+        xSmoothing: 0.2,
+        ySmoothing: 0.2,
+        spreadSmoothing: 0.35
+    },
+    {
+        id: 'pad-2',
+        label: 'Color Wash',
+        templateId: 'chromatic-wash',
+        xParam: 'hue',
+        yParam: 'intensity',
+        spreadParam: 'saturation',
+        xCurve: 'ease-out',
+        yCurve: 'ease-in',
+        spreadCurve: 'ease-in-out',
+        xSmoothing: 0.15,
+        ySmoothing: 0.25,
+        spreadSmoothing: 0.3
+    },
+    {
+        id: 'pad-3',
+        label: 'Structure',
+        templateId: 'geometry-chisel',
+        xParam: 'gridDensity',
+        yParam: 'morphFactor',
+        spreadParam: 'chaos',
+        xCurve: 'expo',
+        yCurve: 'ease-in-out',
+        spreadCurve: 'ease-out',
+        xSmoothing: 0.25,
+        ySmoothing: 0.3,
+        spreadSmoothing: 0.4
+    }
+];
+
+function mergeById(defaultList = [], overrideList = []) {
+    const map = new Map();
+    defaultList.forEach(item => {
+        if (!item || !item.id) return;
+        map.set(item.id, JSON.parse(JSON.stringify(item)));
+    });
+    overrideList.forEach(item => {
+        if (!item || !item.id) return;
+        const existing = map.get(item.id) || {};
+        map.set(item.id, { ...existing, ...JSON.parse(JSON.stringify(item)) });
+    });
+    return Array.from(map.values());
+}
+
+export const DEFAULT_PERFORMANCE_CONFIG = {
+    touchPads: {
+        padCount: 3,
+        maxPadCount: 6,
+        defaultMappings: DEFAULT_TOUCHPAD_MAPPINGS,
+        presetStorageKey: 'vib34d_touchpad_presets_v1',
+        parameterTags: ['performance', 'rotation', 'structure', 'color', 'dynamics'],
+        gestureTags: ['performance', 'audio', 'dynamics'],
+        layout: {
+            minWidth: 220,
+            gap: 12,
+            aspectRatio: 1
+        },
+        axisDefaults: {
+            curve: 'ease-in-out',
+            smoothing: 0.2,
+            x: { curve: 'ease-in-out', smoothing: 0.2 },
+            y: { curve: 'ease-in-out', smoothing: 0.2 },
+            spread: { curve: 'ease-out', smoothing: 0.3 }
+        },
+        templates: [
+            {
+                id: 'orbital-sculpt',
+                label: 'Orbital Sculpt',
+                description: 'Orbit structural rotation while spreading to push speed for dramatic lifts.',
+                mapping: {
+                    xParam: 'rot4dXW',
+                    yParam: 'rot4dYW',
+                    spreadParam: 'speed',
+                    invertX: false,
+                    invertY: false,
+                    xCurve: 'ease-in-out',
+                    yCurve: 'ease-in-out',
+                    spreadCurve: 'ease-out',
+                    xSmoothing: 0.2,
+                    ySmoothing: 0.25,
+                    spreadSmoothing: 0.35
+                }
+            },
+            {
+                id: 'chromatic-wash',
+                label: 'Chromatic Wash',
+                description: 'Blend hue, intensity and saturation washes that react smoothly with audio cues.',
+                mapping: {
+                    xParam: 'hue',
+                    yParam: 'intensity',
+                    spreadParam: 'saturation',
+                    invertX: false,
+                    invertY: false,
+                    xCurve: 'ease-out',
+                    yCurve: 'ease-in',
+                    spreadCurve: 'ease-in-out',
+                    xSmoothing: 0.15,
+                    ySmoothing: 0.2,
+                    spreadSmoothing: 0.3
+                }
+            },
+            {
+                id: 'geometry-chisel',
+                label: 'Geometry Chisel',
+                description: 'Carve morphing geometry with a spread gesture that unlocks controlled chaos.',
+                mapping: {
+                    xParam: 'gridDensity',
+                    yParam: 'morphFactor',
+                    spreadParam: 'chaos',
+                    invertX: false,
+                    invertY: false,
+                    xCurve: 'expo',
+                    yCurve: 'ease-in-out',
+                    spreadCurve: 'ease-out',
+                    xSmoothing: 0.25,
+                    ySmoothing: 0.3,
+                    spreadSmoothing: 0.4
+                }
+            }
+        ],
+        layoutPresets: [
+            {
+                id: 'club-trio',
+                label: 'Club Trio',
+                description: 'Tight clustered pads tuned for cramped DJ booths and compact rigs.',
+                settings: {
+                    minWidth: 210,
+                    gap: 10,
+                    aspectRatio: 1
+                }
+            },
+            {
+                id: 'stage-spread',
+                label: 'Stage Spread',
+                description: 'Wide spacing for dual performers sharing pads across a large desk.',
+                settings: {
+                    minWidth: 260,
+                    gap: 18,
+                    aspectRatio: 1.1
+                }
+            },
+            {
+                id: 'immersive-stack',
+                label: 'Immersive Stack',
+                description: 'Stacked portrait pads ideal for vertical touchscreens or tablets.',
+                settings: {
+                    minWidth: 200,
+                    gap: 14,
+                    aspectRatio: 1.35
+                }
+            }
+        ]
+    },
+    audio: {
+        defaults: {
+            enabled: true,
+            sensitivity: 0.75,
+            smoothing: 0.35,
+            beatSync: true,
+            bands: {
+                bass: { enabled: true, weight: 1.1 },
+                mid: { enabled: true, weight: 0.9 },
+                treble: { enabled: false, weight: 0.7 },
+                energy: { enabled: true, weight: 1.0 }
+            },
+            flourish: {
+                enabled: true,
+                threshold: 0.65,
+                amount: 0.4,
+                parameter: 'intensity'
+            }
+        },
+        storageKey: 'vib34d_audio_settings_v1'
+    },
+    presets: {
+        storageKey: 'vib34d_performance_presets_v1'
+    }
+};
+
+export function mergePerformanceConfig(overrides = {}) {
+    const overrideTouchPads = overrides.touchPads || {};
+    const rawPadCount = Number(overrideTouchPads.padCount);
+    const sanitizedPadCount = Number.isFinite(rawPadCount)
+        ? Math.max(1, Math.round(rawPadCount))
+        : DEFAULT_PERFORMANCE_CONFIG.touchPads.padCount;
+    const rawMaxPadCount = Number(overrideTouchPads.maxPadCount);
+    const sanitizedMaxPadCount = Number.isFinite(rawMaxPadCount)
+        ? Math.max(1, Math.round(rawMaxPadCount))
+        : DEFAULT_PERFORMANCE_CONFIG.touchPads.maxPadCount;
+    const effectiveMaxPadCount = Math.max(
+        sanitizedMaxPadCount,
+        sanitizedPadCount,
+        DEFAULT_PERFORMANCE_CONFIG.touchPads.padCount
+    );
+
+    return {
+        touchPads: {
+            ...DEFAULT_PERFORMANCE_CONFIG.touchPads,
+            ...overrideTouchPads,
+            padCount: Math.min(sanitizedPadCount, effectiveMaxPadCount),
+            maxPadCount: effectiveMaxPadCount,
+            layout: {
+                ...DEFAULT_PERFORMANCE_CONFIG.touchPads.layout,
+                ...(overrideTouchPads.layout || {})
+            },
+            axisDefaults: {
+                ...DEFAULT_PERFORMANCE_CONFIG.touchPads.axisDefaults,
+                ...(overrideTouchPads.axisDefaults || {}),
+                x: {
+                    ...DEFAULT_PERFORMANCE_CONFIG.touchPads.axisDefaults.x,
+                    ...(overrideTouchPads.axisDefaults?.x || {})
+                },
+                y: {
+                    ...DEFAULT_PERFORMANCE_CONFIG.touchPads.axisDefaults.y,
+                    ...(overrideTouchPads.axisDefaults?.y || {})
+                },
+                spread: {
+                    ...DEFAULT_PERFORMANCE_CONFIG.touchPads.axisDefaults.spread,
+                    ...(overrideTouchPads.axisDefaults?.spread || {})
+                }
+            },
+            templates: mergeById(
+                DEFAULT_PERFORMANCE_CONFIG.touchPads.templates,
+                overrideTouchPads.templates || []
+            ),
+            layoutPresets: mergeById(
+                DEFAULT_PERFORMANCE_CONFIG.touchPads.layoutPresets,
+                overrideTouchPads.layoutPresets || []
+            )
+        },
+        audio: {
+            ...DEFAULT_PERFORMANCE_CONFIG.audio,
+            defaults: {
+                ...DEFAULT_PERFORMANCE_CONFIG.audio.defaults,
+                ...(overrides.audio?.defaults || {}),
+                bands: {
+                    ...DEFAULT_PERFORMANCE_CONFIG.audio.defaults.bands,
+                    ...(overrides.audio?.defaults?.bands || {})
+                },
+                flourish: {
+                    ...DEFAULT_PERFORMANCE_CONFIG.audio.defaults.flourish,
+                    ...(overrides.audio?.defaults?.flourish || {})
+                }
+            }
+        },
+        presets: {
+            ...DEFAULT_PERFORMANCE_CONFIG.presets,
+            ...(overrides.presets || {})
+        }
+    };
+}

--- a/src/ui/PerformanceHub.js
+++ b/src/ui/PerformanceHub.js
@@ -1,0 +1,40 @@
+export class PerformanceHub {
+    constructor({ engine = null, parameterManager = null } = {}) {
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.listeners = new Map();
+    }
+
+    on(eventName, handler) {
+        if (!eventName || typeof handler !== 'function') {
+            return () => {};
+        }
+
+        if (!this.listeners.has(eventName)) {
+            this.listeners.set(eventName, new Set());
+        }
+
+        const handlers = this.listeners.get(eventName);
+        handlers.add(handler);
+
+        return () => {
+            handlers.delete(handler);
+            if (handlers.size === 0) {
+                this.listeners.delete(eventName);
+            }
+        };
+    }
+
+    emit(eventName, payload) {
+        const handlers = this.listeners.get(eventName);
+        if (!handlers) return;
+
+        handlers.forEach(handler => {
+            try {
+                handler(payload);
+            } catch (error) {
+                console.warn(`PerformanceHub listener for "${eventName}" failed`, error);
+            }
+        });
+    }
+}

--- a/src/ui/PerformancePresetManager.js
+++ b/src/ui/PerformancePresetManager.js
@@ -1,0 +1,260 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+const STORAGE_AVAILABLE = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export class PerformancePresetManager {
+    constructor({
+        parameterManager = null,
+        touchPadController = null,
+        audioPanel = null,
+        container = null,
+        hub = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.presets
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.touchPadController = touchPadController;
+        this.audioPanel = audioPanel;
+        this.hub = hub;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.presets, ...(config || {}) };
+
+        this.container = container || this.ensureContainer();
+        this.presets = this.loadPresetsFromStorage();
+
+        this.render();
+        this.renderPresetList();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-presets');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-presets';
+        return section;
+    }
+
+    render() {
+        if (!this.container) return;
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Presets</h3>
+                <p class="performance-block__subtitle">Capture mappings, parameters and audio settings to rehearse choreography or swap shows instantly.</p>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        const createRow = document.createElement('div');
+        createRow.className = 'preset-create-row';
+        createRow.innerHTML = `
+            <input type="text" class="preset-input" placeholder="Preset name">
+            <button type="button" class="preset-save">Save Preset</button>
+        `;
+        const saveButton = createRow.querySelector('.preset-save');
+        const input = createRow.querySelector('.preset-input');
+        saveButton.addEventListener('click', () => {
+            const name = input.value.trim();
+            if (!name) {
+                input.focus();
+                input.classList.add('is-invalid');
+                return;
+            }
+            input.classList.remove('is-invalid');
+            this.savePreset(name);
+            input.value = '';
+        });
+        input.addEventListener('input', () => input.classList.remove('is-invalid'));
+        this.container.appendChild(createRow);
+
+        const list = document.createElement('ul');
+        list.className = 'preset-list';
+        this.container.appendChild(list);
+        this.listElement = list;
+    }
+
+    renderPresetList() {
+        if (!this.listElement) return;
+        this.listElement.innerHTML = '';
+
+        if (!Array.isArray(this.presets) || this.presets.length === 0) {
+            const emptyState = document.createElement('li');
+            emptyState.className = 'preset-empty';
+            emptyState.textContent = 'No presets saved yet. Create one after dialling in a look.';
+            this.listElement.appendChild(emptyState);
+            return;
+        }
+
+        const escapeHtml = (value) => String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+
+        this.presets.forEach(preset => {
+            const item = document.createElement('li');
+            item.className = 'preset-item';
+            const layoutPresetId = preset.touchPads?.layoutPresetId || preset.layoutPresetId || null;
+            const layoutLabel = this.findLayoutPresetLabel(layoutPresetId);
+            const padLabels = (preset.touchPads?.mappings || preset.mappings || [])
+                .map(mapping => mapping.label || mapping.id)
+                .filter(Boolean)
+                .slice(0, 3);
+            const padCount = typeof preset.touchPads?.padCount === 'number'
+                ? preset.touchPads.padCount
+                : Array.isArray(preset.mappings)
+                    ? preset.mappings.length
+                    : null;
+            const summaryParts = [];
+            if (padLabels.length) {
+                summaryParts.push(padLabels.join(' • '));
+            } else {
+                summaryParts.push('No pad mappings saved');
+            }
+            if (padCount) {
+                summaryParts.push(`${padCount} pad${padCount === 1 ? '' : 's'}`);
+            }
+            if (layoutLabel) {
+                summaryParts.push(layoutLabel);
+            }
+            const padSummary = summaryParts.map(escapeHtml).join(' • ');
+            item.innerHTML = `
+                <div class="preset-item__details">
+                    <strong>${escapeHtml(preset.name)}</strong>
+                    <span>${new Date(preset.createdAt).toLocaleString()}</span>
+                    <small class="preset-item__summary">${padSummary}</small>
+                </div>
+                <div class="preset-item__actions">
+                    <button type="button" data-action="load">Load</button>
+                    <button type="button" data-action="delete">Delete</button>
+                </div>
+            `;
+
+            item.querySelector('[data-action="load"]').addEventListener('click', () => this.applyPreset(preset));
+            item.querySelector('[data-action="delete"]').addEventListener('click', () => this.deletePreset(preset.id));
+            this.listElement.appendChild(item);
+        });
+    }
+
+    collectState() {
+        const parameters = this.parameterManager?.getAllParameters?.() || {};
+        const touchPadState = this.touchPadController?.getState?.();
+        const mappings = touchPadState?.mappings
+            || this.touchPadController?.getMappings?.()
+            || [];
+        const layout = touchPadState?.layout
+            || this.touchPadController?.getLayoutSettings?.()
+            || null;
+        const layoutPresetId = touchPadState?.layoutPresetId
+            || this.touchPadController?.activeLayoutPresetId
+            || null;
+        const audio = this.audioPanel?.getSettings?.() || {};
+        return {
+            parameters,
+            mappings,
+            layout,
+            layoutPresetId,
+            audio,
+            touchPads: touchPadState ? clone(touchPadState) : { mappings, layout }
+        };
+    }
+
+    savePreset(name) {
+        const state = this.collectState();
+        const preset = {
+            id: `preset-${Date.now()}`,
+            name,
+            createdAt: Date.now(),
+            ...state
+        };
+        this.presets.unshift(preset);
+        this.persist();
+        this.renderPresetList();
+        if (this.hub) {
+            this.hub.emit('preset-saved', { preset: clone(preset) });
+        }
+    }
+
+    applyPreset(preset) {
+        if (!preset) return;
+
+        if (this.parameterManager && preset.parameters) {
+            this.parameterManager.setParameters(preset.parameters, { source: 'preset' });
+        }
+        if (this.touchPadController) {
+            if (preset.touchPads && this.touchPadController.applyState) {
+                this.touchPadController.applyState(preset.touchPads);
+            } else {
+                if (preset.mappings) {
+                    this.touchPadController.applyMappings(preset.mappings);
+                }
+                if (preset.layout && this.touchPadController.applyLayout) {
+                    this.touchPadController.applyLayout(preset.layout);
+                }
+            }
+        }
+        if (this.audioPanel && preset.audio) {
+            this.audioPanel.applySettings(preset.audio);
+        }
+
+        if (this.hub) {
+            this.hub.emit('preset-applied', { preset: clone(preset) });
+        }
+    }
+
+    deletePreset(id) {
+        this.presets = this.presets.filter(preset => preset.id !== id);
+        this.persist();
+        this.renderPresetList();
+        if (this.hub) {
+            this.hub.emit('preset-deleted', { id });
+        }
+    }
+
+    findLayoutPresetLabel(layoutPresetId) {
+        if (!layoutPresetId) return '';
+        if (layoutPresetId === 'custom') {
+            return 'Custom layout';
+        }
+        const presets = this.touchPadController?.layoutPresets || [];
+        const match = presets.find(preset => preset.id === layoutPresetId);
+        return match?.label || '';
+    }
+
+    loadPresetsFromStorage() {
+        if (!STORAGE_AVAILABLE) return [];
+        try {
+            const raw = window.localStorage.getItem(this.config.storageKey);
+            if (!raw) return [];
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            console.warn('Failed to load performance presets', error);
+            return [];
+        }
+    }
+
+    persist() {
+        if (!STORAGE_AVAILABLE) return;
+        try {
+            window.localStorage.setItem(this.config.storageKey, JSON.stringify(this.presets));
+        } catch (error) {
+            console.warn('Failed to persist presets', error);
+        }
+    }
+
+    getState() {
+        return {
+            presets: clone(this.presets)
+        };
+    }
+}

--- a/src/ui/PerformanceSuite.js
+++ b/src/ui/PerformanceSuite.js
@@ -1,0 +1,131 @@
+import { TouchPadController } from './TouchPadController.js';
+import { AudioReactivityPanel } from './AudioReactivityPanel.js';
+import { PerformancePresetManager } from './PerformancePresetManager.js';
+import { PerformanceHub } from './PerformanceHub.js';
+import { mergePerformanceConfig } from './PerformanceConfig.js';
+
+export class PerformanceSuite {
+    constructor({ engine = null, parameterManager = null, config = {} } = {}) {
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.config = mergePerformanceConfig(config);
+
+        this.hub = new PerformanceHub({ engine: this.engine, parameterManager: this.parameterManager });
+        this.root = null;
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.touchPadState = { mappings: [], layout: null };
+        this.audioSettings = null;
+
+        this.init();
+    }
+
+    init() {
+        this.mountLayout();
+        this.touchPadController = new TouchPadController({
+            parameterManager: this.parameterManager,
+            container: this.touchpadContainer,
+            config: this.config.touchPads,
+            hub: this.hub,
+            onMappingChange: (state) => {
+                this.touchPadState = state;
+            }
+        });
+
+        this.audioPanel = new AudioReactivityPanel({
+            parameterManager: this.parameterManager,
+            container: this.audioContainer,
+            config: this.config.audio,
+            hub: this.hub,
+            onSettingsChange: (settings) => this.handleAudioSettings(settings)
+        });
+
+        this.presetManager = new PerformancePresetManager({
+            parameterManager: this.parameterManager,
+            touchPadController: this.touchPadController,
+            audioPanel: this.audioPanel,
+            container: this.presetsContainer,
+            hub: this.hub,
+            config: this.config.presets
+        });
+
+        this.touchPadState = this.touchPadController.getState();
+        this.audioSettings = this.audioPanel.getSettings();
+        this.applyAudioSettings();
+    }
+
+    mountLayout() {
+        const host = document.getElementById('controlPanel') || document.body;
+        this.root = document.createElement('section');
+        this.root.className = 'performance-suite';
+
+        const columns = document.createElement('div');
+        columns.className = 'performance-suite__columns';
+
+        this.touchpadContainer = document.createElement('section');
+        this.touchpadContainer.className = 'performance-suite__column';
+        columns.appendChild(this.touchpadContainer);
+
+        this.audioContainer = document.createElement('section');
+        this.audioContainer.className = 'performance-suite__column';
+        columns.appendChild(this.audioContainer);
+
+        this.presetsContainer = document.createElement('section');
+        this.presetsContainer.className = 'performance-suite__column';
+        columns.appendChild(this.presetsContainer);
+
+        this.root.appendChild(columns);
+        host.appendChild(this.root);
+    }
+
+    handleAudioSettings(settings) {
+        this.audioSettings = settings;
+        this.applyAudioSettings();
+    }
+
+    applyAudioSettings() {
+        if (this.engine && typeof this.engine.setLiveAudioSettings === 'function') {
+            this.engine.setLiveAudioSettings(this.audioSettings);
+        }
+    }
+
+    getState() {
+        const touchPads = this.touchPadController?.getState?.() || { mappings: [] };
+        return {
+            touchPads,
+            mappings: touchPads.mappings,
+            audio: this.audioPanel?.getSettings?.() || {},
+            presets: this.presetManager?.getState?.().presets || []
+        };
+    }
+
+    applyState(state = {}) {
+        if (state.touchPads && this.touchPadController?.applyState) {
+            this.touchPadController.applyState(state.touchPads);
+        } else if (state.mappings && this.touchPadController) {
+            this.touchPadController.applyMappings(state.mappings);
+        }
+        if (state.audio && this.audioPanel) {
+            this.audioPanel.applySettings(state.audio);
+        }
+        if (Array.isArray(state.presets) && this.presetManager) {
+            this.presetManager.presets = state.presets;
+            this.presetManager.persist();
+            this.presetManager.renderPresetList();
+        }
+        this.touchPadState = this.touchPadController?.getState?.() || this.touchPadState;
+    }
+
+    destroy() {
+        if (this.touchPadController) {
+            this.touchPadController.destroy();
+            this.touchPadController = null;
+        }
+        this.audioPanel = null;
+        this.presetManager = null;
+        if (this.root && this.root.parentNode) {
+            this.root.parentNode.removeChild(this.root);
+        }
+    }
+}

--- a/src/ui/TouchPadController.js
+++ b/src/ui/TouchPadController.js
@@ -1,0 +1,1985 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+const CURVE_OPTIONS = [
+    { id: 'linear', label: 'Linear' },
+    { id: 'ease-in', label: 'Ease In' },
+    { id: 'ease-out', label: 'Ease Out' },
+    { id: 'ease-in-out', label: 'Ease In/Out' },
+    { id: 'expo', label: 'Exponential' },
+    { id: 'sine', label: 'Sine Wave' }
+];
+
+const CUSTOM_TEMPLATE_ID = 'custom';
+const CUSTOM_LAYOUT_ID = 'custom';
+const CUSTOM_TEMPLATE_LABEL = 'Custom mapping';
+const CUSTOM_TEMPLATE_DESCRIPTION = 'Design your own mapping for improvised gestures.';
+const CUSTOM_LAYOUT_DESCRIPTION = 'Dial in pad spacing to match any rig or touchscreen.';
+const DEFAULT_MAX_PAD_COUNT = 6;
+const RECENT_PARAMETER_LIMIT = 8;
+const STATUS_RESET_DELAY = 1600;
+
+function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+}
+
+function copyMapping(mapping) {
+    return JSON.parse(JSON.stringify(mapping));
+}
+
+function toNumber(value, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export class TouchPadController {
+    constructor({
+        parameterManager = null,
+        container = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.touchPads,
+        hub = null,
+        onMappingChange = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.hub = hub;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.touchPads, ...(config || {}) };
+        this.onMappingChange = typeof onMappingChange === 'function' ? onMappingChange : () => {};
+
+        this.container = container || this.ensureContainer();
+        this.parameterOptions = this.buildParameterOptions();
+        this.parameterLookup = new Map(this.parameterOptions.map(option => [option.id, option]));
+        this.availableParameterTags = this.buildAvailableParameterTags();
+        this.parameterFilter = '';
+        this.activeTagFilters = new Set();
+        this.parameterSelectRefs = new Set();
+        this.parameterFilterRefs = null;
+        const maxPads = Math.max(1, toNumber(this.config.maxPadCount, DEFAULT_MAX_PAD_COUNT));
+        this.padCount = Math.min(Math.max(1, this.config.padCount || 3), maxPads);
+        this.padCountControlRef = null;
+        this.pads = [];
+        this.grid = null;
+        this.layoutSettings = this.buildLayoutSettings();
+        this.layoutControlRefs = {};
+        this.layoutPresetRefs = null;
+        this.templates = this.buildTemplates();
+        this.templateIndex = new Map(this.templates.map(template => [template.id, template]));
+        this.layoutPresets = this.buildLayoutPresets();
+        this.layoutPresetIndex = new Map(this.layoutPresets.map(preset => [preset.id, preset]));
+        this.activeLayoutPresetId = this.detectLayoutPresetId();
+        this.smoothingState = new Map();
+        this.mappingClipboard = null;
+        this.recentParameters = [];
+
+        this.render();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-touchpads');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+
+        const section = document.createElement('section');
+        section.id = 'performance-touchpads';
+        return section;
+    }
+
+    buildParameterOptions() {
+        if (!this.parameterManager || typeof this.parameterManager.listParameterMetadata !== 'function') {
+            return [];
+        }
+
+        const filter = Array.isArray(this.config.parameterTags) && this.config.parameterTags.length
+            ? { tags: this.config.parameterTags }
+            : {};
+
+        const options = this.parameterManager.listParameterMetadata(filter);
+        if (options.length > 0) {
+            return options;
+        }
+
+        // Fall back to every parameter if no filtered options
+        return this.parameterManager.listParameterMetadata();
+    }
+
+    buildAvailableParameterTags() {
+        const tagSet = new Set();
+        this.parameterOptions.forEach(option => {
+            if (!Array.isArray(option.tags)) return;
+            option.tags.forEach(tag => {
+                if (typeof tag === 'string' && tag.trim()) {
+                    tagSet.add(tag.trim());
+                }
+            });
+        });
+        return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+    }
+
+    buildLayoutSettings() {
+        const layout = this.config.layout || {};
+        return {
+            minWidth: toNumber(layout.minWidth, 220),
+            gap: toNumber(layout.gap, 12),
+            aspectRatio: toNumber(layout.aspectRatio, 1)
+        };
+    }
+
+    buildTemplates() {
+        if (!Array.isArray(this.config.templates)) {
+            return [];
+        }
+        return this.config.templates.map(template => {
+            const base = template?.mapping || {};
+            const normalized = this.normaliseMapping({
+                ...base,
+                label: base.label || template.label || ''
+            });
+            return {
+                id: template.id,
+                label: template.label,
+                description: template.description,
+                mapping: normalized
+            };
+        });
+    }
+
+    buildLayoutPresets() {
+        if (!Array.isArray(this.config.layoutPresets)) {
+            return [];
+        }
+        return this.config.layoutPresets.map(preset => ({
+            id: preset.id,
+            label: preset.label,
+            description: preset.description,
+            settings: {
+                minWidth: toNumber(preset.settings?.minWidth, this.layoutSettings.minWidth),
+                gap: toNumber(preset.settings?.gap, this.layoutSettings.gap),
+                aspectRatio: toNumber(preset.settings?.aspectRatio, this.layoutSettings.aspectRatio)
+            }
+        }));
+    }
+
+    detectLayoutPresetId() {
+        const match = this.layoutPresets.find(preset => this.layoutMatchesPreset(preset.settings));
+        return match ? match.id : CUSTOM_LAYOUT_ID;
+    }
+
+    layoutMatchesPreset(settings = {}) {
+        if (!settings) return false;
+        const epsilon = 0.01;
+        return Math.abs((settings.minWidth ?? 0) - this.layoutSettings.minWidth) < 0.51
+            && Math.abs((settings.gap ?? 0) - this.layoutSettings.gap) < 0.51
+            && Math.abs((settings.aspectRatio ?? 0) - this.layoutSettings.aspectRatio) < epsilon;
+    }
+
+    getAxisDefaults(axisKey) {
+        const axisDefaults = this.config.axisDefaults || {};
+        const globalCurve = axisDefaults.curve || 'linear';
+        const globalSmoothing = toNumber(axisDefaults.smoothing, 0.1);
+        const specific = axisDefaults[axisKey] || {};
+        return {
+            curve: specific.curve || globalCurve,
+            smoothing: toNumber(specific.smoothing, globalSmoothing)
+        };
+    }
+
+    normaliseMapping(mapping = {}) {
+        const xDefaults = this.getAxisDefaults('x');
+        const yDefaults = this.getAxisDefaults('y');
+        const spreadDefaults = this.getAxisDefaults('spread');
+        return {
+            id: mapping.id || '',
+            label: mapping.label || '',
+            xParam: mapping.xParam || '',
+            yParam: mapping.yParam || '',
+            spreadParam: mapping.spreadParam || '',
+            invertX: Boolean(mapping.invertX),
+            invertY: Boolean(mapping.invertY),
+            xCurve: mapping.xCurve || xDefaults.curve,
+            yCurve: mapping.yCurve || yDefaults.curve,
+            spreadCurve: mapping.spreadCurve || spreadDefaults.curve,
+            xSmoothing: Math.min(0.95, Math.max(0, toNumber(mapping.xSmoothing, xDefaults.smoothing))),
+            ySmoothing: Math.min(0.95, Math.max(0, toNumber(mapping.ySmoothing, yDefaults.smoothing))),
+            spreadSmoothing: Math.min(0.95, Math.max(0, toNumber(mapping.spreadSmoothing, spreadDefaults.smoothing))),
+            templateId: mapping.templateId || ''
+        };
+    }
+
+    render() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+        this.parameterSelectRefs.clear();
+        this.parameterFilterRefs = null;
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Touch Pads</h3>
+                <p class="performance-block__subtitle">Assign any parameter to expressive XY pads. Use a two-finger spread to drive a third parameter.</p>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        const parameterFilters = this.renderParameterFilter();
+        if (parameterFilters) {
+            this.container.appendChild(parameterFilters);
+        }
+
+        const layoutControls = this.renderLayoutControls();
+        if (layoutControls) {
+            this.container.appendChild(layoutControls);
+        }
+
+        const grid = document.createElement('div');
+        grid.className = 'touchpad-grid';
+        this.container.appendChild(grid);
+        this.grid = grid;
+
+        const mappings = this.config.defaultMappings || [];
+        this.pads = [];
+        for (let index = 0; index < this.padCount; index += 1) {
+            const mapping = copyMapping(mappings[index] || {});
+            const pad = this.createPad(mapping || {});
+            this.pads.push(pad);
+            grid.appendChild(pad.wrapper);
+        }
+
+        this.updateLayoutControlUI();
+        this.updateLayoutVariables();
+        this.updatePadActionStates();
+
+        // Notify initial mapping state
+        this.notifyMappingChange();
+    }
+
+    renderParameterFilter() {
+        if (!this.parameterOptions.length) {
+            return null;
+        }
+
+        const wrapper = document.createElement('section');
+        wrapper.className = 'touchpad-parameter-filter';
+
+        const searchLabel = document.createElement('label');
+        searchLabel.className = 'touchpad-parameter-filter__search';
+        const searchTitle = document.createElement('span');
+        searchTitle.textContent = 'Find parameters';
+        const searchInput = document.createElement('input');
+        searchInput.type = 'search';
+        searchInput.placeholder = 'Search by name or tag';
+        searchInput.value = this.parameterFilter;
+        searchInput.addEventListener('input', () => {
+            this.parameterFilter = searchInput.value.trim();
+            this.refreshParameterSelectOptions();
+            this.updateParameterFilterSummary();
+        });
+        searchLabel.appendChild(searchTitle);
+        searchLabel.appendChild(searchInput);
+        wrapper.appendChild(searchLabel);
+
+        const tagButtons = new Map();
+        if (this.availableParameterTags.length) {
+            const tagsRow = document.createElement('div');
+            tagsRow.className = 'touchpad-parameter-filter__tags';
+            const tagsLabel = document.createElement('span');
+            tagsLabel.className = 'touchpad-parameter-filter__tags-label';
+            tagsLabel.textContent = 'Quick tags';
+            tagsRow.appendChild(tagsLabel);
+
+            const tagList = document.createElement('div');
+            tagList.className = 'touchpad-parameter-filter__tag-list';
+            this.availableParameterTags.forEach(tag => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'touchpad-tag';
+                button.textContent = tag;
+                button.addEventListener('click', () => {
+                    if (this.activeTagFilters.has(tag)) {
+                        this.activeTagFilters.delete(tag);
+                    } else {
+                        this.activeTagFilters.add(tag);
+                    }
+                    this.refreshParameterSelectOptions();
+                    this.updateParameterFilterSummary();
+                });
+                tagList.appendChild(button);
+                tagButtons.set(tag, button);
+            });
+            tagsRow.appendChild(tagList);
+            wrapper.appendChild(tagsRow);
+        }
+
+        const footer = document.createElement('div');
+        footer.className = 'touchpad-parameter-filter__footer';
+        const summary = document.createElement('span');
+        summary.className = 'touchpad-parameter-filter__summary';
+        footer.appendChild(summary);
+
+        const resetButton = document.createElement('button');
+        resetButton.type = 'button';
+        resetButton.className = 'touchpad-tag touchpad-tag--reset';
+        resetButton.textContent = 'Reset filters';
+        resetButton.hidden = true;
+        resetButton.addEventListener('click', () => {
+            this.parameterFilter = '';
+            this.activeTagFilters.clear();
+            searchInput.value = '';
+            this.refreshParameterSelectOptions();
+            this.updateParameterFilterSummary();
+        });
+        footer.appendChild(resetButton);
+        wrapper.appendChild(footer);
+
+        this.parameterFilterRefs = {
+            wrapper,
+            summary,
+            searchInput,
+            tagButtons,
+            resetButton
+        };
+
+        this.updateParameterFilterSummary();
+
+        return wrapper;
+    }
+
+    renderLayoutControls() {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'touchpad-layout';
+
+        const header = document.createElement('div');
+        header.className = 'touchpad-layout__header';
+        header.innerHTML = `
+            <strong>Pad Layout</strong>
+            <span>Tune pad size, spacing and aspect</span>
+        `;
+        wrapper.appendChild(header);
+
+        const controls = document.createElement('div');
+        controls.className = 'touchpad-layout__controls';
+
+        const padCountControl = this.createPadCountControl();
+        controls.appendChild(padCountControl.wrapper);
+        this.padCountControlRef = padCountControl;
+
+        const minWidthControl = this.createLayoutControl({
+            label: 'Pad width',
+            min: 180,
+            max: 380,
+            step: 10,
+            role: 'minWidth',
+            formatter: (value) => `${Math.round(value)}px`
+        });
+        const gapControl = this.createLayoutControl({
+            label: 'Grid gap',
+            min: 8,
+            max: 32,
+            step: 2,
+            role: 'gap',
+            formatter: (value) => `${Math.round(value)}px`
+        });
+        const aspectControl = this.createLayoutControl({
+            label: 'Aspect ratio',
+            min: 0.75,
+            max: 1.4,
+            step: 0.05,
+            role: 'aspectRatio',
+            formatter: (value) => `${Number(value).toFixed(2)} : 1`
+        });
+
+        controls.appendChild(minWidthControl.wrapper);
+        controls.appendChild(gapControl.wrapper);
+        controls.appendChild(aspectControl.wrapper);
+
+        const presetControl = this.createLayoutPresetControl();
+        controls.appendChild(presetControl.wrapper);
+        wrapper.appendChild(controls);
+
+        this.layoutControlRefs = {
+            minWidthInput: minWidthControl.input,
+            minWidthValue: minWidthControl.valueLabel,
+            gapInput: gapControl.input,
+            gapValue: gapControl.valueLabel,
+            aspectRatioInput: aspectControl.input,
+            aspectRatioValue: aspectControl.valueLabel
+        };
+        this.layoutPresetRefs = presetControl;
+
+        this.updatePadCountUI();
+        return wrapper;
+    }
+
+    createLayoutControl({ label, min, max, step, role, formatter }) {
+        const wrapper = document.createElement('label');
+        wrapper.className = 'touchpad-layout__control';
+
+        const title = document.createElement('span');
+        title.className = 'touchpad-layout__label';
+        title.textContent = label;
+        wrapper.appendChild(title);
+
+        const row = document.createElement('div');
+        row.className = 'touchpad-layout__row';
+
+        const input = document.createElement('input');
+        input.type = 'range';
+        input.min = String(min);
+        input.max = String(max);
+        input.step = String(step);
+        input.dataset.role = role;
+
+        const valueLabel = document.createElement('span');
+        valueLabel.className = 'touchpad-layout__value';
+
+        row.appendChild(input);
+        row.appendChild(valueLabel);
+        wrapper.appendChild(row);
+
+        const commitChange = () => {
+            const currentValue = toNumber(input.value, this.layoutSettings[role]);
+            this.layoutSettings = {
+                ...this.layoutSettings,
+                [role]: currentValue
+            };
+            valueLabel.textContent = formatter(currentValue);
+            this.markLayoutAsCustom({ skipNotify: true });
+            this.updateLayoutVariables();
+            this.notifyLayoutChange();
+        };
+
+        input.addEventListener('input', commitChange);
+
+        return { wrapper, input, valueLabel, formatter };
+    }
+
+    createPadCountControl() {
+        const wrapper = document.createElement('label');
+        wrapper.className = 'touchpad-layout__control touchpad-layout__control--pads';
+
+        const title = document.createElement('span');
+        title.className = 'touchpad-layout__label';
+        title.textContent = 'Pad slots';
+        wrapper.appendChild(title);
+
+        const row = document.createElement('div');
+        row.className = 'touchpad-layout__row';
+
+        const input = document.createElement('input');
+        input.type = 'range';
+        input.min = '1';
+        input.max = String(this.getMaxPadCount());
+        input.step = '1';
+        input.value = String(this.padCount);
+
+        const valueLabel = document.createElement('span');
+        valueLabel.className = 'touchpad-layout__value';
+        valueLabel.textContent = this.formatPadCount(this.padCount);
+
+        const commit = () => {
+            const next = Math.round(toNumber(input.value, this.padCount));
+            valueLabel.textContent = this.formatPadCount(next);
+            if (next !== this.padCount) {
+                this.setPadCount(next);
+            } else {
+                this.updatePadCountUI();
+            }
+        };
+
+        input.addEventListener('input', () => {
+            const preview = Math.round(toNumber(input.value, this.padCount));
+            valueLabel.textContent = this.formatPadCount(preview);
+        });
+        input.addEventListener('change', commit);
+
+        row.appendChild(input);
+        row.appendChild(valueLabel);
+        wrapper.appendChild(row);
+
+        return { wrapper, input, valueLabel };
+    }
+
+    createLayoutPresetControl() {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'touchpad-layout__preset';
+
+        const label = document.createElement('label');
+        label.className = 'touchpad-select';
+        const title = document.createElement('span');
+        title.textContent = 'Layout preset';
+        const select = document.createElement('select');
+
+        const options = [
+            { value: CUSTOM_LAYOUT_ID, label: 'Custom layout' },
+            ...this.layoutPresets.map(preset => ({ value: preset.id, label: preset.label }))
+        ];
+
+        select.innerHTML = options.map(option => `<option value="${option.value}">${option.label}</option>`).join('');
+        select.value = this.activeLayoutPresetId;
+
+        select.addEventListener('change', () => {
+            const value = select.value;
+            if (value === CUSTOM_LAYOUT_ID) {
+                this.activeLayoutPresetId = CUSTOM_LAYOUT_ID;
+                this.refreshLayoutPresetUI();
+                this.notifyLayoutChange();
+                return;
+            }
+            this.applyLayoutPreset(value);
+        });
+
+        label.appendChild(title);
+        label.appendChild(select);
+
+        const description = document.createElement('p');
+        description.className = 'touchpad-layout__preset-description';
+        description.textContent = CUSTOM_LAYOUT_DESCRIPTION;
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(description);
+
+        return { wrapper, select, description };
+    }
+
+    updateLayoutVariables() {
+        if (this.grid) {
+            this.grid.style.setProperty('--touchpad-grid-gap', `${this.layoutSettings.gap}px`);
+            this.grid.style.setProperty('--touchpad-min-width', `${this.layoutSettings.minWidth}px`);
+        }
+        if (this.container) {
+            this.container.style.setProperty('--touchpad-aspect', this.layoutSettings.aspectRatio);
+        }
+    }
+
+    updateLayoutControlUI() {
+        const refs = this.layoutControlRefs;
+        if (!refs) return;
+
+        if (refs.minWidthInput) {
+            refs.minWidthInput.value = String(this.layoutSettings.minWidth);
+            refs.minWidthValue.textContent = `${Math.round(this.layoutSettings.minWidth)}px`;
+        }
+        if (refs.gapInput) {
+            refs.gapInput.value = String(this.layoutSettings.gap);
+            refs.gapValue.textContent = `${Math.round(this.layoutSettings.gap)}px`;
+        }
+        if (refs.aspectRatioInput) {
+            refs.aspectRatioInput.value = String(this.layoutSettings.aspectRatio);
+            refs.aspectRatioValue.textContent = `${this.layoutSettings.aspectRatio.toFixed(2)} : 1`;
+        }
+        this.refreshLayoutPresetUI();
+    }
+
+    notifyLayoutChange() {
+        const detected = this.detectLayoutPresetId();
+        if (detected !== this.activeLayoutPresetId) {
+            this.activeLayoutPresetId = detected;
+            this.refreshLayoutPresetUI();
+        }
+        this.notifyMappingChange();
+        if (this.hub) {
+            this.hub.emit('touchpad-layout-change', {
+                layout: this.getLayoutSettings(),
+                layoutPresetId: this.activeLayoutPresetId
+            });
+        }
+    }
+
+    getLayoutSettings() {
+        return {
+            minWidth: this.layoutSettings.minWidth,
+            gap: this.layoutSettings.gap,
+            aspectRatio: this.layoutSettings.aspectRatio
+        };
+    }
+
+    applyLayout(layout = {}) {
+        if (!layout || typeof layout !== 'object') return;
+        this.layoutSettings = {
+            ...this.layoutSettings,
+            minWidth: toNumber(layout.minWidth, this.layoutSettings.minWidth),
+            gap: toNumber(layout.gap, this.layoutSettings.gap),
+            aspectRatio: toNumber(layout.aspectRatio, this.layoutSettings.aspectRatio)
+        };
+        this.updateLayoutControlUI();
+        this.updateLayoutVariables();
+        this.notifyLayoutChange();
+    }
+
+    applyLayoutPreset(presetId) {
+        const preset = this.layoutPresetIndex.get(presetId);
+        if (!preset) {
+            this.markLayoutAsCustom();
+            return;
+        }
+        this.layoutSettings = {
+            ...this.layoutSettings,
+            ...preset.settings
+        };
+        this.activeLayoutPresetId = preset.id;
+        this.updateLayoutControlUI();
+        this.updateLayoutVariables();
+        this.notifyLayoutChange();
+    }
+
+    markLayoutAsCustom({ skipNotify = false } = {}) {
+        this.activeLayoutPresetId = CUSTOM_LAYOUT_ID;
+        this.refreshLayoutPresetUI();
+        if (!skipNotify) {
+            this.notifyLayoutChange();
+        }
+    }
+
+    refreshLayoutPresetUI() {
+        if (!this.layoutPresetRefs?.select) return;
+        const select = this.layoutPresetRefs.select;
+        const description = this.layoutPresetRefs.description;
+        const preset = this.layoutPresetIndex.get(this.activeLayoutPresetId);
+        select.value = this.activeLayoutPresetId;
+        if (description) {
+            description.textContent = preset?.description || CUSTOM_LAYOUT_DESCRIPTION;
+        }
+    }
+
+    getMaxPadCount() {
+        return Math.max(1, toNumber(this.config.maxPadCount, DEFAULT_MAX_PAD_COUNT));
+    }
+
+    formatPadCount(count) {
+        const value = Math.max(1, Math.round(count));
+        return `${value} pad${value === 1 ? '' : 's'}`;
+    }
+
+    updatePadCountUI() {
+        if (!this.padCountControlRef) return;
+        const { input, valueLabel } = this.padCountControlRef;
+        if (input) {
+            input.max = String(this.getMaxPadCount());
+            input.value = String(this.padCount);
+        }
+        if (valueLabel) {
+            valueLabel.textContent = this.formatPadCount(this.padCount);
+        }
+    }
+
+    setPadCount(count, { silent = false } = {}) {
+        if (!this.grid) return;
+        const maxCount = this.getMaxPadCount();
+        const target = Math.min(Math.max(1, Math.round(count)), maxCount);
+        if (target === this.padCount) {
+            this.updatePadCountUI();
+            return;
+        }
+
+        if (target > this.padCount) {
+            for (let index = this.padCount; index < target; index += 1) {
+                const mapping = this.getDefaultMappingForIndex(index);
+                const pad = this.createPad(mapping);
+                this.pads.push(pad);
+                this.grid.appendChild(pad.wrapper);
+            }
+        } else {
+            for (let index = this.padCount - 1; index >= target; index -= 1) {
+                const pad = this.pads[index];
+                if (!pad) continue;
+                ['xParam', 'yParam', 'spreadParam'].forEach(key => {
+                    if (pad.mapping?.[key]) {
+                        const source = key === 'xParam' ? 'touchpad-x' : key === 'yParam' ? 'touchpad-y' : 'touchpad-gesture';
+                        this.clearSmoothingState(pad.mapping[key], source);
+                    }
+                });
+                this.clearPadStatusTimer(pad);
+                if (pad.cleanup) {
+                    pad.cleanup();
+                }
+                if (pad.wrapper?.parentNode) {
+                    pad.wrapper.parentNode.removeChild(pad.wrapper);
+                }
+                if (pad.controls?.xSelect?.ref) {
+                    this.parameterSelectRefs.delete(pad.controls.xSelect.ref);
+                }
+                if (pad.controls?.ySelect?.ref) {
+                    this.parameterSelectRefs.delete(pad.controls.ySelect.ref);
+                }
+                if (pad.controls?.spreadSelect?.ref) {
+                    this.parameterSelectRefs.delete(pad.controls.spreadSelect.ref);
+                }
+                this.pads.pop();
+            }
+        }
+
+        this.padCount = target;
+        this.updatePadCountUI();
+        this.refreshParameterSelectOptions();
+        this.updatePadActionStates();
+
+        if (this.hub) {
+            this.hub.emit('touchpad-pad-count-change', { padCount: this.padCount });
+        }
+        if (!silent) {
+            this.notifyMappingChange();
+        }
+    }
+
+    getDefaultMappingForIndex(index) {
+        const defaults = Array.isArray(this.config.defaultMappings) ? this.config.defaultMappings : [];
+        const template = defaults[index];
+        return template ? copyMapping(template) : {};
+    }
+
+    getState() {
+        return {
+            mappings: this.getMappings(),
+            layout: this.getLayoutSettings(),
+            layoutPresetId: this.activeLayoutPresetId,
+            padCount: this.padCount
+        };
+    }
+
+    applyState(state) {
+        if (!state) return;
+        if (Array.isArray(state)) {
+            this.applyMappings(state);
+            return;
+        }
+
+        let didApplyMappings = false;
+        if (state.mappings) {
+            if (Array.isArray(state.mappings) && state.mappings.length && state.mappings.length !== this.padCount) {
+                this.setPadCount(state.mappings.length, { silent: true });
+            }
+            this.applyMappings(state.mappings);
+            didApplyMappings = true;
+        }
+        if (typeof state.padCount === 'number' && state.padCount !== this.padCount) {
+            this.setPadCount(state.padCount, { silent: true });
+        }
+        const layoutPresetId = state.layoutPresetId || state.layoutPreset || state.layout?.presetId;
+        let appliedPreset = false;
+        if (layoutPresetId && layoutPresetId !== CUSTOM_LAYOUT_ID && this.layoutPresetIndex.has(layoutPresetId)) {
+            this.applyLayoutPreset(layoutPresetId);
+            appliedPreset = true;
+        }
+        if (state.layout && !appliedPreset) {
+            this.applyLayout(state.layout);
+            if (layoutPresetId === CUSTOM_LAYOUT_ID) {
+                this.markLayoutAsCustom({ skipNotify: true });
+                this.refreshLayoutPresetUI();
+            }
+        } else if (!state.layout && layoutPresetId === CUSTOM_LAYOUT_ID) {
+            this.markLayoutAsCustom({ skipNotify: true });
+        }
+
+        if (!didApplyMappings) {
+            this.notifyMappingChange();
+        }
+    }
+
+    createPad(mapping = {}) {
+        const index = this.pads.length + 1;
+        const padId = mapping.id || `pad-${index}`;
+        const label = mapping.label || `Pad ${index}`;
+        const normalizedMapping = this.normaliseMapping({ ...mapping, id: padId, label });
+        let templateId = mapping.templateId;
+        if (!templateId) {
+            templateId = this.detectTemplateId(normalizedMapping);
+        }
+        if (!templateId) {
+            templateId = CUSTOM_TEMPLATE_ID;
+        }
+        normalizedMapping.templateId = templateId;
+
+        const wrapper = document.createElement('article');
+        wrapper.className = 'touchpad-card';
+
+        const header = document.createElement('header');
+        header.className = 'touchpad-card__header';
+
+        const titleGroup = document.createElement('div');
+        titleGroup.className = 'touchpad-card__title-group';
+
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.className = 'touchpad-card__name';
+        nameInput.value = normalizedMapping.label || label;
+        nameInput.placeholder = 'Pad name';
+
+        titleGroup.appendChild(nameInput);
+
+        const statusEl = document.createElement('span');
+        statusEl.className = 'touchpad-card__status';
+        statusEl.dataset.role = 'status';
+        statusEl.textContent = 'Ready';
+
+        header.appendChild(titleGroup);
+        header.appendChild(statusEl);
+
+        const padSurface = document.createElement('div');
+        padSurface.className = 'touchpad-surface';
+        padSurface.setAttribute('data-pad-id', padId);
+
+        const indicator = document.createElement('div');
+        indicator.className = 'touchpad-indicator';
+        padSurface.appendChild(indicator);
+
+        const controls = document.createElement('div');
+        controls.className = 'touchpad-controls';
+
+        const pointerState = new Map();
+
+        const padState = {
+            id: padId,
+            label: normalizedMapping.label,
+            wrapper,
+            header,
+            surface: padSurface,
+            indicator,
+            statusEl,
+            mapping: { ...normalizedMapping },
+            pointerState,
+            controls: {}
+        };
+
+        nameInput.addEventListener('input', () => {
+            padState.mapping.label = nameInput.value;
+            padState.label = nameInput.value;
+            this.notifyMappingChange();
+        });
+
+        const templateControl = this.createTemplateControl(padState);
+        controls.appendChild(templateControl.wrapper);
+
+        const xSelect = this.createParameterSelect('X Axis', padState.mapping.xParam || '', (value) => {
+            if (padState.mapping.xParam && padState.mapping.xParam !== value) {
+                this.clearSmoothingState(padState.mapping.xParam, 'touchpad-x');
+            }
+            padState.mapping.xParam = value || '';
+            this.flagPadAsCustom(padState);
+            if (this.registerRecentParameter(value)) {
+                this.refreshParameterSelectOptions();
+            }
+            this.notifyMappingChange();
+        }, { role: 'xParam' });
+        const ySelect = this.createParameterSelect('Y Axis', padState.mapping.yParam || '', (value) => {
+            if (padState.mapping.yParam && padState.mapping.yParam !== value) {
+                this.clearSmoothingState(padState.mapping.yParam, 'touchpad-y');
+            }
+            padState.mapping.yParam = value || '';
+            this.flagPadAsCustom(padState);
+            if (this.registerRecentParameter(value)) {
+                this.refreshParameterSelectOptions();
+            }
+            this.notifyMappingChange();
+        }, { role: 'yParam' });
+        const gestureSelect = this.createParameterSelect('Spread', padState.mapping.spreadParam || '', (value) => {
+            if (padState.mapping.spreadParam && padState.mapping.spreadParam !== value) {
+                this.clearSmoothingState(padState.mapping.spreadParam, 'touchpad-gesture');
+            }
+            padState.mapping.spreadParam = value || '';
+            this.flagPadAsCustom(padState);
+            if (this.registerRecentParameter(value)) {
+                this.refreshParameterSelectOptions();
+            }
+            this.notifyMappingChange();
+        }, { allowNone: true, placeholder: 'None', role: 'spreadParam' });
+
+        const axisRow = document.createElement('div');
+        axisRow.className = 'touchpad-controls__row';
+        axisRow.appendChild(xSelect.wrapper);
+        axisRow.appendChild(ySelect.wrapper);
+
+        const gestureRow = document.createElement('div');
+        gestureRow.className = 'touchpad-controls__row';
+        gestureRow.appendChild(gestureSelect.wrapper);
+
+        const invertRow = document.createElement('div');
+        invertRow.className = 'touchpad-controls__row touchpad-controls__row--toggles';
+        const invertXToggle = this.createToggle('Invert X', Boolean(padState.mapping.invertX), (checked) => {
+            padState.mapping.invertX = checked;
+            this.flagPadAsCustom(padState);
+            this.notifyMappingChange();
+        }, 'invertX');
+        const invertYToggle = this.createToggle('Invert Y', Boolean(padState.mapping.invertY), (checked) => {
+            padState.mapping.invertY = checked;
+            this.flagPadAsCustom(padState);
+            this.notifyMappingChange();
+        }, 'invertY');
+        const swapButton = document.createElement('button');
+        swapButton.type = 'button';
+        swapButton.className = 'touchpad-swap';
+        swapButton.textContent = 'Swap Axes';
+        swapButton.addEventListener('click', () => {
+            const previous = { ...padState.mapping };
+            this.clearSmoothingState(previous.xParam, 'touchpad-x');
+            this.clearSmoothingState(previous.yParam, 'touchpad-y');
+
+            padState.mapping.xParam = previous.yParam;
+            padState.mapping.yParam = previous.xParam;
+            padState.mapping.xCurve = previous.yCurve;
+            padState.mapping.yCurve = previous.xCurve;
+            padState.mapping.xSmoothing = previous.ySmoothing;
+            padState.mapping.ySmoothing = previous.xSmoothing;
+            padState.mapping.invertX = previous.invertY;
+            padState.mapping.invertY = previous.invertX;
+
+            this.updatePadControlsFromMapping(padState);
+            this.flagPadAsCustom(padState);
+            this.notifyMappingChange();
+        });
+
+        invertRow.appendChild(invertXToggle.wrapper);
+        invertRow.appendChild(invertYToggle.wrapper);
+        invertRow.appendChild(swapButton);
+
+        const responseGroup = document.createElement('div');
+        responseGroup.className = 'touchpad-response-group';
+
+        const xResponse = this.createResponseControl('X Response', {
+            curve: padState.mapping.xCurve,
+            smoothing: padState.mapping.xSmoothing
+        }, 'x', (next) => {
+            padState.mapping.xCurve = next.curve;
+            padState.mapping.xSmoothing = next.smoothing;
+            this.flagPadAsCustom(padState);
+        });
+
+        const yResponse = this.createResponseControl('Y Response', {
+            curve: padState.mapping.yCurve,
+            smoothing: padState.mapping.ySmoothing
+        }, 'y', (next) => {
+            padState.mapping.yCurve = next.curve;
+            padState.mapping.ySmoothing = next.smoothing;
+            this.flagPadAsCustom(padState);
+        });
+
+        const spreadResponse = this.createResponseControl('Spread Gesture', {
+            curve: padState.mapping.spreadCurve,
+            smoothing: padState.mapping.spreadSmoothing
+        }, 'spread', (next) => {
+            padState.mapping.spreadCurve = next.curve;
+            padState.mapping.spreadSmoothing = next.smoothing;
+            this.flagPadAsCustom(padState);
+        });
+
+        responseGroup.appendChild(xResponse.wrapper);
+        responseGroup.appendChild(yResponse.wrapper);
+        responseGroup.appendChild(spreadResponse.wrapper);
+
+        const actionControls = this.createPadActions(padState);
+
+        padState.controls = {
+            nameInput,
+            template: templateControl,
+            xSelect,
+            ySelect,
+            spreadSelect: gestureSelect,
+            invertX: invertXToggle,
+            invertY: invertYToggle,
+            xResponse,
+            yResponse,
+            spreadResponse,
+            actions: actionControls
+        };
+
+        controls.appendChild(axisRow);
+        controls.appendChild(gestureRow);
+        controls.appendChild(invertRow);
+        controls.appendChild(responseGroup);
+        controls.appendChild(actionControls.wrapper);
+
+        wrapper.appendChild(header);
+        wrapper.appendChild(padSurface);
+        wrapper.appendChild(controls);
+
+        this.bindPadEvents(padState);
+        if (this.registerRecentFromMapping(padState.mapping)) {
+            this.refreshParameterSelectOptions();
+        }
+        this.updatePadControlsFromMapping(padState);
+        return padState;
+    }
+
+    createTemplateControl(padState) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'touchpad-template';
+
+        const label = document.createElement('label');
+        label.className = 'touchpad-select';
+        const title = document.createElement('span');
+        title.textContent = 'Pad template';
+        const select = document.createElement('select');
+
+        const options = [
+            { id: CUSTOM_TEMPLATE_ID, label: CUSTOM_TEMPLATE_LABEL },
+            ...this.templates.map(template => ({ id: template.id, label: template.label }))
+        ];
+
+        select.innerHTML = options.map(option => `<option value="${option.id}">${option.label}</option>`).join('');
+        select.value = padState.mapping.templateId || CUSTOM_TEMPLATE_ID;
+
+        select.addEventListener('change', () => {
+            this.applyTemplateToPad(padState, select.value);
+        });
+
+        label.appendChild(title);
+        label.appendChild(select);
+
+        const description = document.createElement('p');
+        description.className = 'touchpad-template__description';
+        description.textContent = this.getTemplateDescription(padState.mapping.templateId);
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(description);
+
+        return { wrapper, select, description };
+    }
+
+    flagPadAsCustom(padState) {
+        if (!padState || !padState.mapping) return;
+        if (padState.mapping.templateId === CUSTOM_TEMPLATE_ID) return;
+        padState.mapping.templateId = CUSTOM_TEMPLATE_ID;
+        this.updatePadTemplateUI(padState);
+    }
+
+    applyTemplateToPad(padState, templateId) {
+        if (!padState || !padState.mapping) return;
+        if (!templateId || templateId === CUSTOM_TEMPLATE_ID) {
+            padState.mapping.templateId = CUSTOM_TEMPLATE_ID;
+            this.updatePadControlsFromMapping(padState);
+            this.notifyMappingChange();
+            return;
+        }
+
+        const template = this.templateIndex.get(templateId);
+        if (!template) {
+            this.flagPadAsCustom(padState);
+            this.notifyMappingChange();
+            return;
+        }
+
+        const previous = { ...padState.mapping };
+        const nextMapping = this.normaliseMapping({
+            ...template.mapping,
+            id: padState.id,
+            label: template.label,
+            templateId: template.id
+        });
+
+        const axes = [
+            { key: 'xParam', source: 'touchpad-x' },
+            { key: 'yParam', source: 'touchpad-y' },
+            { key: 'spreadParam', source: 'touchpad-gesture' }
+        ];
+        axes.forEach(({ key, source }) => {
+            if (previous[key] && previous[key] !== nextMapping[key]) {
+                this.clearSmoothingState(previous[key], source);
+            }
+        });
+
+        padState.mapping = { ...padState.mapping, ...nextMapping };
+        padState.label = padState.mapping.label;
+        this.updatePadControlsFromMapping(padState);
+        if (this.registerRecentFromMapping(padState.mapping)) {
+            this.refreshParameterSelectOptions();
+        }
+        this.notifyMappingChange();
+    }
+
+    getTemplateDescription(templateId) {
+        if (!templateId || templateId === CUSTOM_TEMPLATE_ID) {
+            return CUSTOM_TEMPLATE_DESCRIPTION;
+        }
+        const template = this.templateIndex.get(templateId);
+        return template?.description || CUSTOM_TEMPLATE_DESCRIPTION;
+    }
+
+    updatePadTemplateUI(padState) {
+        if (!padState?.controls?.template) return;
+        const templateId = padState.mapping.templateId || CUSTOM_TEMPLATE_ID;
+        const control = padState.controls.template;
+        control.select.value = templateId;
+        control.description.textContent = this.getTemplateDescription(templateId);
+        control.wrapper.classList.toggle('touchpad-template--custom', templateId === CUSTOM_TEMPLATE_ID);
+    }
+
+    updatePadControlsFromMapping(padState) {
+        if (!padState || !padState.mapping) return;
+        const mapping = padState.mapping;
+
+        if (!mapping.templateId) {
+            const detected = this.detectTemplateId(mapping);
+            mapping.templateId = detected || CUSTOM_TEMPLATE_ID;
+        }
+
+        const nameInput = padState.controls?.nameInput;
+        if (nameInput && document.activeElement !== nameInput) {
+            nameInput.value = mapping.label || '';
+        }
+
+        if (padState.controls?.xSelect?.ref) {
+            this.populateParameterSelect(padState.controls.xSelect.ref, mapping.xParam || '');
+        }
+        if (padState.controls?.ySelect?.ref) {
+            this.populateParameterSelect(padState.controls.ySelect.ref, mapping.yParam || '');
+        }
+        if (padState.controls?.spreadSelect?.ref) {
+            this.populateParameterSelect(padState.controls.spreadSelect.ref, mapping.spreadParam || '');
+        }
+        if (padState.controls?.invertX) {
+            padState.controls.invertX.input.checked = Boolean(mapping.invertX);
+        }
+        if (padState.controls?.invertY) {
+            padState.controls.invertY.input.checked = Boolean(mapping.invertY);
+        }
+        if (padState.controls?.xResponse) {
+            padState.controls.xResponse.select.value = mapping.xCurve || this.getAxisDefaults('x').curve;
+            padState.controls.xResponse.slider.value = String(mapping.xSmoothing);
+            padState.controls.xResponse.updateLabel();
+        }
+        if (padState.controls?.yResponse) {
+            padState.controls.yResponse.select.value = mapping.yCurve || this.getAxisDefaults('y').curve;
+            padState.controls.yResponse.slider.value = String(mapping.ySmoothing);
+            padState.controls.yResponse.updateLabel();
+        }
+        if (padState.controls?.spreadResponse) {
+            padState.controls.spreadResponse.select.value = mapping.spreadCurve || this.getAxisDefaults('spread').curve;
+            padState.controls.spreadResponse.slider.value = String(mapping.spreadSmoothing);
+            padState.controls.spreadResponse.updateLabel();
+        }
+
+        this.updatePadTemplateUI(padState);
+    }
+
+    detectTemplateId(mapping = {}) {
+        const normalized = this.normaliseMapping(mapping);
+        const match = this.templates.find(template => this.mappingMatchesTemplate(normalized, template.mapping));
+        return match ? match.id : '';
+    }
+
+    mappingMatchesTemplate(mapping, templateMapping) {
+        if (!mapping || !templateMapping) return false;
+        const keys = ['xParam', 'yParam', 'spreadParam', 'invertX', 'invertY', 'xCurve', 'yCurve', 'spreadCurve'];
+        const smoothingKeys = ['xSmoothing', 'ySmoothing', 'spreadSmoothing'];
+        return keys.every(key => (mapping[key] || '') === (templateMapping[key] || ''))
+            && smoothingKeys.every(key => Math.abs((mapping[key] ?? 0) - (templateMapping[key] ?? 0)) < 0.0001);
+    }
+
+    createParameterSelect(label, value, onChange, { allowNone = false, placeholder = 'Select parameter', role = '' } = {}) {
+        const wrapper = document.createElement('label');
+        wrapper.className = 'touchpad-select';
+        const span = document.createElement('span');
+        span.textContent = label;
+        const select = document.createElement('select');
+        if (role) {
+            select.dataset.role = role;
+        }
+
+        const selectRef = { select, allowNone, placeholder };
+        this.parameterSelectRefs.add(selectRef);
+        this.populateParameterSelect(selectRef, value || '');
+
+        select.addEventListener('change', () => {
+            onChange(select.value);
+        });
+
+        wrapper.appendChild(span);
+        wrapper.appendChild(select);
+        return { wrapper, select, ref: selectRef };
+    }
+
+    populateParameterSelect(selectRef, value = '') {
+        if (!selectRef?.select) return;
+        const { select, allowNone, placeholder } = selectRef;
+        const currentValue = value ?? '';
+        const filtered = this.getFilteredParameters({ includeIds: currentValue ? [currentValue] : [] });
+        const recent = this.getRecentParametersForSelect(currentValue);
+
+        while (select.firstChild) {
+            select.removeChild(select.firstChild);
+        }
+
+        if (allowNone) {
+            const option = document.createElement('option');
+            option.value = '';
+            option.textContent = placeholder || 'Select parameter';
+            select.appendChild(option);
+        } else if (!currentValue) {
+            const placeholderOption = document.createElement('option');
+            placeholderOption.value = '';
+            placeholderOption.textContent = placeholder || 'Select parameter';
+            placeholderOption.disabled = true;
+            placeholderOption.selected = true;
+            select.appendChild(placeholderOption);
+        }
+
+        const dedupe = new Set();
+        const groups = [];
+
+        const ensureGroup = (label) => {
+            let entry = groups.find(group => group.label === label);
+            if (!entry) {
+                entry = { label, items: [], sort: label !== 'Recently used' };
+                groups.push(entry);
+            }
+            return entry;
+        };
+
+        const pushMeta = (label, meta) => {
+            if (!meta || !meta.id || dedupe.has(meta.id)) return;
+            dedupe.add(meta.id);
+            ensureGroup(label).items.push(meta);
+        };
+
+        recent.forEach(meta => pushMeta('Recently used', meta));
+        filtered.forEach(meta => pushMeta(meta.group || 'Parameters', meta));
+
+        groups.forEach(group => {
+            if (!group.items.length) return;
+            if (group.sort) {
+                group.items.sort((a, b) => a.label.localeCompare(b.label));
+            }
+            const optgroup = document.createElement('optgroup');
+            optgroup.label = group.label;
+            group.items.forEach(meta => {
+                const option = document.createElement('option');
+                option.value = meta.id;
+                option.textContent = meta.label;
+                optgroup.appendChild(option);
+            });
+            select.appendChild(optgroup);
+        });
+
+        if (currentValue) {
+            const hasValue = Array.from(select.options).some(option => option.value === currentValue);
+            if (!hasValue) {
+                const fallback = document.createElement('option');
+                fallback.value = currentValue;
+                const meta = this.parameterLookup.get(currentValue);
+                fallback.textContent = meta ? `${meta.label} (filtered)` : currentValue;
+                select.appendChild(fallback);
+            }
+        }
+
+        if (currentValue && Array.from(select.options).some(option => option.value === currentValue)) {
+            select.value = currentValue;
+        } else if (allowNone) {
+            select.value = '';
+        } else {
+            const firstAvailable = Array.from(select.options).find(option => option.value);
+            if (firstAvailable) {
+                select.value = firstAvailable.value;
+            }
+        }
+
+        return select.value;
+    }
+
+    refreshParameterSelectOptions() {
+        this.parameterSelectRefs.forEach(selectRef => {
+            const currentValue = selectRef.select?.value || '';
+            this.populateParameterSelect(selectRef, currentValue);
+        });
+    }
+
+    parameterMatchesFilters(meta) {
+        if (!meta) return false;
+        const query = (this.parameterFilter || '').toLowerCase();
+        const label = String(meta.label || '').toLowerCase();
+        const id = String(meta.id || '').toLowerCase();
+        const tags = Array.isArray(meta.tags) ? meta.tags : [];
+        const matchesSearch = !query
+            || label.includes(query)
+            || id.includes(query)
+            || tags.some(tag => String(tag).toLowerCase().includes(query));
+        const matchesTags = !this.activeTagFilters.size
+            || tags.some(tag => this.activeTagFilters.has(tag));
+        return matchesSearch && matchesTags;
+    }
+
+    getRecentParametersForSelect(currentValue) {
+        if (!this.recentParameters.length) return [];
+        const include = new Set();
+        if (currentValue) {
+            include.add(currentValue);
+        }
+        const seen = new Set();
+        const results = [];
+        this.recentParameters.forEach(id => {
+            if (!id || seen.has(id)) return;
+            seen.add(id);
+            const meta = this.parameterLookup.get(id);
+            if (!meta) return;
+            if (include.has(meta.id) || this.parameterMatchesFilters(meta)) {
+                results.push(meta);
+            }
+        });
+        return results;
+    }
+
+    getFilteredParameters({ includeIds = [] } = {}) {
+        const includes = new Set((includeIds || []).filter(Boolean));
+        const results = [];
+        const seen = new Set();
+        this.parameterOptions.forEach(meta => {
+            if (!meta) return;
+            if (this.parameterMatchesFilters(meta) || includes.has(meta.id)) {
+                results.push(meta);
+                seen.add(meta.id);
+                includes.delete(meta.id);
+            }
+        });
+
+        includes.forEach(id => {
+            if (seen.has(id)) return;
+            const meta = this.parameterLookup.get(id);
+            if (meta) {
+                results.push(meta);
+            } else if (id) {
+                results.push({ id, label: id, group: 'Parameters', tags: [] });
+            }
+        });
+
+        return results.sort((a, b) => {
+            if (a.group === b.group) {
+                return a.label.localeCompare(b.label);
+            }
+            return (a.group || '').localeCompare(b.group || '');
+        });
+    }
+
+    countFilteredParameters() {
+        const filtered = this.getFilteredParameters();
+        return { filtered: filtered.length, total: this.parameterOptions.length };
+    }
+
+    updateParameterFilterSummary() {
+        if (!this.parameterFilterRefs) return;
+        const { summary, resetButton, tagButtons, wrapper } = this.parameterFilterRefs;
+        const { filtered, total } = this.countFilteredParameters();
+        const hasFilter = Boolean((this.parameterFilter || '').length) || this.activeTagFilters.size > 0;
+
+        if (summary) {
+            if (filtered === 0 && hasFilter) {
+                summary.textContent = 'No parameters match these filters';
+            } else if (filtered === total) {
+                summary.textContent = `Showing ${total} parameter${total === 1 ? '' : 's'}`;
+            } else {
+                summary.textContent = `Showing ${filtered} of ${total} parameters`;
+            }
+        }
+        if (resetButton) {
+            resetButton.hidden = !hasFilter;
+        }
+        if (wrapper) {
+            wrapper.classList.toggle('touchpad-parameter-filter--active', hasFilter);
+        }
+        if (tagButtons instanceof Map) {
+            tagButtons.forEach((button, tag) => {
+                button.classList.toggle('touchpad-tag--active', this.activeTagFilters.has(tag));
+            });
+        }
+    }
+
+    createToggle(label, checked, onChange, role = '') {
+        const wrapper = document.createElement('label');
+        wrapper.className = 'touchpad-toggle';
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.checked = checked;
+        if (role) {
+            input.dataset.role = role;
+        }
+        input.addEventListener('change', () => onChange(input.checked));
+        const span = document.createElement('span');
+        span.textContent = label;
+        wrapper.appendChild(input);
+        wrapper.appendChild(span);
+        return { wrapper, input };
+    }
+
+    createResponseControl(label, value, rolePrefix, onChange) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'touchpad-response';
+
+        const header = document.createElement('div');
+        header.className = 'touchpad-response__header';
+        const title = document.createElement('span');
+        title.textContent = label;
+        const valueLabel = document.createElement('span');
+        valueLabel.className = 'touchpad-response__value';
+        valueLabel.dataset.role = `${rolePrefix}SmoothingValue`;
+        header.appendChild(title);
+        header.appendChild(valueLabel);
+
+        const select = document.createElement('select');
+        select.className = 'touchpad-response__select';
+        select.dataset.role = `${rolePrefix}Curve`;
+        select.innerHTML = CURVE_OPTIONS.map(option => {
+            const selected = option.id === value.curve ? ' selected' : '';
+            return `<option value="${option.id}"${selected}>${option.label}</option>`;
+        }).join('');
+
+        const sliderRow = document.createElement('div');
+        sliderRow.className = 'touchpad-response__slider-row';
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.min = '0';
+        slider.max = '0.95';
+        slider.step = '0.05';
+        slider.value = String(value.smoothing);
+        slider.dataset.role = `${rolePrefix}Smoothing`;
+        slider.className = 'touchpad-response__slider';
+        sliderRow.appendChild(slider);
+
+        const updateLabel = () => {
+            valueLabel.textContent = this.formatSmoothingLabel(Number(slider.value));
+        };
+        updateLabel();
+
+        const commit = () => {
+            const next = {
+                curve: select.value || 'linear',
+                smoothing: toNumber(slider.value, value.smoothing)
+            };
+            onChange(next);
+        };
+
+        select.addEventListener('change', () => {
+            commit();
+            this.notifyMappingChange();
+        });
+        slider.addEventListener('input', () => {
+            updateLabel();
+            commit();
+            this.notifyMappingChange();
+        });
+
+        wrapper.appendChild(header);
+        wrapper.appendChild(select);
+        wrapper.appendChild(sliderRow);
+
+        return {
+            wrapper,
+            select,
+            slider,
+            updateLabel
+        };
+    }
+
+    createPadActions(padState) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'touchpad-card__actions';
+
+        const copyButton = document.createElement('button');
+        copyButton.type = 'button';
+        copyButton.className = 'touchpad-action';
+        copyButton.textContent = 'Copy';
+        copyButton.title = 'Copy this pad mapping';
+        copyButton.addEventListener('click', () => this.copyPadMapping(padState));
+
+        const pasteButton = document.createElement('button');
+        pasteButton.type = 'button';
+        pasteButton.className = 'touchpad-action';
+        pasteButton.textContent = 'Paste';
+        pasteButton.title = 'Paste the last copied mapping';
+        pasteButton.addEventListener('click', () => this.pastePadMapping(padState));
+
+        const duplicateButton = document.createElement('button');
+        duplicateButton.type = 'button';
+        duplicateButton.className = 'touchpad-action touchpad-action--primary';
+        duplicateButton.textContent = 'Duplicate';
+        duplicateButton.title = 'Duplicate this pad after itself';
+        duplicateButton.addEventListener('click', () => this.duplicatePad(padState));
+
+        const clearButton = document.createElement('button');
+        clearButton.type = 'button';
+        clearButton.className = 'touchpad-action touchpad-action--ghost';
+        clearButton.textContent = 'Clear';
+        clearButton.title = 'Remove assigned parameters';
+        clearButton.addEventListener('click', () => this.clearPadMapping(padState));
+
+        wrapper.appendChild(copyButton);
+        wrapper.appendChild(pasteButton);
+        wrapper.appendChild(duplicateButton);
+        wrapper.appendChild(clearButton);
+
+        return {
+            wrapper,
+            copyButton,
+            pasteButton,
+            duplicateButton,
+            clearButton
+        };
+    }
+
+    copyPadMapping(padState) {
+        if (!padState?.mapping) return;
+        const snapshot = this.normaliseMapping({
+            ...padState.mapping,
+            id: '',
+            templateId: padState.mapping.templateId || this.detectTemplateId(padState.mapping) || CUSTOM_TEMPLATE_ID
+        });
+        this.mappingClipboard = snapshot;
+        this.announcePadStatus(padState, 'Copied');
+        this.updatePadActionStates();
+    }
+
+    pastePadMapping(padState) {
+        if (!padState?.mapping || !this.mappingClipboard) return;
+
+        const previous = { ...padState.mapping };
+        const clipboard = { ...this.mappingClipboard };
+        const templateId = clipboard.templateId || this.detectTemplateId(clipboard) || CUSTOM_TEMPLATE_ID;
+
+        const padIndex = this.pads.indexOf(padState);
+        const defaultLabel = padIndex >= 0 ? `Pad ${padIndex + 1}` : '';
+        const shouldAdoptClipboardLabel = Boolean(clipboard.label)
+            && (!padState.mapping.label || padState.mapping.label === defaultLabel);
+
+        const nextMapping = this.normaliseMapping({
+            ...padState.mapping,
+            ...clipboard,
+            id: padState.id,
+            label: shouldAdoptClipboardLabel ? clipboard.label : (padState.mapping.label || padState.label),
+            templateId
+        });
+
+        const axes = [
+            { key: 'xParam', source: 'touchpad-x' },
+            { key: 'yParam', source: 'touchpad-y' },
+            { key: 'spreadParam', source: 'touchpad-gesture' }
+        ];
+        axes.forEach(({ key, source }) => {
+            if (previous[key] && previous[key] !== nextMapping[key]) {
+                this.clearSmoothingState(previous[key], source);
+            }
+        });
+
+        padState.mapping = { ...padState.mapping, ...nextMapping };
+        padState.label = padState.mapping.label;
+        this.flagPadAsCustom(padState);
+        this.updatePadControlsFromMapping(padState);
+        const changed = this.registerRecentFromMapping(padState.mapping);
+        if (changed) {
+            this.refreshParameterSelectOptions();
+        }
+        this.notifyMappingChange();
+        this.announcePadStatus(padState, 'Pasted');
+    }
+
+    duplicatePad(padState) {
+        if (!padState || !this.grid) return;
+        const max = this.getMaxPadCount();
+        if (this.padCount >= max) {
+            this.announcePadStatus(padState, 'Max pads reached');
+            return;
+        }
+
+        const label = this.generateDuplicateLabel(padState.mapping.label || padState.label || '');
+        const mapping = this.normaliseMapping({
+            ...padState.mapping,
+            id: '',
+            label,
+            templateId: padState.mapping.templateId || this.detectTemplateId(padState.mapping) || CUSTOM_TEMPLATE_ID
+        });
+
+        const newPad = this.createPad(mapping);
+        const index = this.pads.indexOf(padState);
+        const insertIndex = index >= 0 ? index + 1 : this.pads.length;
+        this.pads.splice(insertIndex, 0, newPad);
+        this.padCount += 1;
+        this.grid.insertBefore(newPad.wrapper, this.grid.children[insertIndex] || null);
+        this.updatePadCountUI();
+        this.refreshParameterSelectOptions();
+        this.updatePadActionStates();
+        if (this.hub) {
+            this.hub.emit('touchpad-pad-count-change', { padCount: this.padCount });
+        }
+        this.notifyMappingChange();
+        this.announcePadStatus(newPad, 'Duplicated');
+    }
+
+    clearPadMapping(padState) {
+        if (!padState?.mapping) return;
+
+        const previous = { ...padState.mapping };
+        ['xParam', 'yParam', 'spreadParam'].forEach(key => {
+            if (!previous[key]) return;
+            const source = key === 'xParam'
+                ? 'touchpad-x'
+                : key === 'yParam'
+                    ? 'touchpad-y'
+                    : 'touchpad-gesture';
+            this.clearSmoothingState(previous[key], source);
+        });
+
+        const cleared = this.normaliseMapping({
+            id: padState.id,
+            label: padState.mapping.label,
+            templateId: CUSTOM_TEMPLATE_ID,
+            xParam: '',
+            yParam: '',
+            spreadParam: '',
+            invertX: false,
+            invertY: false
+        });
+
+        padState.mapping = { ...padState.mapping, ...cleared };
+        this.flagPadAsCustom(padState);
+        this.updatePadControlsFromMapping(padState);
+        this.notifyMappingChange();
+        this.announcePadStatus(padState, 'Cleared');
+    }
+
+    padHasAssignments(padState) {
+        if (!padState?.mapping) return false;
+        return Boolean(padState.mapping.xParam || padState.mapping.yParam || padState.mapping.spreadParam);
+    }
+
+    announcePadStatus(padState, message) {
+        if (!padState?.statusEl) return;
+        this.clearPadStatusTimer(padState);
+        padState.statusEl.textContent = message;
+        padState.statusTimer = setTimeout(() => {
+            padState.statusTimer = null;
+            if ((padState.pointerState?.size || 0) === 0) {
+                padState.statusEl.textContent = 'Ready';
+            }
+        }, STATUS_RESET_DELAY);
+    }
+
+    clearPadStatusTimer(padState) {
+        if (!padState?.statusTimer) return;
+        clearTimeout(padState.statusTimer);
+        padState.statusTimer = null;
+    }
+
+    generateDuplicateLabel(baseLabel = '') {
+        const trimmed = (baseLabel || '').trim();
+        if (!trimmed) {
+            return '';
+        }
+        const existing = new Set(this.pads.map(pad => (pad?.mapping?.label || '').toLowerCase()));
+        let candidate = `${trimmed} Copy`;
+        let suffix = 2;
+        while (existing.has(candidate.toLowerCase())) {
+            candidate = `${trimmed} Copy ${suffix}`;
+            suffix += 1;
+        }
+        return candidate;
+    }
+
+    registerRecentParameter(parameterId) {
+        const id = parameterId ? String(parameterId) : '';
+        if (!id) return false;
+        const existingIndex = this.recentParameters.indexOf(id);
+        if (existingIndex === 0) {
+            return false;
+        }
+        if (existingIndex > -1) {
+            this.recentParameters.splice(existingIndex, 1);
+        }
+        this.recentParameters.unshift(id);
+        if (this.recentParameters.length > RECENT_PARAMETER_LIMIT) {
+            this.recentParameters.length = RECENT_PARAMETER_LIMIT;
+        }
+        return true;
+    }
+
+    registerRecentFromMapping(mapping) {
+        if (!mapping) return false;
+        let changed = false;
+        ['xParam', 'yParam', 'spreadParam'].forEach(key => {
+            if (this.registerRecentParameter(mapping[key])) {
+                changed = true;
+            }
+        });
+        return changed;
+    }
+
+    updatePadActionStates() {
+        const clipboardReady = Boolean(this.mappingClipboard);
+        const canDuplicate = this.padCount < this.getMaxPadCount();
+        this.pads.forEach(pad => {
+            const actions = pad.controls?.actions;
+            if (!actions) return;
+            if (actions.pasteButton) {
+                actions.pasteButton.disabled = !clipboardReady;
+                actions.pasteButton.title = clipboardReady ? 'Paste the copied mapping' : 'Copy a pad first';
+            }
+            if (actions.duplicateButton) {
+                actions.duplicateButton.disabled = !canDuplicate;
+                actions.duplicateButton.title = canDuplicate ? 'Duplicate this pad' : 'Max pads reached';
+            }
+            if (actions.clearButton) {
+                const hasAssignments = this.padHasAssignments(pad);
+                actions.clearButton.disabled = !hasAssignments;
+                actions.clearButton.title = hasAssignments ? 'Clear assigned parameters' : 'Nothing to clear';
+            }
+        });
+    }
+
+    formatSmoothingLabel(value) {
+        const percent = Math.round(clamp01(value) * 100);
+        return `${percent}% damping`;
+    }
+
+    applyCurveValue(value, curve) {
+        const v = clamp01(value);
+        switch (curve) {
+            case 'ease-in':
+                return v * v;
+            case 'ease-out':
+                return 1 - (1 - v) * (1 - v);
+            case 'ease-in-out':
+                return v < 0.5
+                    ? 2 * v * v
+                    : 1 - Math.pow(-2 * v + 2, 2) / 2;
+            case 'expo':
+                return v === 0 ? 0 : Math.pow(v, 1.75);
+            case 'sine':
+                return Math.sin((v * Math.PI) / 2);
+            default:
+                return v;
+        }
+    }
+
+    bindPadEvents(pad) {
+        const handlePointerDown = (event) => {
+            event.preventDefault();
+            this.clearPadStatusTimer(pad);
+            pad.surface.setPointerCapture(event.pointerId);
+            pad.pointerState.set(event.pointerId, this.normalizePointer(event, pad.surface));
+            this.updatePadFromPointers(pad);
+        };
+
+        const handlePointerMove = (event) => {
+            if (!pad.pointerState.has(event.pointerId)) return;
+            this.clearPadStatusTimer(pad);
+            pad.pointerState.set(event.pointerId, this.normalizePointer(event, pad.surface));
+            this.updatePadFromPointers(pad);
+        };
+
+        const handlePointerUp = (event) => {
+            this.clearPadStatusTimer(pad);
+            pad.pointerState.delete(event.pointerId);
+            this.updatePadFromPointers(pad);
+        };
+
+        const handleLeave = () => {
+            this.clearPadStatusTimer(pad);
+            pad.pointerState.clear();
+            this.updatePadFromPointers(pad);
+        };
+
+        pad.surface.addEventListener('pointerdown', handlePointerDown);
+        pad.surface.addEventListener('pointermove', handlePointerMove);
+        pad.surface.addEventListener('pointerup', handlePointerUp);
+        pad.surface.addEventListener('pointercancel', handlePointerUp);
+        pad.surface.addEventListener('pointerleave', handleLeave);
+
+        pad.cleanup = () => {
+            pad.surface.removeEventListener('pointerdown', handlePointerDown);
+            pad.surface.removeEventListener('pointermove', handlePointerMove);
+            pad.surface.removeEventListener('pointerup', handlePointerUp);
+            pad.surface.removeEventListener('pointercancel', handlePointerUp);
+            pad.surface.removeEventListener('pointerleave', handleLeave);
+        };
+    }
+
+    normalizePointer(event, element) {
+        const rect = element.getBoundingClientRect();
+        const x = clamp01((event.clientX - rect.left) / rect.width);
+        const y = clamp01((event.clientY - rect.top) / rect.height);
+        return { x, y, pointerId: event.pointerId };
+    }
+
+    updatePadFromPointers(pad) {
+        const pointers = Array.from(pad.pointerState.values());
+        const pointerCount = pointers.length;
+        const statusLabel = pointerCount > 0 ? `${pointerCount} touch${pointerCount > 1 ? 'es' : ''}` : 'Ready';
+        if (pad.statusEl) {
+            pad.statusEl.textContent = statusLabel;
+        }
+
+        if (pointerCount === 0) {
+            pad.indicator.style.opacity = '0';
+            return;
+        }
+
+        const centroid = pointers.reduce((acc, pointer) => {
+            acc.x += pointer.x;
+            acc.y += pointer.y;
+            return acc;
+        }, { x: 0, y: 0 });
+
+        centroid.x /= pointerCount;
+        centroid.y /= pointerCount;
+
+        pad.indicator.style.opacity = '1';
+        pad.indicator.style.transform = `translate(${centroid.x * 100}%, ${centroid.y * 100}%)`;
+
+        const { mapping } = pad;
+        if (!this.parameterManager) return;
+
+        if (mapping.xParam) {
+            this.applyAxisValue({
+                parameter: mapping.xParam,
+                invert: mapping.invertX,
+                curve: mapping.xCurve,
+                smoothing: mapping.xSmoothing
+            }, centroid.x, 'touchpad-x');
+        }
+        if (mapping.yParam) {
+            this.applyAxisValue({
+                parameter: mapping.yParam,
+                invert: mapping.invertY,
+                curve: mapping.yCurve,
+                smoothing: mapping.ySmoothing
+            }, centroid.y, 'touchpad-y');
+        }
+        if (mapping.spreadParam && pointerCount > 1) {
+            const spreadValue = this.calculateSpreadValue(pointers);
+            this.applyAxisValue({
+                parameter: mapping.spreadParam,
+                invert: false,
+                curve: mapping.spreadCurve,
+                smoothing: mapping.spreadSmoothing
+            }, spreadValue, 'touchpad-gesture');
+        }
+
+        if (this.hub) {
+            this.hub.emit('touchpad-input', {
+                padId: mapping.id,
+                centroid,
+                pointerCount,
+                mapping: { ...mapping }
+            });
+        }
+    }
+
+    calculateSpreadValue(pointers) {
+        if (pointers.length < 2) return 0;
+        let maxDistance = 0;
+        for (let i = 0; i < pointers.length; i += 1) {
+            for (let j = i + 1; j < pointers.length; j += 1) {
+                const dx = pointers[i].x - pointers[j].x;
+                const dy = pointers[i].y - pointers[j].y;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+                if (distance > maxDistance) {
+                    maxDistance = distance;
+                }
+            }
+        }
+        return clamp01(maxDistance * Math.SQRT2);
+    }
+
+    applyAxisValue(axisConfig, normalizedValue, source) {
+        if (!this.parameterManager || !axisConfig || !axisConfig.parameter) return;
+        const def = this.parameterManager.getParameterDefinition(axisConfig.parameter);
+        if (!def) return;
+
+        const inverted = axisConfig.invert ? 1 - clamp01(normalizedValue) : clamp01(normalizedValue);
+        const curved = this.applyCurveValue(inverted, axisConfig.curve);
+        const smoothing = Math.min(0.95, Math.max(0, axisConfig.smoothing ?? 0));
+        const stateKey = `${axisConfig.parameter}:${source || 'touchpad'}`;
+        const previous = this.smoothingState.get(stateKey);
+        const lerpFactor = 1 - smoothing;
+        const smoothed = previous === undefined ? curved : previous + (curved - previous) * lerpFactor;
+        this.smoothingState.set(stateKey, smoothed);
+
+        const value = def.min + (def.max - def.min) * smoothed;
+        this.parameterManager.setParameter(axisConfig.parameter, value, source || 'touchpad');
+    }
+
+    clearSmoothingState(parameter, source) {
+        if (!parameter) return;
+        const key = `${parameter}:${source || 'touchpad'}`;
+        this.smoothingState.delete(key);
+    }
+
+    notifyMappingChange() {
+        const state = this.getState();
+        this.onMappingChange(state);
+        this.updatePadActionStates();
+        if (this.hub) {
+            this.hub.emit('touchpad-mapping-change', state);
+        }
+    }
+
+    getMappings() {
+        return this.pads.map(pad => ({ ...pad.mapping }));
+    }
+
+    applyMappings(mappings = []) {
+        if (!Array.isArray(mappings) || mappings.length === 0) return;
+        this.smoothingState.clear();
+        let recentsChanged = false;
+        mappings.forEach((mapping, index) => {
+            const pad = this.pads[index];
+            if (!pad) return;
+
+            const previous = { ...pad.mapping };
+            const nextMapping = this.normaliseMapping({
+                ...pad.mapping,
+                ...mapping,
+                id: pad.mapping.id,
+                label: mapping.label || pad.mapping.label
+            });
+
+            let templateId = mapping.templateId ?? pad.mapping.templateId ?? '';
+            if (templateId && templateId !== CUSTOM_TEMPLATE_ID) {
+                const template = this.templateIndex.get(templateId);
+                if (!template || !this.mappingMatchesTemplate(nextMapping, template.mapping)) {
+                    templateId = this.detectTemplateId(nextMapping);
+                }
+            } else if (!templateId) {
+                templateId = this.detectTemplateId(nextMapping);
+            }
+            nextMapping.templateId = templateId || CUSTOM_TEMPLATE_ID;
+
+            const axes = [
+                { key: 'xParam', source: 'touchpad-x' },
+                { key: 'yParam', source: 'touchpad-y' },
+                { key: 'spreadParam', source: 'touchpad-gesture' }
+            ];
+            axes.forEach(({ key, source }) => {
+                if (previous[key] && previous[key] !== nextMapping[key]) {
+                    this.clearSmoothingState(previous[key], source);
+                }
+            });
+
+            pad.mapping = { ...pad.mapping, ...nextMapping };
+            pad.label = pad.mapping.label;
+            this.updatePadControlsFromMapping(pad);
+            if (this.registerRecentFromMapping(pad.mapping)) {
+                recentsChanged = true;
+            }
+        });
+
+        if (recentsChanged) {
+            this.refreshParameterSelectOptions();
+        }
+        this.notifyMappingChange();
+    }
+
+    destroy() {
+        this.pads.forEach(pad => {
+            this.clearPadStatusTimer(pad);
+            if (pad.cleanup) pad.cleanup();
+        });
+        this.pads = [];
+        this.grid = null;
+        this.layoutControlRefs = {};
+        this.smoothingState.clear();
+        this.parameterSelectRefs.clear();
+        this.activeTagFilters.clear();
+        this.parameterFilter = '';
+        this.parameterFilterRefs = null;
+        if (this.container) {
+            this.container.innerHTML = '';
+        }
+    }
+}

--- a/styles/performance.css
+++ b/styles/performance.css
@@ -1,0 +1,755 @@
+.performance-suite {
+    margin-top: 24px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(0, 255, 255, 0.2);
+    font-family: 'Orbitron', sans-serif;
+    color: #e8f6ff;
+}
+
+.performance-suite__columns {
+    display: grid;
+    gap: 16px;
+}
+
+@media (min-width: 1024px) {
+    .performance-suite__columns {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.performance-suite__column {
+    background: rgba(8, 20, 32, 0.55);
+    border: 1px solid rgba(0, 255, 255, 0.15);
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 8px 24px rgba(0, 40, 80, 0.25);
+}
+
+.performance-block {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.performance-block__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.performance-block__title {
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #7ffcff;
+    margin-bottom: 4px;
+}
+
+.performance-block__subtitle {
+    font-size: 0.7rem;
+    line-height: 1.4;
+    color: rgba(231, 248, 255, 0.65);
+}
+
+.touchpad-grid {
+    display: grid;
+    gap: var(--touchpad-grid-gap, 12px);
+    grid-template-columns: repeat(auto-fit, minmax(var(--touchpad-min-width, 220px), 1fr));
+}
+
+.touchpad-card {
+    background: rgba(2, 12, 24, 0.6);
+    border: 1px solid rgba(127, 252, 255, 0.12);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.touchpad-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.touchpad-card__title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.touchpad-card__name {
+    background: rgba(6, 18, 32, 0.85);
+    border: 1px solid rgba(127, 252, 255, 0.25);
+    color: #e8f6ff;
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+}
+
+.touchpad-card__name:focus {
+    outline: none;
+    border-color: rgba(127, 252, 255, 0.6);
+    box-shadow: 0 0 0 2px rgba(127, 252, 255, 0.15);
+}
+
+.touchpad-card__header h4 {
+    font-size: 0.95rem;
+    letter-spacing: 0.06em;
+    color: #bffaff;
+}
+
+.touchpad-card__status {
+    font-size: 0.65rem;
+    color: rgba(191, 250, 255, 0.7);
+    text-transform: uppercase;
+}
+
+.touchpad-surface {
+    position: relative;
+    border-radius: 10px;
+    background: radial-gradient(circle at center, rgba(127, 252, 255, 0.22), rgba(0, 20, 40, 0.9));
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    overflow: hidden;
+    aspect-ratio: var(--touchpad-aspect, 1);
+    touch-action: none;
+}
+
+.touchpad-indicator {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #7ffcff;
+    box-shadow: 0 0 12px rgba(127, 252, 255, 0.8);
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    transition: opacity 0.18s ease;
+}
+
+.touchpad-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.touchpad-controls__row {
+    display: flex;
+    gap: 8px;
+}
+
+.touchpad-template {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.touchpad-template__description {
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.6);
+    margin: 0;
+}
+
+.touchpad-template--custom .touchpad-template__description {
+    color: rgba(191, 250, 255, 0.7);
+}
+
+.touchpad-parameter-filter {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: rgba(4, 18, 32, 0.55);
+    border: 1px solid rgba(127, 252, 255, 0.14);
+    border-radius: 10px;
+    padding: 12px;
+    margin-bottom: 12px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.touchpad-parameter-filter--active {
+    border-color: rgba(127, 252, 255, 0.32);
+    box-shadow: 0 0 0 1px rgba(127, 252, 255, 0.08);
+}
+
+.touchpad-parameter-filter__search {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-parameter-filter__search input[type="search"] {
+    background: rgba(6, 20, 32, 0.9);
+    border: 1px solid rgba(127, 252, 255, 0.18);
+    border-radius: 6px;
+    padding: 6px 8px;
+    color: #e7f8ff;
+    font-size: 0.8rem;
+}
+
+.touchpad-parameter-filter__search input[type="search"]::placeholder {
+    color: rgba(231, 248, 255, 0.45);
+}
+
+.touchpad-parameter-filter__tags {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(231, 248, 255, 0.7);
+}
+
+.touchpad-parameter-filter__tags-label {
+    color: rgba(231, 248, 255, 0.6);
+}
+
+.touchpad-parameter-filter__tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.touchpad-tag {
+    border: 1px solid rgba(127, 252, 255, 0.2);
+    background: rgba(8, 28, 40, 0.8);
+    color: rgba(231, 248, 255, 0.8);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.touchpad-tag:hover {
+    border-color: rgba(127, 252, 255, 0.45);
+}
+
+.touchpad-tag--active {
+    background: rgba(127, 252, 255, 0.18);
+    border-color: rgba(127, 252, 255, 0.6);
+    color: #7ffcff;
+}
+
+.touchpad-tag--reset {
+    background: transparent;
+    border-color: rgba(127, 252, 255, 0.25);
+    color: rgba(231, 248, 255, 0.6);
+}
+
+.touchpad-tag--reset:hover {
+    border-color: rgba(127, 252, 255, 0.45);
+    color: #7ffcff;
+}
+
+.touchpad-parameter-filter__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.touchpad-parameter-filter__summary {
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.6);
+}
+
+.touchpad-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    background: rgba(4, 18, 32, 0.6);
+    border: 1px solid rgba(127, 252, 255, 0.18);
+    border-radius: 10px;
+    padding: 12px;
+}
+
+.touchpad-layout__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(231, 248, 255, 0.8);
+}
+
+.touchpad-layout__header strong {
+    color: #7ffcff;
+    font-weight: 600;
+}
+
+.touchpad-layout__header span {
+    font-size: 0.65rem;
+    text-transform: none;
+    letter-spacing: 0;
+    color: rgba(231, 248, 255, 0.6);
+}
+
+.touchpad-layout__controls {
+    display: grid;
+    gap: 10px;
+}
+
+.touchpad-layout__preset {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.touchpad-layout__preset-description {
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.6);
+    margin: 0;
+}
+
+@media (min-width: 720px) {
+    .touchpad-layout__controls {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.touchpad-layout__control {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-layout__control--pads .touchpad-layout__row {
+    align-items: center;
+}
+
+.touchpad-layout__control--pads .touchpad-layout__value {
+    min-width: 72px;
+}
+
+.touchpad-layout__label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-layout__row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.touchpad-layout__row input[type="range"] {
+    flex: 1;
+    accent-color: #7ffcff;
+}
+
+.touchpad-layout__value {
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.65);
+    min-width: 60px;
+    text-align: right;
+}
+
+.touchpad-select {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-select select {
+    background: rgba(6, 18, 32, 0.95);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    color: #e8f6ff;
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.75rem;
+    width: 100%;
+}
+
+.touchpad-controls__row--toggles {
+    align-items: center;
+}
+
+.touchpad-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-toggle input {
+    accent-color: #7ffcff;
+}
+
+.touchpad-swap {
+    margin-left: auto;
+    background: transparent;
+    border: 1px solid rgba(127, 252, 255, 0.35);
+    color: #7ffcff;
+    border-radius: 6px;
+    font-size: 0.65rem;
+    padding: 6px 10px;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.touchpad-card__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+}
+
+@media (max-width: 480px) {
+    .touchpad-card__actions {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+}
+
+.touchpad-action {
+    background: rgba(6, 18, 32, 0.9);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    color: #e8f6ff;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.touchpad-action:hover:not(:disabled) {
+    background: rgba(127, 252, 255, 0.15);
+    border-color: rgba(127, 252, 255, 0.45);
+    transform: translateY(-1px);
+}
+
+.touchpad-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.touchpad-action--primary {
+    background: linear-gradient(135deg, rgba(127, 252, 255, 0.24), rgba(8, 60, 90, 0.85));
+    border-color: rgba(127, 252, 255, 0.5);
+    color: #7ffcff;
+}
+
+.touchpad-action--primary:hover:not(:disabled) {
+    background: linear-gradient(135deg, rgba(127, 252, 255, 0.32), rgba(12, 72, 108, 0.95));
+}
+
+.touchpad-action--ghost {
+    background: transparent;
+    border-color: rgba(127, 252, 255, 0.18);
+    color: rgba(231, 248, 255, 0.7);
+}
+
+.touchpad-action--ghost:hover:not(:disabled) {
+    border-color: rgba(127, 252, 255, 0.32);
+    color: rgba(231, 248, 255, 0.9);
+}
+
+.touchpad-response-group {
+    display: grid;
+    gap: 10px;
+}
+
+@media (min-width: 720px) {
+    .touchpad-response-group {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.touchpad-response {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    background: rgba(6, 20, 34, 0.7);
+    border: 1px solid rgba(127, 252, 255, 0.18);
+    border-radius: 8px;
+}
+
+.touchpad-response__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.touchpad-response__value {
+    font-size: 0.6rem;
+    color: rgba(231, 248, 255, 0.6);
+}
+
+.touchpad-response__select {
+    background: rgba(4, 16, 30, 0.95);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    color: #e8f6ff;
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.72rem;
+    width: 100%;
+}
+
+.touchpad-response__slider-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.touchpad-response__slider {
+    flex: 1;
+    accent-color: #7ffcff;
+}
+
+.touchpad-swap:hover {
+    background: rgba(127, 252, 255, 0.1);
+    transform: translateY(-1px);
+}
+
+.audio-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.audio-fieldset {
+    border: 1px solid rgba(127, 252, 255, 0.16);
+    border-radius: 10px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: rgba(0, 20, 32, 0.45);
+}
+
+.audio-band {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgba(127, 252, 255, 0.15);
+    background: rgba(4, 18, 32, 0.55);
+    transition: opacity 0.2s ease;
+}
+
+.audio-band--disabled {
+    opacity: 0.6;
+}
+
+.audio-band__weight {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    color: rgba(231, 248, 255, 0.7);
+}
+
+.audio-band__weight input[type="range"] {
+    flex: 1;
+    accent-color: #7ffcff;
+}
+
+.audio-band__value {
+    font-size: 0.7rem;
+    color: rgba(191, 250, 255, 0.85);
+    min-width: 38px;
+    text-align: right;
+}
+
+.audio-fieldset legend {
+    padding: 0 6px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: #bffaff;
+}
+
+.toggle-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(8, 24, 36, 0.8);
+    border-radius: 20px;
+    padding: 6px 12px;
+    font-size: 0.7rem;
+    color: rgba(231, 248, 255, 0.8);
+}
+
+.toggle-pill input {
+    accent-color: #7ffcff;
+}
+
+.slider-control {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.slider-control input[type="range"] {
+    width: 100%;
+    accent-color: #7ffcff;
+}
+
+.audio-select {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.65rem;
+    color: rgba(231, 248, 255, 0.75);
+}
+
+.audio-select select {
+    background: rgba(6, 18, 32, 0.95);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    color: #e8f6ff;
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.75rem;
+}
+
+.preset-create-row {
+    display: flex;
+    gap: 8px;
+}
+
+.preset-input {
+    flex: 1;
+    background: rgba(6, 18, 32, 0.95);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    border-radius: 6px;
+    color: #e8f6ff;
+    padding: 6px 10px;
+    font-size: 0.75rem;
+}
+
+.preset-input.is-invalid {
+    border-color: #ff6f91;
+    box-shadow: 0 0 0 1px rgba(255, 111, 145, 0.5);
+}
+
+.preset-save {
+    background: linear-gradient(135deg, rgba(127, 252, 255, 0.8), rgba(0, 140, 255, 0.9));
+    border: none;
+    border-radius: 6px;
+    color: #001422;
+    font-size: 0.75rem;
+    padding: 6px 12px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.preset-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+}
+
+.preset-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(2, 12, 24, 0.6);
+    border: 1px solid rgba(127, 252, 255, 0.18);
+    border-radius: 8px;
+    padding: 8px 10px;
+    gap: 12px;
+}
+
+.preset-item__details {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.7rem;
+}
+
+.preset-item__details strong {
+    color: #bffaff;
+    letter-spacing: 0.05em;
+}
+
+.preset-item__details span {
+    color: rgba(231, 248, 255, 0.55);
+    font-size: 0.6rem;
+}
+
+.preset-item__summary {
+    display: block;
+    font-size: 0.6rem;
+    color: rgba(191, 250, 255, 0.75);
+}
+
+.preset-item__actions {
+    display: flex;
+    gap: 8px;
+}
+
+.preset-item__actions button {
+    background: rgba(8, 24, 36, 0.85);
+    border: 1px solid rgba(127, 252, 255, 0.28);
+    border-radius: 6px;
+    color: #7ffcff;
+    font-size: 0.65rem;
+    padding: 6px 10px;
+    cursor: pointer;
+    text-transform: uppercase;
+}
+
+.preset-item__actions button:hover {
+    background: rgba(127, 252, 255, 0.12);
+}
+
+.preset-empty {
+    text-align: center;
+    font-size: 0.7rem;
+    color: rgba(231, 248, 255, 0.5);
+    padding: 16px 0;
+}
+
+@media (max-width: 768px) {
+    .performance-suite__columns {
+        grid-template-columns: 1fr;
+    }
+
+    .touchpad-controls__row,
+    .preset-create-row {
+        flex-direction: column;
+    }
+
+    .touchpad-swap {
+        margin-left: 0;
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## Summary
- add pad-level copy, paste, duplicate, and clear actions with status feedback, clipboarding, and hub-aware pad count updates
- track recent parameter selections to surface a "Recently used" group in axis dropdowns and keep filters refreshed when assignments change
- style the new action controls so the touchpad cards gain responsive buttons that match the performance suite theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc05caa6508329ab27b723e3f7b18c