### PR TITLE
Add sensor schema registry and validation

### DIFF
--- a/DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md
+++ b/DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,52 @@
+# Adaptive Engine Architecture Review
+
+## Purpose
+This document captures a ground-truth assessment of the adaptive VIB34D code introduced in the previous refactor. It records what currently exists, how it is wired together, and whether the implementation is suitable as a commercial core for extensible wearable/ambient UI design.
+
+## 1. Current System Inventory
+### 1.1 Core Runtime Layer
+- `src/core/AdaptiveInterfaceEngine.js` extends the historical `VIB34DIntegratedEngine` and owns the adaptive pipeline (sensory bridge → layout synthesizer → parameter writes).【F:src/core/AdaptiveInterfaceEngine.js†L1-L95】
+- The base holographic subsystems (FACETED/QUANTUM/HOLOGRAPHIC/POLYCHORA) remain intact under `src/` and are still parameter-driven via the shared `parameterManager` foundation documented in `SYSTEM_STATUS.md`.【F:SYSTEM_STATUS.md†L59-L129】
+
+### 1.2 Adaptive Input & Layout Layer
+- `src/ui/adaptive/SensoryInputBridge.js` normalizes intent, biometric, ambient, and gesture events with configurable decay and subscription hooks.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】
+- `src/ui/adaptive/SpatialLayoutSynthesizer.js` converts the sensory snapshot into multi-zone layout descriptors, typography guidance, and motion cues.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L124】
+- `src/ui/adaptive/InterfacePatternRegistry.js` catalogs monetizable UI patterns and exposes filtering/export APIs.【F:src/ui/adaptive/InterfacePatternRegistry.js†L1-L87】
+
+### 1.3 Commercialization Layer
+- `src/features/DesignLanguageManager.js` maps variation names to registry patterns, generates monetization/integration descriptors, and controls the active "design language" mode.【F:src/features/DesignLanguageManager.js†L1-L80】
+- `src/product/ProductTelemetryHarness.js` buffers product analytics events with optional flush-to-endpoint logic.【F:src/product/ProductTelemetryHarness.js†L1-L71】
+
+### 1.4 Experience Layer
+- `wearable-designer.html` (255 lines) acts as the showcase shell that instantiates `AdaptiveInterfaceEngine`, renders marketing UI, and exposes monetization toggles. The file is large, tightly coupled, and currently lacks modular structure for reuse.
+
+## 2. Architectural Strengths
+1. **Separation of concerns** – Sensory normalization, layout synthesis, design language mapping, and telemetry are isolated classes with single responsibilities.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L124】
+2. **Non-breaking integration** – `AdaptiveInterfaceEngine` still relies on the historical parameter manager so legacy visualizers continue to function.【F:src/core/AdaptiveInterfaceEngine.js†L40-L71】
+3. **Commercial hooks present** – Design-language metadata and telemetry harness outline viable monetization paths, fulfilling the productization brief.【F:src/features/DesignLanguageManager.js†L36-L67】【F:src/product/ProductTelemetryHarness.js†L1-L71】
+
+## 3. Critical Gaps & Risks
+1. **Instantiation coupling** – Only the bespoke `wearable-designer.html` consumes the adaptive engine. No modular entry point exists for reuse across apps, making it hard to sell as a SDK.
+2. **Input validation maturity** – New `SensorSchemaRegistry` clamps and normalizes gaze/neural/biometric payloads, but hardware-specific adapters, consent prompts, and type definitions are still missing for production wearables.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1-L218】
+3. **Monolithic layout logic** – `SpatialLayoutSynthesizer` blends heuristics, presets, and annotation emission in a single class, complicating testability and alternative layout strategies.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L9-L111】
+4. **Telemetry abstraction is minimal** – The harness only logs to `fetch`/`console.table` and offers no batching strategies, auth signing, or privacy controls—insufficient for enterprise clients.【F:src/product/ProductTelemetryHarness.js†L18-L57】
+5. **Documentation drift** – Marketing-heavy README and plan documents claim full product readiness, while there is no engineering validation, API reference, or integration samples beyond the demo shell.【F:README.md†L1-L53】【F:DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md†L1-L40】
+
+## 4. Suitability as Commercial Core
+- **Short term:** The adaptive stack can power exploratory demos and concept pitches thanks to the isolated modules, new sensor schema validation, and compatibility with the existing visualization engine. Remaining risks involve SDK packaging, telemetry privacy, and end-to-end hardware validation.
+- **Long term:** Without a refactor focused on interface contracts, plugin architecture, and modular packaging, the current code will not scale. It risks becoming another bespoke demo rather than a reusable platform.
+
+## 5. Recommended Refactor Themes
+1. **SDK Boundary Definition** – Extract a framework-neutral package (`packages/adaptive-core`) exposing `AdaptiveInterfaceEngine`, sensor adapter interfaces, and TypeScript definitions.
+2. **Input Contract Hardening** – Extend the new schema validation layer with TypeScript definitions, consent workflows, and adapter lifecycle hooks (connect/disconnect/test) for real sensor hardware.
+3. **Layout Strategy Pipeline** – Split `SpatialLayoutSynthesizer` into strategy modules (zoning, motion, chroma) and allow dependency injection for alternative heuristics.
+4. **Telemetry Provider Interface** – Replace the raw harness with provider plug-ins (ConsoleProvider, HttpProvider, SegmentProvider) and privacy controls (PII scrubbing, opt-in flags).
+5. **Experience Layer Modularization** – Rebuild `wearable-designer.html` as a composable UI kit (e.g., Web Components or React wrapper) with smaller example scenes.
+
+## 6. Next Steps Snapshot
+- Phase 0 (Now): Create engineering roadmap & tracking system, align documentation with reality.
+- Phase 1: Carve out SDK boundary, formalize schema registration workflows, and codify telemetry privacy guardrails.
+- Phase 2: Modularize layout/telemetry subsystems and add automated tests.
+- Phase 3: Produce integration samples and extension templates for tooling partners.
+
+Refer to `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` for task-level tracking and status updates as the refactor progresses.

--- a/DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md
+++ b/DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md
@@ -1,0 +1,44 @@
+# Adaptive Engine Core Viability Assessment
+
+## 1. Session Context (2025-10-07)
+- **Objective:** Validate whether the current adaptive stack can serve as the commercial core for wearable/ambient UI tooling.
+- **Inputs Reviewed:** `AdaptiveInterfaceEngine`, sensory/layout modules, commercialization utilities, and the wearable designer shell.
+- **Outcome:** The existing structure is a strong prototype but requires a refactor programme before being packaged as a core SDK.
+
+## 2. Capability Fit Analysis
+| Layer | Strengths | Limitations | Decision |
+|-------|-----------|-------------|----------|
+| Core Runtime (`AdaptiveInterfaceEngine`) | Preserves legacy visualizer compatibility while introducing adaptive pipeline hooks for sensory updates.【F:src/core/AdaptiveInterfaceEngine.js†L16-L79】 | Lifecycle and variation flows are hardwired to demo hooks instead of a published API surface. | Keep, but extract public methods + TypeScript definitions during SDK boundary work (Phase 1).
+| Sensory Input (`SensoryInputBridge`) | Extensible channel registry, configurable decay, schema normalization, and snapshot export suitable for eye/neural adapters.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1-L218】 | Still missing hardware lifecycle controls (`connect/disconnect`, error events) and consent reporting. | Retain architecture, add adapter interface + consent-aware diagnostics in refactor.
+| Layout (`SpatialLayoutSynthesizer`) | Multi-zone descriptors with chroma/motion heuristics already mapped to engine parameters.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L18-L111】 | Monolithic heuristics make alternative strategies/testing difficult. | Split into strategy modules (zoning/motion/color) and expose injection API.
+| Commercialization (`DesignLanguageManager`, `InterfacePatternRegistry`, `ProductTelemetryHarness`) | Provides monetization metadata and telemetry hooks showing business value.【F:src/features/DesignLanguageManager.js†L18-L78】【F:src/ui/adaptive/InterfacePatternRegistry.js†L11-L87】【F:src/product/ProductTelemetryHarness.js†L7-L70】 | Telemetry lacks provider abstraction & privacy controls; registry is in-memory without persistence APIs. | Replace harness with provider plug-ins, introduce persistence/export adapters.
+| Experience Shell (`wearable-designer.html`) | Demonstrates adaptive behaviour + commercialization toggles end-to-end.【F:wearable-designer.html†L1-L255】 | Single 255-line file prevents reuse, testing, or partner integration samples. | Rebuild as modular demo kit (Phase 3).
+
+## 3. Scalability & Elegance Gaps
+1. **API Boundary Ambiguity** – Consumers must import internal modules directly; no SDK packaging, versioning, or compatibility guarantees.
+2. **Data Contract Fragility** – Runtime schema validation now clamps payloads, but missing hardware lifecycle hooks and consent flows still threaten production integrations.
+3. **Testing & Automation Debt** – No automated verification; telemetry and layout logic are untested.
+4. **Commercialization Hardening** – Telemetry lacks opt-in/PII controls; monetization metadata needs persistence/export surfaces for partner platforms.
+
+## 4. Core Decision
+- **Go-Forward Stance:** The prototype is a viable foundation *if and only if* we execute the refactor roadmap. A rewrite is unnecessary; strategic modularization and contract hardening will yield an SDK-grade core.
+- **KPIs for Graduation:**
+  - Public SDK entry point with semantic versioning and documentation.
+  - Validated sensory adapter contracts (runtime schemas + adapter lifecycle tests).
+  - Pluggable layout/telemetry strategies with baseline automated coverage.
+  - Modular demo kit showcasing partner integration flows.
+
+## 5. Refactor Programme Synopsis
+| Phase | Focus | Key Deliverables |
+|-------|-------|------------------|
+| Phase 0 (now) | Planning & alignment | Updated tracker, session log, viability assessment (this doc). |
+| Phase 1 | SDK boundary & contracts | Package `AdaptiveInterfaceEngine`, define adapter interfaces, add schema validation. |
+| Phase 2 | Modular subsystems | Strategy modules for layout, provider pattern for telemetry, baseline Playwright smoke tests. |
+| Phase 3 | Commercialization assets | Modular demo kit, partner starter templates, monetization analytics documentation. |
+
+## 6. Immediate Next Actions
+1. Finalize environment readiness plan (document dependency gaps, prioritize lightweight alternatives before full `install-deps`).
+2. Update development tracker with new sprint items for SDK boundary definition and environment tooling.
+3. Author a modularization brief for the layout/telemetry refactor (to seed Phase 2 backlog refinement).
+4. Capture session log entry (see `PLANNING/SESSION_LOG.md`) with decisions and follow-up owners.
+

--- a/DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md
+++ b/DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md
@@ -1,0 +1,36 @@
+# Adaptive UI Productization Plan
+
+## Vision
+Transform the existing VIB34D holographic engine into a commercial-grade adaptive interface design platform targeted at future-facing wearable and ambient devices. The product will enable designers to prototype and deploy 4D-projection-inspired user interfaces that respond to non-traditional inputs such as eye focus, neural gestures, biometric signals, and spatial gestures.
+
+## Strategic Objectives
+1. **Product Repositioning** – Reframe the core engine as a UI/UX prototyping suite instead of a gallery-only renderer.
+2. **Adaptive Input Layer** – Introduce abstractions for sensor-driven inputs (eye tracking, neural intent, biometric feedback, ambient context).
+3. **UI Component Language** – Replace variation-only focus with reusable UI schema modules that map to wearable experience patterns.
+4. **Design Workflow Integration** – Prepare extension points for Figma, Framer, Webflow, and custom plugin ecosystems.
+5. **Monetization Foundations** – Provide subscription hooks, analytics, and licensing toggles for enterprise support.
+6. **Documentation & Support** – Deliver comprehensive docs, roadmap, and onboarding artifacts.
+
+## Work Breakdown Structure
+- [x] Create adaptive input bridge module (sensor abstraction).
+- [x] Build responsive layout synthesizer for non-screen surfaces.
+- [x] Extend variation manager into design pattern registry.
+- [x] Add commercialization hooks (licensing, telemetry, modular add-ons).
+- [x] Produce new HTML entry point showcasing wearable/adaptive UI workflow.
+- [x] Update README and craft go-to-market documentation.
+- [x] Outline partner & plugin integration strategy.
+
+## Implementation Log
+This section will be filled while executing the plan to provide transparent, time-ordered documentation of every change.
+
+- ✅ **Initialized documentation** – Captured vision, objectives, and work breakdown for adaptive UI productization.
+- ✅ **Created SensoryInputBridge** – Added `src/ui/adaptive/SensoryInputBridge.js` to normalize multi-modal sensor data for wearable interfaces.
+- ✅ **Added SpatialLayoutSynthesizer** – Introduced `src/ui/adaptive/SpatialLayoutSynthesizer.js` to translate adaptive signals into wearable-friendly layout descriptors.
+- ✅ **Established InterfacePatternRegistry** – Added `src/ui/adaptive/InterfacePatternRegistry.js` to catalogue monetizable adaptive UI blueprints.
+- ✅ **Bound geometry to design** – Implemented `src/features/DesignLanguageManager.js` to map holographic variations to sellable UI languages.
+- ✅ **Productized core engine** – Created `src/core/AdaptiveInterfaceEngine.js` with sensory-driven layout synthesis and telemetry hooks.
+- ✅ **Telemetry foundation** – Added `src/product/ProductTelemetryHarness.js` for licensing-aware analytics.
+- ✅ **Wearable designer experience** – Authored `wearable-designer.html` showcasing adaptive UI workflow and commercial hooks.
+- ✅ **Updated README** – Reframed project messaging around adaptive wearable UI productization.
+- ✅ **Partner strategy** – Documented plugin ecosystems and monetization roadmap in `DOCS/PARTNER_INTEGRATION_STRATEGY.md`.
+

--- a/DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md
+++ b/DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md
@@ -1,0 +1,52 @@
+# Layout & Telemetry Modularization Brief
+
+## Purpose
+Establish the target architecture and acceptance criteria for splitting the adaptive layout and telemetry layers into modular, swappable components. This brief seeds Backlog items B-03, B-04, and B-08.
+
+## Current Pain Points
+- `SpatialLayoutSynthesizer` combines intensity heuristics, zone allocation, motion synthesis, and annotation plug-ins in a single class, making it difficult to extend for new wearable surfaces or haptic-only interfaces.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L113】
+- `ProductTelemetryHarness` handles licensing, buffering, and network flushing without any provider abstraction or privacy controls, limiting monetization readiness for enterprise deployments.【F:src/product/ProductTelemetryHarness.js†L1-L63】
+- Demo wiring in `wearable-designer.html` binds these modules directly to UI controls, preventing SDK consumers from selecting only the pieces they need.
+
+## Target End-State
+> **Implementation Update (2025-10-10):** Baseline strategy/annotation interfaces now live in `src/ui/adaptive/strategies` and
+> `src/ui/adaptive/annotations` with runtime registration exercised by the wearable designer demo.
+
+1. **Layout Strategy Plug-ins**
+   - Introduce a `LayoutStrategy` interface with `prepare(context)` and `compose(layoutDraft)` hooks.
+   - Provide reference strategies: `FocusWeightedStrategy` (current behavior), `PeripheralHandoffStrategy`, and `HapticFallbackStrategy`.
+   - Move annotation handling into discrete `LayoutAnnotation` modules that declare dependencies and priority.
+> **Implementation Update (2025-10-10):** `ProductTelemetryHarness` now delegates to provider implementations under
+> `src/product/telemetry` and supports runtime registration via the adaptive engine.
+
+2. **Telemetry Provider Interface**
+   - Define `TelemetryProvider` with `identify`, `track`, and `flush` methods plus metadata about storage locations.
+   - Ship `ConsoleTelemetryProvider` (default), `HttpTelemetryProvider` (configurable endpoint), and a stub `PartnerTelemetryProvider` for integrations.
+   - Require opt-in data minimization flags and anonymization options for biometric streams.
+> **Implementation Update (2025-10-10):** The new `createAdaptiveSDK` factory composes sensors, strategies, and telemetry
+> providers for partner demos.
+
+3. **SDK Composition Layer**
+   - Create a lightweight `AdaptiveSDK` factory that wires `SensoryInputBridge`, layout strategies, and telemetry providers via dependency injection.
+   - Ensure UI shells (demo experiences, partner plug-ins) can import from this factory without bundling unused adapters.
+
+## Acceptance Criteria
+- Strategies, annotations, and telemetry providers can be registered and swapped at runtime without modifying core classes.
+- Unit tests cover registration lifecycles and conflict resolution rules for layout and telemetry modules.
+- Documentation includes migration notes for partners adopting the new interfaces.
+- Demo shell loads default strategies/providers but can toggle alternatives via configuration JSON.
+
+## Deliverables
+- Updated module scaffolding in `/src/ui/adaptive` and `/src/product` that reflects the interfaces above.
+- Integration tests or smoke scripts validating end-to-end signal → layout → telemetry flow using the new abstractions.
+- README and partner collateral updates summarizing the modular architecture.
+
+## Dependencies & Risks
+- Requires decision on the lightweight testing stack to avoid reintroducing the Playwright blocker.
+- Telemetry provider changes must align with privacy/legal review before public release.
+- Layout strategy plug-ins may increase bundle size; consider tree-shaking guidance for partner SDKs.
+
+## Next Actions
+1. Finalize testing stack recommendation (see `DOCS/TESTING_STACK_EVALUATION.md`).
+2. Define SDK public API boundary (Backlog item B-01) to inform dependency injection design.
+3. Produce migration checklist for existing demo experiences to adopt modular interfaces.

--- a/DOCS/PARTNER_INTEGRATION_STRATEGY.md
+++ b/DOCS/PARTNER_INTEGRATION_STRATEGY.md
@@ -1,0 +1,29 @@
+# Partner & Plugin Integration Strategy
+
+## Target Ecosystems
+- **Figma** – Primary design plugin delivering adaptive component previews and intent-driven variants.
+- **Framer** – Real-time prototyping integration enabling neural/gesture simulation controls.
+- **Webflow** – Code export and hosted telemetry integration for adaptive websites.
+- **Unity / Unreal** – Wearable companion apps and holographic installations.
+
+## Integration Layers
+1. **Design Tokens API** – Surface color/motion tokens from `DesignLanguageManager` via REST or local bridge.
+2. **Pattern Catalog Sync** – Use `AdaptiveInterfaceEngine.exportMarketplaceCatalog()` to populate plugin storefronts.
+3. **Telemetry Webhooks** – Forward `ProductTelemetryHarness` buffers to partner analytics endpoints for shared insights.
+4. **Sensor Simulation Kits** – Bundle `SensoryInputBridge` adapters that emulate gaze, EEG, and biometrics inside each tool.
+
+## Commercial Opportunities
+- Tiered subscriptions aligned with pattern tiers (Starter, Pro, Enterprise).
+- Revenue share with platform marketplaces for premium holographic UI packs.
+- Enterprise support contracts bundling integration assistance and custom pattern creation.
+
+## Roadmap Highlights
+- Q1: Deliver Figma plugin alpha with adaptive preview controls.
+- Q2: Launch marketplace-ready pattern packs with licensing telemetry enabled.
+- Q3: Expand to neural hardware OEM SDK partnership leveraging SensoryInputBridge adapters.
+
+## Support Structure
+- Dedicated partner portal referencing `wearable-designer.html` demo flows.
+- API documentation generated from `DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md` milestones.
+- Community Discord & knowledge base for indie creators.
+

--- a/DOCS/SDK_BOUNDARY_PROPOSAL.md
+++ b/DOCS/SDK_BOUNDARY_PROPOSAL.md
@@ -1,0 +1,52 @@
+# Adaptive SDK Boundary Proposal
+
+## Purpose
+Define an explicit, supportable interface for product teams and partners consuming the adaptive engine. The proposal captures the initial module surface, dependency injection patterns, and packaging considerations required to evolve the prototype into a salable SDK.
+
+## Guiding Principles
+1. **Composable inputs and outputs.** Sensor feeds, layout strategies, and telemetry providers must be replaceable without deep
+   engine changes.
+2. **Progressive adoption.** Downstream products should be able to adopt a subset (e.g., layout only) before integrating full
+   adaptive control loops.
+3. **Commercial hardening.** Licensing checks, telemetry consent, and extension hooks ship as part of the boundary rather than
+   ad-hoc demo logic.
+
+## Proposed Public Surface
+| Area | Export | Responsibilities |
+|------|--------|------------------|
+| Core | `AdaptiveInterfaceEngine` | Lifecycle orchestration, module registry, high-level `renderAdaptiveFrame(context)` API. |
+| Inputs | `SensoryInputBridge`, `SensorSchemaRegistry`, `registerSensorSchema` | Normalization + validation contracts for gaze, neural, biometric, ambient signals. |
+| Layout | `SpatialLayoutSynthesizer`, `LayoutStrategy`, `LayoutContext` types | Strategy registration, generation of layout descriptors, annotations, and motion cues. |
+| Patterns | `InterfacePatternRegistry`, `DesignLanguageManager` | Mapping between layout descriptors and monetizable UI packages. |
+| Telemetry | `TelemetryClient`, `TelemetryProvider`, `ProductTelemetryHarness` compatibility shim | Event buffering, provider injection, consent state. |
+| Utilities | `createAdaptiveSDK(config)`, `AdaptiveError`, `AdaptiveLogger` | Bootstrapping helper returning configured engine + telemetry hooks. |
+
+## Dependency Injection Model
+- **Sensors:** supply adapters to `createAdaptiveSDK({ sensory: { adapters } })` and optionally register schemas with `registerSensorSchema(type, schema)` or via `sensorSchemas` config. Providers must expose `start`, `stop`, and `read()` for polling or use the `ingest` hook for push models.
+- **Layout Strategies:** `SpatialLayoutSynthesizer` exposes `registerStrategy(strategy)` and `clearStrategies()` for swapping
+  out bundles. Built-in strategies remain available as fallbacks.
+- **Telemetry Providers:** Providers implement `identify`, `track`, and `flush`. The runtime defaults to buffered mode via
+  `ProductTelemetryHarness` + `ConsoleTelemetryProvider` when no provider is specified.
+- **Pattern Packs:** `InterfacePatternRegistry` accepts packaged bundles containing metadata, monetization hints, and renderers.
+
+## Packaging Plan
+1. **Phase 1:** Ship as ESM bundle + type definitions. Provide factory `createAdaptiveSDK` returning
+   `{ engine, sensoryBridge, telemetry, registerSensorSchema }` and honoring `sensorSchemas` configuration.
+2. **Phase 2:** Publish adapters for React/Vue/Web Components. Ensure wearable demo consumes the same factory to avoid drift.
+3. **Phase 3:** Release plug-in kits (Figma/Webflow) that call into the SDK boundary for previews and telemetry capture.
+
+## Acceptance Criteria
+- Runtime initialization requires only the configuration object defined above.
+- Layout/telemetry modules expose abstract strategy/provider interfaces with Vitest coverage.
+- Telemetry consent + license keys enforced before any `send` call.
+- README and integration docs reference the SDK surface rather than internal files.
+
+## Open Questions
+- How should we version pattern packs relative to engine releases?
+- Do we need a compatibility layer for legacy VIB34D gallery consumers?
+- Should licensing checks block engine boot or degrade gracefully with limited features?
+
+## Next Steps
+1. Align backlog item **B-01** with this boundary and break down implementation tasks.
+2. Provide type sketches (TypeScript or JSDoc) for the exported interfaces.
+3. Schedule design review with partner teams to validate packaging expectations.

--- a/DOCS/TESTING_STACK_EVALUATION.md
+++ b/DOCS/TESTING_STACK_EVALUATION.md
@@ -1,0 +1,51 @@
+# Adaptive Engine Testing Stack Evaluation
+
+## Goals
+- Provide automated coverage for the adaptive pipeline without exceeding lightweight container limits.
+- Maintain compatibility with headless CI providers and partner SDK contributors.
+- Support future visual regression checks for projection-based interfaces.
+
+## Options Assessed
+
+### 1. Vitest + jsdom
+- **Pros:**
+  - Lightweight dependency footprint; no system-level browser binaries required.
+  - Fast feedback loop for unit tests covering `SensoryInputBridge`, layout strategies, and telemetry providers.
+  - Built-in mocking utilities suitable for sensor stream simulations.
+- **Cons:**
+  - Limited fidelity for actual rendering or 4D projection previews.
+  - Requires manual wiring for accessibility or visual assertions.
+- **Use Cases:** Core unit/integration coverage for modularized layout/telemetry logic; contract tests for SDK APIs.
+
+### 2. Playwright (current default)
+- **Pros:**
+  - High-fidelity browser automation for demo shells and partner plug-in prototypes.
+  - Supports screenshot baselines and cross-browser compatibility testing.
+- **Cons:**
+  - Installation requires ~500 MB of OS packages (`npx playwright install-deps`) which exceeds current container constraints.
+  - Slower execution; overkill for logic-focused modules pre-UI hardening.
+- **Use Cases:** Targeted smoke suites once SDK stabilizes and CI environment accommodates heavier dependencies.
+
+### 3. WebdriverIO + Chromium Snapshot
+- **Pros:**
+  - Configurable to use system Chromium already present in some CI images.
+  - Plugin ecosystem for visual diffing.
+- **Cons:**
+  - More configuration overhead; duplicates effort if we eventually standardize on Playwright.
+  - Still requires maintaining browser binaries for deterministic runs.
+- **Use Cases:** Backup option if Playwright licensing or footprint remains unresolved.
+
+## Recommendation
+1. **Adopt Vitest + jsdom as the primary test runner for Phase 1** to unlock unit coverage of modular strategies and providers without waiting on OS-level dependencies.
+2. **Retain Playwright tooling in the repo but mark it optional** until we have an approved container image or CI tier that bundles the required packages.
+
+## Implementation Status (2025-10-09 Update)
+- Vitest + jsdom dependencies added to `package.json`; configuration lives in `vitest.config.js`.
+- Baseline suites cover `SpatialLayoutSynthesizer` and `ProductTelemetryHarness` under `tests/vitest/`.
+- Playwright scripts remain callable via `npm run test:e2e*`; browser installation is still deferred pending blocker B-07.
+3. **Document a staged testing strategy**: unit (Vitest), contract (Vitest + lightweight DOM), high-fidelity (Playwright/manual) so partners understand expectation levels.
+
+## Next Steps
+- Add Vitest, jsdom, and supporting typings to `package.json` devDependencies.
+- Draft initial test skeletons for `SpatialLayoutSynthesizer` strategies and `TelemetryProvider` registry.
+- Update the development tracker environment checklist to reflect the two-tier testing plan and unblock B-07 decision.

--- a/PLANNING/ADAPTIVE_ENGINE_TRACKER.md
+++ b/PLANNING/ADAPTIVE_ENGINE_TRACKER.md
@@ -1,0 +1,71 @@
+# Adaptive Engine Development Tracker
+
+This tracker translates the architecture review into actionable engineering work. Update it with every change to maintain transparency and ensure we stay aligned with commercialization goals.
+
+## How to Use
+1. **Capture work items** in the Backlog with clear acceptance criteria.
+2. **Promote items** into the Current Sprint when actively working on them and log daily notes.
+3. **Close items** in the Completed section with links to commits/PRs and recorded learnings.
+4. **Review blockers** during async/weekly check-ins and document decisions here.
+
+## Environment & Tooling Checklist
+- [x] Node.js dependencies installed via `npm install` (Playwright for browser automation).【3edf52†L1-L5】
+- [x] Vitest + jsdom stack configured for Phase 1 unit coverage. *(Configured 2025-10-09 with `vitest.config.js` + baseline layout/telemetry tests.)*
+- [ ] Playwright browsers installed (`npx playwright install`). *(Remains optional until Vitest baseline is stable or CI image includes OS deps.)*
+- [x] Python3 available for static server (`python3 -m http.server`).
+- [ ] Optional: Add `zod` and `typescript` once schema validation and type definitions are prioritized.
+
+## Backlog
+| ID | Title | Description | Owner | Status | Target Milestone |
+|----|-------|-------------|-------|--------|------------------|
+| B-01 | Define SDK boundary | Design the public API surface for `AdaptiveInterfaceEngine`, sensor adapters, and telemetry providers. | Core Team | ⏳ In Progress | Phase 1 |
+| B-02 | Sensor schema validation | Introduce runtime schemas (likely Zod) and adapters for gaze, neural, biometrics, ambient inputs. | Core Team | ✅ Done | Phase 1 |
+| B-03 | Layout strategy modularization | Break the monolithic `SpatialLayoutSynthesizer` into interchangeable strategies with tests. | Core Team | ✅ Done | Phase 1 |
+| B-04 | Telemetry provider interface | Implement provider pattern + privacy controls to replace `ProductTelemetryHarness`'s console fallback. | Core Team | ✅ Done | Phase 1 |
+| B-05 | Demo shell modularization | Rebuild `wearable-designer.html` as documented UI components and integration samples. | Experience Team | Planned | Phase 3 |
+| B-06 | Partner integration starter kits | Create Figma/Webflow plugin scaffolds referencing the SDK boundary. | Platform Team | Planned | Phase 3 |
+| B-07 | Environment automation plan | Decide on lightweight browser automation stack or pre-baked Playwright image to unblock CI. | Core Team | ⏳ In Progress | Phase 1 |
+| B-08 | Layout/telemetry modularization brief | Capture target module structure + acceptance for strategy/provider refactor. | Core Team | ✅ Done | Phase 2 |
+| B-09 | Privacy & consent hardening | Document telemetry data classifications and provider consent requirements. | Core Team | Planned | Phase 1 |
+| B-10 | Strategy pack starter kits | Package reference strategies/annotations for partner SDK add-ons. | Platform Team | Planned | Phase 2 |
+
+## Current Sprint (Phase 0)
+| ID | Task | Acceptance Criteria | Status | Notes |
+|----|------|---------------------|--------|-------|
+| S0-01 | Document architecture baseline | Architecture review published with current inventory, risk analysis, and refactor themes. | ✅ Done | See `DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md`. |
+| S0-02 | Stand up development tracker | Central tracker document (this file) with backlog, sprint view, and environment checklist. | ✅ Done | Initial backlog seeded from architecture review recommendations. |
+| S0-03 | Align README with reality | Update README messaging to distinguish between demo capabilities and planned SDK roadmap. | ✅ Done | README updated in Phase 0 baseline; keep monitoring for drift. |
+| S0-04 | Core viability assessment | Produce deep-dive evaluation on suitability of current stack as commercial core. | ✅ Done | See `DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md`. |
+| S0-05 | Environment readiness audit | Run dependency sync, document blockers, and log next steps. | ✅ Done | Dependencies aligned (Vitest + jsdom) and Playwright deferred; blockers tracked under B-07. |
+| S0-07 | Establish Vitest baseline coverage | Add Vitest + jsdom dependencies, config, and initial unit tests for adaptive modules. | ✅ Done | See `vitest.config.js` and `tests/vitest/*`. |
+| S0-08 | Draft SDK boundary proposal | Capture initial API surface, DI model, and packaging plan for commercialization. | ✅ Done | See `DOCS/SDK_BOUNDARY_PROPOSAL.md`. |
+| S0-09 | Outline wearable designer migration plan | Create checklist for porting the demo shell onto modular runtime interfaces. | ✅ Done | See `PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md`. |
+| S0-06 | Testing stack recommendation | Document comparative analysis and recommendation for lightweight automated testing. | ✅ Done | See `DOCS/TESTING_STACK_EVALUATION.md`. |
+
+## Completed Log
+| Date | Item | Outcome | Follow-ups |
+|------|------|---------|------------|
+| 2025-01-25 | S0-01 | Architecture review delivered and checked into repository. | Feed tasks into backlog items B-01..B-05. |
+| 2025-01-25 | S0-02 | Development tracker established with environment checklist and backlog. | Maintain as source of truth for prioritization. |
+| 2025-10-07 | S0-03 | README alignment verified; messaging matches prototype reality. | Monitor marketing collateral for scope creep. |
+| 2025-10-07 | S0-04 | Core viability assessment published for stakeholder review. | Feed recommendations into Phase 1/2 planning docs. |
+| 2025-10-08 | S0-06 | Testing stack recommendation documented with path forward. | Schedule dependency update task and Vitest baseline implementation. |
+| 2025-10-09 | S0-05 | Environment readiness audit completed with Vitest deps installed; Playwright optional. | Continue tracking automation decision under B-07. |
+| 2025-10-09 | S0-07 | Vitest baseline coverage delivered with layout/telemetry suites. | Expand coverage to additional strategies/providers as they land. |
+| 2025-10-09 | S0-08 | SDK boundary proposal authored to guide Phase 1 implementation. | Review with partner tooling teams. |
+| 2025-10-09 | S0-09 | Wearable designer migration checklist captured for experience team coordination. | Revisit after SDK boundary solidifies. |
+| 2025-10-10 | B-03 | Layout strategies + annotations extracted into modular registry with Vitest coverage. | Extend to partner-specific strategy packs. |
+| 2025-10-10 | B-04 | Telemetry provider interface + SDK factory implemented with demo adoption. | Add privacy review + provider catalog. |
+| 2025-10-11 | B-02 | Sensor schema registry + validation integrated into sensory bridge with Vitest coverage. | Layer consent prompts + hardware adapter lifecycle into follow-up tasks. |
+
+## Blockers & Risks
+- **Documentation credibility:** Marketing-heavy messaging conflicts with current engineering readiness. Resolving S0-03 is critical for stakeholder trust.
+- **Strategy validation:** Partner-specific layout strategy packs still need authoring and validation against real wearable surfaces.
+- **Environment footprint:** Playwright OS dependencies exceed lightweight container limits. Vitest adoption reduces immediate pressure, but CI image work is still required before enabling Playwright suites.
+- **Telemetry/privacy gaps:** Schema validation now clamps payloads, but provider consent flows and PII classification remain open. Track under backlog item B-09.
+- **Dependency security:** `npm install` reports four moderate vulnerabilities; schedule audit once SDK packaging stabilizes.
+
+## Next Review
+- **Owner:** Core Team Lead
+- **Date:** 2025-10-14
+- **Agenda:** Resolve environment automation strategy (B-07), lock SDK boundary acceptance criteria (B-01), and confirm authorship plan for modularization brief (B-08).

--- a/PLANNING/SESSION_LOG.md
+++ b/PLANNING/SESSION_LOG.md
@@ -1,0 +1,108 @@
+# Adaptive Engine Work Session Log
+
+## 2025-10-07 – Session 01
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Environment readiness check for adaptive development.
+  - Deep viability assessment of adaptive stack as commercial core.
+  - Planning updates to ensure ongoing documentation and tracking.
+- **Actions Taken:**
+  1. Ran `npm install` to sync Node dependencies (no repo changes committed).
+  2. Attempted `npx playwright install` and `npx playwright install-deps`; aborted due to heavy system package requirements after validating the risk (logged for follow-up).
+  3. Authored the [Adaptive Engine Core Viability Assessment](../DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md) capturing module-level strengths, gaps, and phased refactor strategy.
+  4. Planned new tracker updates to reflect environment blockers and Phase 1 refactor tasks.
+- **Decisions:**
+  - Proceed with refactor (no rewrite) contingent on Phase 1–3 roadmap execution.
+  - Defer full Playwright dependency installation until we evaluate lighter-weight browser automation options or container base images.
+- **Risks/Issues Raised:**
+  - Environment setup requires ~500 MB of OS packages; we need an approved path before making it a standard prerequisite.
+  - Lack of formal SDK boundary remains the top technical blocker for commercialization.
+- **Next Planned Actions:**
+  1. Update `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` with environment blocker status and new sprint/backlog items.
+  2. Draft a modularization brief for layout/telemetry refactor (Phase 2 seeding).
+  3. Evaluate alternative testing stacks (e.g., Vitest + jsdom) before committing to Playwright-deps installation.
+
+## 2025-10-08 – Session 02
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Document lightweight testing stack recommendation to unblock automation planning.
+  - Define modularization blueprint for layout and telemetry layers.
+  - Update tracker artifacts to reflect new decisions and deliverables.
+- **Actions Taken:**
+  1. Authored the [Adaptive Engine Testing Stack Evaluation](../DOCS/TESTING_STACK_EVALUATION.md) recommending Vitest + jsdom for Phase 1 and keeping Playwright optional.
+  2. Produced the [Layout & Telemetry Modularization Brief](../DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md) outlining strategy/provider interfaces and acceptance criteria.
+  3. Updated `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` with the Vitest checklist item, backlog status changes, and new sprint/completed log entries.
+- **Decisions:**
+  - Adopt Vitest + jsdom as the default automated test stack for Phase 1 while deferring Playwright browser installs to optional workflows.
+  - Close backlog item B-08 with the published modularization brief; treat subsequent work as implementation tasks under Phase 2.
+- **Risks/Issues Raised:**
+  - Dependency installation for Vitest still pending; must ensure additions do not conflict with existing Playwright tooling.
+  - Need to socialize modularization plan with partner tooling teams to confirm compatibility with plug-in roadmaps.
+- **Next Planned Actions:**
+  1. Update `package.json` with Vitest/jsdom dependencies and scaffold baseline tests.
+  2. Draft SDK boundary proposal supporting dependency injection model described in the modularization brief.
+ 3. Coordinate with experience team on migration checklist for `wearable-designer.html` once modular interfaces land.
+
+## 2025-10-09 – Session 03
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Execute Vitest + jsdom adoption to unblock adaptive module coverage.
+  - Capture commercialization-facing specs (SDK boundary, migration checklist).
+  - Close out environment readiness follow-ups noted in prior sessions.
+- **Actions Taken:**
+  1. Added Vitest/jsdom dependencies, scripts, and config; authored baseline unit suites for `SpatialLayoutSynthesizer` and `ProductTelemetryHarness`.
+  2. Published the [Adaptive SDK Boundary Proposal](../DOCS/SDK_BOUNDARY_PROPOSAL.md) describing public surface, DI model, and packaging roadmap.
+  3. Created the [Wearable Designer Migration Checklist](WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md) to guide demo refactor activities.
+- **Decisions:**
+  - Marked environment audit complete now that Vitest stack is configured; Playwright remains optional until B-07 resolves.
+  - Began backlog item B-01 with the authored SDK boundary proposal to steer upcoming implementation work.
+- **Risks/Issues Raised:**
+  - `npm install` surfaced four moderate vulnerabilities; schedule follow-up security review once dependency graph stabilizes.
+  - Vitest currently emits deprecation warning about CJS API usage—track for future tooling update.
+- **Next Planned Actions:**
+  1. Extend Vitest coverage to sensor normalization once channel abstractions land.
+  2. Break down B-01 into implementation tickets aligned with the SDK boundary proposal.
+  3. Coordinate with experience team to prioritize wearable designer migration once runtime factory is in place.
+
+## 2025-10-10 – Session 04
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Implement runtime-pluggable layout strategies, annotations, and telemetry providers per modularization brief.
+  - Introduce Adaptive SDK factory for dependency-injected integrations and update wearable demo wiring.
+  - Extend Vitest coverage to validate new strategy/provider registries and data minimization logic.
+- **Actions Taken:**
+  1. Refactored `SpatialLayoutSynthesizer` into strategy/annotation registries with default Focus/Peripheral/Haptic strategies and stress annotations.
+  2. Rebuilt `ProductTelemetryHarness` around provider interfaces (console/http/partner) and shipped the `createAdaptiveSDK` factory consumed by `wearable-designer.html`.
+  3. Updated Vitest suites for layout + telemetry, refreshed README, SDK proposal, modularization brief, tracker, and session log to reflect the new runtime architecture.
+- **Decisions:**
+  - Close backlog items B-03 and B-04; shift upcoming work toward provider privacy review (B-09) and partner strategy packs (B-10).
+  - Use `createAdaptiveSDK` as the canonical bootstrap path for demos and partner plug-ins going forward.
+- **Risks/Issues Raised:**
+  - Need dedicated privacy review before enabling HTTP telemetry provider in production contexts.
+  - Strategy API now supports pluggability; require UX validation to tune defaults for specific wearable modalities.
+- **Next Planned Actions:**
+  1. Draft privacy/consent guidance for telemetry providers (B-09).
+  2. Break B-01 into concrete API docs now that `createAdaptiveSDK` exists.
+  3. Coordinate with experience team on migrating remaining demos to the SDK factory and capturing screenshots for marketing.
+
+## 2025-10-11 – Session 05
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Harden sensory input contracts with runtime schema validation and partner extension hooks.
+  - Extend the SDK boundary to expose schema registration ergonomics.
+  - Update documentation and planning artifacts to reflect the new validation layer and privacy follow-ups.
+- **Actions Taken:**
+  1. Implemented `SensorSchemaRegistry` with default schemas for gaze, neural, biometric, ambient, and gesture inputs plus runtime registration hooks.
+  2. Integrated schema validation into `SensoryInputBridge`, exposed `registerSensorSchema` through `AdaptiveInterfaceEngine`/`createAdaptiveSDK`, and added Vitest coverage for sanitization flows.
+  3. Refreshed README, SDK boundary proposal, architecture review, tracker, and session log to capture the validation milestone and highlight remaining privacy tasks.
+- **Decisions:**
+  - Marked backlog item B-02 complete; follow-up work will focus on consent prompts and hardware adapter lifecycle guidance.
+  - Treat telemetry privacy hardening (B-09) as the next critical documentation deliverable before expanding partner demos.
+- **Risks/Issues Raised:**
+  - Schema validation currently logs to console; need structured reporting for consent/audit purposes.
+  - No TypeScript definitions yet—partners still lack compile-time assurances around sensor payloads.
+- **Next Planned Actions:**
+  1. Author telemetry privacy & consent guidance (B-09) covering provider expectations and schema issue reporting.
+  2. Draft TypeScript/JSDoc definitions for sensor schemas as part of the SDK boundary documentation.
+  3. Prototype hardware adapter lifecycle hooks (connect/disconnect/test) and integrate into the tracker as a new backlog item.
+

--- a/PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md
+++ b/PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Wearable Designer Migration Checklist
+
+## Objective
+Transition `wearable-designer.html` from a monolithic prototype into an integration sample that consumes the modular adaptive SDK
+interfaces.
+
+## Pre-Migration Prerequisites
+- [ ] SDK boundary finalized and exported via `createAdaptiveRuntime` factory.
+- [ ] Layout strategies and telemetry providers injectable (Phase 2 deliverables).
+- [ ] Baseline Vitest coverage in place for layout + telemetry modules.
+- [ ] Partner design team reviews migration scope and UI dependencies.
+
+## Migration Tasks
+1. **Bootstrap Integration Layer**
+   - [ ] Replace direct imports with `createAdaptiveRuntime` + dependency map.
+   - [ ] Introduce configuration file for pattern packs and sensor channel wiring.
+2. **Componentize UI Shell**
+   - [ ] Break sections (hero, monetization banners, telemetry console) into reusable Web Components or templated modules.
+   - [ ] Ensure styling tokens map to `DesignLanguageManager` outputs.
+3. **Telemetry & Licensing Hooks**
+   - [ ] Wire consent + license prompts to `ProductTelemetryHarness` provider injection.
+   - [ ] Verify flushing/analytics toggles respect disabled state.
+4. **Testing & Validation**
+   - [ ] Author Vitest integration tests for the new adapter layer (mock sensors + telemetry).
+   - [ ] Schedule manual wearable experience review against the monetization checklist.
+
+## Post-Migration Follow-ups
+- [ ] Update README Quick Start to reference the new modular entry point.
+- [ ] Capture learnings + UI deltas in the development tracker.
+- [ ] Plan product marketing assets demonstrating plug-in pathway.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,63 @@
-# VIB34D Holographic Visualization Engine
+# VIB34D Adaptive Interface Platform (Prototype)
 
-A WebGL-based 4D mathematics visualization system with 4 different rendering engines.
+The VIB34D visualization engine now includes an experimental adaptive layer aimed at wearable, ambient, and projection-first interfaces. The current codebase demonstrates the concept but still requires significant engineering work before it can be marketed as a supported SDK. Start here to understand the available pieces and how we plan to evolve them.
 
-## 🚀 Quick Start
+## 🚀 Quick Start (Concept Demo)
 
 ```bash
 # Clone and navigate
-cd v2-refactored-mobile-fix
+cd vib34d-ultimate-viewer
 
-# Start local server
+# Start local server (no build tooling required)
 python3 -m http.server 8080
 
-# Open in browser
-http://localhost:8080/index-clean.html
+# Open the wearable/ambient demo shell
+http://localhost:8080/wearable-designer.html
 ```
 
-## 🎮 The 4 Systems
+> **Note:** `wearable-designer.html` is a prototype experience that wires the adaptive engine into a marketing-oriented UI. It is not yet packaged as a reusable toolkit.
 
-**🔷 FACETED** - Simple 2D geometric patterns  
-**🌌 QUANTUM** - Complex 3D lattice effects  
-**✨ HOLOGRAPHIC** - Audio-reactive visualizations  
-**🔮 POLYCHORA** - True 4D polytope mathematics  
+## 🧠 Adaptive Architecture Overview
 
-Switch between systems using the top navigation buttons. All systems share the same 11-parameter control system.
+| Layer | Purpose | Key Files |
+|-------|---------|-----------|
+| Core Runtime | Extends the legacy `VIB34DIntegratedEngine` with adaptive hooks while preserving existing visualizers. | `src/core/AdaptiveInterfaceEngine.js` |
+| Sensory Input | Normalizes gaze, neural, biometric, and ambient signals into semantic channels with schema validation. | `src/ui/adaptive/SensoryInputBridge.js`, `src/ui/adaptive/sensors/SensorSchemaRegistry.js` |
+| Layout Synthesis | Generates intent-driven layout descriptors, motion cues, and color adaptation guidance using pluggable strategies/annotations. | `src/ui/adaptive/SpatialLayoutSynthesizer.js`, `src/ui/adaptive/strategies/*`, `src/ui/adaptive/annotations/*` |
+| Design Language | Maps engine variations to monetizable interface patterns and integration metadata. | `src/features/DesignLanguageManager.js`, `src/ui/adaptive/InterfacePatternRegistry.js` |
+| Telemetry | Buffers analytics/licensing events and dispatches via provider interfaces. | `src/product/ProductTelemetryHarness.js`, `src/product/telemetry/*` |
+| SDK Composition | Lightweight factory for DI-based integration into partner shells. | `src/core/AdaptiveSDK.js` |
+| Experience Shell | Demonstration UI highlighting adaptive behaviours and commercialization hooks. | `wearable-designer.html` |
 
-## 📱 Mobile Support
+Read the [Adaptive Engine Architecture Review](DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md) for an in-depth assessment of the current implementation, strengths, and risks.
 
-Mobile performance is optimized. The system loads quickly on phones and runs at 45-60 FPS on most devices.
+## 📈 Roadmap & Tracking
 
-## 🎨 Features
+- [Adaptive Engine Development Tracker](PLANNING/ADAPTIVE_ENGINE_TRACKER.md) – Source of truth for backlog, sprint focus, and environment readiness.
+- [Adaptive Engine Core Viability Assessment](DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md) – Deep-dive on whether the current stack can graduate to a commercial SDK and what refactors are required.
+- [Adaptive Engine Testing Stack Evaluation](DOCS/TESTING_STACK_EVALUATION.md) – Recommendation to adopt Vitest + jsdom for Phase 1 coverage while keeping Playwright optional.
+- [Layout & Telemetry Modularization Brief](DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md) – Target interfaces and acceptance criteria for strategy/provider refactors.
+- [Adaptive SDK Boundary Proposal](DOCS/SDK_BOUNDARY_PROPOSAL.md) – Proposed public API surface, dependency injection model, and packaging plan for commercialization.
+- `DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md` – Strategic objectives and go-to-market framing from the previous refactor.
+- `DOCS/PARTNER_INTEGRATION_STRATEGY.md` – High-level integration opportunities for tooling ecosystems.
+- [Wearable Designer Migration Checklist](PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md) – Tasks for porting the demo shell onto the modular runtime once interfaces stabilize.
 
-- **Real-time 4D mathematics** with WebGL rendering
-- **11 parameter control system** with live updates  
-- **Gallery system** for saving/loading configurations
-- **Trading card export** in multiple formats
-- **Audio reactivity** in holographic system
-- **Cross-system compatibility** - parameters work across all engines
+Phase 1 now delivers runtime-pluggable layout strategies, annotations, telemetry providers, and sensor payload schema validation alongside an `AdaptiveSDK` factory for dependency injection. Upcoming focus areas include formalizing the SDK boundary documentation, codifying telemetry privacy guidance, and porting experience shells onto the new factory. Progress on these tasks is recorded in the tracker above.
 
-## 🔧 Development
+## 🎨 Engine Heritage
 
-Main files:
-- `index-clean.html` - Main interface (427 lines)
-- `js/core/app.js` - System controller  
-- `js/controls/ui-handlers.js` - Parameter controls
-- `src/` - Engine implementations
+All four holographic subsystems remain available for creative workflows and continue to share the unified parameter controls described in `SYSTEM_STATUS.md`. The adaptive layer currently sits on top of this proven rendering core.
 
-CSS is modularized in `styles/` directory. All JavaScript uses ES6 modules with graceful fallbacks.
+## 🔧 Development Notes
 
-## 📊 Status
+- The adaptive modules are delivered as native ES modules; a static HTTP server is sufficient for local prototyping.
+- Legacy gallery/test harnesses remain in the repository to preserve historical functionality while refactoring proceeds.
+- Automated testing for the adaptive pipeline now uses Vitest + jsdom (`npm test`). Playwright smoke suites remain available under `npm run test:e2e*` but require optional browser installs.
 
-✅ All systems operational  
-✅ Mobile optimized  
-✅ No critical issues  
-✅ Ready for use  
+## 📊 Reality Check
 
-See `CLAUDE.md` for detailed documentation and `SYSTEM_STATUS.md` for current technical status.
+- ⚠️ Prototype status – Suitable for demonstrations, not production deployments.
+- ⚠️ Documentation gap – API contracts, adapter lifecycles, and telemetry providers still need formal specs.
+- ✅ Visualization core – Legacy systems remain stable and documented (see `SYSTEM_STATUS.md`).
+
+Contributions should reference the architecture review and tracker documents to stay aligned with the evolving roadmap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,562 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.55.0",
-        "playwright": "^1.55.0"
+        "jsdom": "^23.2.0",
+        "playwright": "^1.55.0",
+        "vitest": "^1.6.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
@@ -29,6 +583,843 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -43,6 +1434,549 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.55.0",
@@ -74,6 +2008,676 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "**Revolutionary transformation: 20+ WebGL contexts → 1 unified context**",
   "main": "index.js",
   "scripts": {
-    "test": "npx playwright test",
-    "test:headed": "npx playwright test --headed",
-    "test:debug": "npx playwright test --debug",
-    "test:report": "npx playwright show-report",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed",
+    "test:e2e:debug": "npx playwright test --debug",
+    "test:e2e:report": "npx playwright show-report",
     "dev": "python3 -m http.server 8145"
   },
   "repository": {
@@ -24,6 +26,8 @@
   "homepage": "https://github.com/Domusgpt/v2-refactored#readme",
   "devDependencies": {
     "@playwright/test": "^1.55.0",
-    "playwright": "^1.55.0"
+    "jsdom": "^23.2.0",
+    "playwright": "^1.55.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/core/AdaptiveInterfaceEngine.js
+++ b/src/core/AdaptiveInterfaceEngine.js
@@ -1,0 +1,143 @@
+import { VIB34DIntegratedEngine } from './Engine.js';
+import { SensoryInputBridge } from '../ui/adaptive/SensoryInputBridge.js';
+import { SpatialLayoutSynthesizer } from '../ui/adaptive/SpatialLayoutSynthesizer.js';
+import { DesignLanguageManager } from '../features/DesignLanguageManager.js';
+import { ProductTelemetryHarness } from '../product/ProductTelemetryHarness.js';
+
+/**
+ * AdaptiveInterfaceEngine
+ * ------------------------------------------------------------
+ * Productized variant of the VIB34D engine tailored for wearable and ambient
+ * UI design. Introduces adaptive sensory input, layout synthesis, and
+ * monetization scaffolding.
+ */
+export class AdaptiveInterfaceEngine extends VIB34DIntegratedEngine {
+    constructor(options = {}) {
+        super();
+
+        this.sensoryBridge = new SensoryInputBridge(options.sensory);
+        this.layoutSynthesizer = new SpatialLayoutSynthesizer(options.layout);
+        this.designLanguageManager = new DesignLanguageManager(this, options.design);
+        this.telemetry = new ProductTelemetryHarness(options.telemetry);
+        this.marketplaceHooks = options.marketplaceHooks || {};
+
+        this.activeLayout = null;
+        this.activeDesignSpec = null;
+        this.adaptiveUpdateNeeded = true;
+
+        this.initializeAdaptivePipeline();
+    }
+
+    initializeAdaptivePipeline() {
+        const markDirty = () => {
+            this.adaptiveUpdateNeeded = true;
+        };
+
+        ['focus', 'intention', 'biometrics', 'environment', 'gesture'].forEach(channel => {
+            this.sensoryBridge.subscribe(channel, markDirty);
+        });
+
+        this.sensoryBridge.subscribe('focus', vector => {
+            this.telemetry.track('adaptive.focus', { x: vector.x, y: vector.y, depth: vector.depth });
+        });
+
+        this.sensoryBridge.subscribe('gesture', gesture => {
+            if (gesture?.intent) {
+                this.telemetry.track('adaptive.gesture', { intent: gesture.intent });
+            }
+        });
+
+        this.telemetry.start();
+        this.sensoryBridge.start();
+        this.syncDesignSpec();
+    }
+
+    registerLayoutStrategy(strategy) {
+        this.layoutSynthesizer.registerStrategy(strategy);
+        this.telemetry.track('design.layout.strategy_registered', { id: strategy.id });
+        return this;
+    }
+
+    registerLayoutAnnotation(annotation) {
+        this.layoutSynthesizer.registerAnnotation(annotation);
+        this.telemetry.track('design.layout.annotation_registered', { id: annotation.id });
+        return this;
+    }
+
+    registerSensorSchema(type, schema) {
+        this.sensoryBridge.registerSchema(type, schema);
+        this.telemetry.track('sensors.schema_registered', { type });
+        return this;
+    }
+
+    registerTelemetryProvider(provider) {
+        this.telemetry.registerProvider(provider);
+        this.telemetry.track('design.telemetry.provider_registered', { id: provider.id });
+        return this;
+    }
+
+    removeTelemetryProvider(id) {
+        this.telemetry.removeProvider(id);
+        this.telemetry.track('design.telemetry.provider_removed', { id });
+        return this;
+    }
+
+    updateVisualizers() {
+        if (this.adaptiveUpdateNeeded) {
+            const context = this.sensoryBridge.getSnapshot();
+            this.activeLayout = this.layoutSynthesizer.generateLayout(context);
+            this.applyLayoutToParameters(this.activeLayout);
+            this.emitAdaptiveUpdate(context, this.activeLayout);
+            this.adaptiveUpdateNeeded = false;
+        }
+
+        super.updateVisualizers();
+    }
+
+    applyLayoutToParameters(layout) {
+        if (!layout) return;
+        this.parameterManager.setParameter('intensity', layout.intensity);
+        this.parameterManager.setParameter('speed', 0.5 + layout.motion.velocity * 1.5);
+        this.parameterManager.setParameter('hue', layout.colorAdaptation.hueShift);
+        this.parameterManager.setParameter('saturation', layout.colorAdaptation.saturation / 100);
+
+        const geometryBias = layout.zones.find(zone => zone.id === 'primary')?.occupancy || 0.6;
+        const geometryIndex = Math.round(geometryBias * 7);
+        this.parameterManager.setParameter('geometry', geometryIndex);
+    }
+
+    emitAdaptiveUpdate(context, layout) {
+        if (typeof this.marketplaceHooks.onAdaptiveUpdate === 'function') {
+            this.marketplaceHooks.onAdaptiveUpdate({ context, layout, design: this.activeDesignSpec });
+        }
+    }
+
+    setVariation(index) {
+        super.setVariation(index);
+        this.syncDesignSpec();
+    }
+
+    syncDesignSpec() {
+        const variationName = this.variationManager.getVariationName(this.currentVariation);
+        this.activeDesignSpec = this.designLanguageManager.getDesignSpec(variationName);
+        this.telemetry.track('design.spec.activated', {
+            variation: variationName,
+            pattern: this.activeDesignSpec.pattern?.id,
+            tier: this.activeDesignSpec.monetization.tier
+        });
+
+        if (typeof this.marketplaceHooks.onPatternChange === 'function') {
+            this.marketplaceHooks.onPatternChange(this.activeDesignSpec);
+        }
+    }
+
+    exportMarketplaceCatalog() {
+        return this.designLanguageManager.exportMarketplaceCatalog();
+    }
+
+    dispose() {
+        this.telemetry.stop();
+        this.sensoryBridge.stop();
+    }
+}
+

--- a/src/core/AdaptiveSDK.js
+++ b/src/core/AdaptiveSDK.js
@@ -1,0 +1,64 @@
+import { AdaptiveInterfaceEngine } from './AdaptiveInterfaceEngine.js';
+
+export function createAdaptiveSDK(config = {}) {
+    const telemetryOptions = { ...(config.telemetry || {}) };
+    if (config.replaceDefaultProviders) {
+        telemetryOptions.useDefaultProvider = false;
+    }
+
+    const engine = new AdaptiveInterfaceEngine({
+        sensory: config.sensory,
+        layout: config.layout,
+        design: config.design,
+        telemetry: telemetryOptions,
+        marketplaceHooks: config.marketplaceHooks
+    });
+
+    if (Array.isArray(config.layoutStrategies)) {
+        engine.layoutSynthesizer.clearStrategies();
+        for (const strategy of config.layoutStrategies) {
+            engine.registerLayoutStrategy(strategy);
+        }
+    }
+
+    if (Array.isArray(config.layoutAnnotations)) {
+        engine.layoutSynthesizer.clearAnnotations();
+        for (const annotation of config.layoutAnnotations) {
+            engine.registerLayoutAnnotation(annotation);
+        }
+    }
+
+    if (Array.isArray(config.telemetryProviders)) {
+        if (config.replaceDefaultProviders ?? false) {
+            engine.telemetry.providers = new Map();
+        }
+        for (const provider of config.telemetryProviders) {
+            engine.registerTelemetryProvider(provider);
+        }
+    }
+
+    if (config.sensorSchemas) {
+        if (Array.isArray(config.sensorSchemas)) {
+            for (const entry of config.sensorSchemas) {
+                if (entry && typeof entry === 'object' && entry.type && entry.schema) {
+                    engine.registerSensorSchema(entry.type, entry.schema);
+                }
+            }
+        } else if (typeof config.sensorSchemas === 'object') {
+            for (const [type, schema] of Object.entries(config.sensorSchemas)) {
+                engine.registerSensorSchema(type, schema);
+            }
+        }
+    }
+
+    return {
+        engine,
+        sensoryBridge: engine.sensoryBridge,
+        layoutSynthesizer: engine.layoutSynthesizer,
+        telemetry: engine.telemetry,
+        registerLayoutStrategy: engine.registerLayoutStrategy.bind(engine),
+        registerLayoutAnnotation: engine.registerLayoutAnnotation.bind(engine),
+        registerTelemetryProvider: engine.registerTelemetryProvider.bind(engine),
+        registerSensorSchema: engine.registerSensorSchema.bind(engine)
+    };
+}

--- a/src/features/DesignLanguageManager.js
+++ b/src/features/DesignLanguageManager.js
@@ -1,0 +1,85 @@
+import { InterfacePatternRegistry } from '../ui/adaptive/InterfacePatternRegistry.js';
+
+/**
+ * DesignLanguageManager
+ * ------------------------------------------------------------
+ * Binds the holographic variation system to adaptive interface patterns,
+ * enabling UI-first workflows while preserving the expressive geometry core.
+ */
+export class DesignLanguageManager {
+    constructor(engine, options = {}) {
+        this.engine = engine;
+        this.registry = new InterfacePatternRegistry(options.patterns);
+        this.languages = new Map();
+        this.activeLanguage = options.defaultLanguage || 'default';
+
+        this.registerLanguage('default', {
+            name: 'Default Adaptive UI',
+            description: 'Base wearable-ready interface mapping built on VIB34D polytopes.',
+            mappings: new Map([
+                ['TETRAHEDRON LATTICE 1', 'neuro-glance-feed'],
+                ['HYPERCUBE LATTICE 2', 'holo-command-ring'],
+                ['SPHERE LATTICE 3', 'biometric-rituals']
+            ])
+        });
+    }
+
+    registerLanguage(id, descriptor) {
+        this.languages.set(id, {
+            name: descriptor.name,
+            description: descriptor.description,
+            mappings: descriptor.mappings instanceof Map ? descriptor.mappings : new Map(Object.entries(descriptor.mappings || {}))
+        });
+    }
+
+    setActiveLanguage(id) {
+        if (this.languages.has(id)) {
+            this.activeLanguage = id;
+        } else {
+            throw new Error(`Design language ${id} not registered`);
+        }
+    }
+
+    getActiveLanguage() {
+        return this.languages.get(this.activeLanguage);
+    }
+
+    getDesignSpec(variationName) {
+        const language = this.getActiveLanguage();
+        const patternId = language?.mappings.get(variationName) || 'neuro-glance-feed';
+        const pattern = this.registry.getPattern(patternId);
+        return {
+            pattern,
+            monetization: this.buildMonetizationDescriptor(patternId),
+            integration: this.buildIntegrationDescriptor(patternId)
+        };
+    }
+
+    buildMonetizationDescriptor(patternId) {
+        const pattern = this.registry.getPattern(patternId);
+        if (!pattern) return { tier: 'starter', license: 'community' };
+        return {
+            tier: pattern.subscriptionTier,
+            license: pattern.subscriptionTier === 'enterprise' ? 'floating-enterprise' : 'seat-based',
+            upsell: pattern.subscriptionTier === 'starter' ? 'pro-upgrade' : null
+        };
+    }
+
+    buildIntegrationDescriptor(patternId) {
+        const pattern = this.registry.getPattern(patternId);
+        const designTokens = {
+            color: pattern?.components?.includes('glanceable-card') ? 'glance' : 'ambient',
+            motion: pattern?.components?.includes('adaptive-controls') ? 'command' : 'flow'
+        };
+        return {
+            figmaPlugin: `vib34d-${patternId}`,
+            webflowPackage: `@vib34d/${patternId}`,
+            designTokens
+        };
+    }
+
+    exportMarketplaceCatalog() {
+        return this.registry.exportForMarketplace();
+    }
+}
+

--- a/src/product/ProductTelemetryHarness.js
+++ b/src/product/ProductTelemetryHarness.js
@@ -1,0 +1,109 @@
+import { ConsoleTelemetryProvider } from './telemetry/ConsoleTelemetryProvider.js';
+
+export class ProductTelemetryHarness {
+    constructor(options = {}) {
+        this.enabled = options.enabled ?? true;
+        this.licenseKey = options.licenseKey || null;
+        this.flushInterval = options.flushInterval || 10000;
+        this.flushHandle = null;
+        this.buffer = [];
+
+        this.dataMinimization = {
+            omitLicense: options.dataMinimization?.omitLicense ?? false,
+            allowedFields: options.dataMinimization?.allowedFields,
+            anonymize: options.dataMinimization?.anonymize ?? false
+        };
+
+        this.providers = new Map();
+        if (options.useDefaultProvider !== false) {
+            this.registerProvider(new ConsoleTelemetryProvider(options.consoleProvider || {}));
+        }
+
+        (options.providers || []).forEach(provider => this.registerProvider(provider));
+    }
+
+    registerProvider(provider) {
+        this.providers.set(provider.id, provider);
+    }
+
+    removeProvider(id) {
+        this.providers.delete(id);
+    }
+
+    identify(identity, traits = {}) {
+        if (!this.enabled) return;
+        const sanitizedTraits = this.sanitizePayload(traits);
+        for (const provider of this.providers.values()) {
+            provider.identify?.(identity, sanitizedTraits);
+        }
+    }
+
+    track(event, payload = {}) {
+        if (!this.enabled) return;
+        const sanitizedPayload = this.sanitizePayload(payload);
+        const record = {
+            event,
+            payload: sanitizedPayload,
+            licenseKey: this.dataMinimization.omitLicense ? undefined : this.licenseKey,
+            timestamp: new Date().toISOString()
+        };
+        this.buffer.push(record);
+        for (const provider of this.providers.values()) {
+            provider.track?.(event, record);
+        }
+    }
+
+    sanitizePayload(payload) {
+        if (!payload || typeof payload !== 'object') return payload;
+        const clone = { ...payload };
+
+        if (this.dataMinimization.allowedFields) {
+            const filtered = {};
+            for (const key of this.dataMinimization.allowedFields) {
+                if (key in clone) {
+                    filtered[key] = clone[key];
+                }
+            }
+            return filtered;
+        }
+
+        if (this.dataMinimization.anonymize) {
+            delete clone.userId;
+            delete clone.identity;
+            delete clone.email;
+        }
+
+        return clone;
+    }
+
+    attachLicense(licenseKey) {
+        this.licenseKey = licenseKey;
+    }
+
+    start() {
+        if (!this.enabled || this.flushHandle) return;
+        this.flushHandle = setInterval(() => this.flush(), this.flushInterval);
+    }
+
+    stop() {
+        if (this.flushHandle) {
+            clearInterval(this.flushHandle);
+            this.flushHandle = null;
+        }
+    }
+
+    async flush() {
+        if (!this.enabled) return;
+        const pending = [];
+        for (const provider of this.providers.values()) {
+            const result = provider.flush?.();
+            if (result instanceof Promise) {
+                pending.push(result);
+            }
+        }
+        this.buffer = [];
+        if (pending.length) {
+            await Promise.allSettled(pending);
+        }
+    }
+}

--- a/src/product/telemetry/ConsoleTelemetryProvider.js
+++ b/src/product/telemetry/ConsoleTelemetryProvider.js
@@ -1,0 +1,33 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class ConsoleTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: 'console', metadata: { storage: 'memory', ...options.metadata } });
+        this.events = [];
+        this.identities = [];
+        this.log = options.log ?? false;
+    }
+
+    identify(identity, traits = {}) {
+        const record = { identity, traits, timestamp: Date.now() };
+        this.identities.push(record);
+        if (this.log) {
+            console.info('[ConsoleTelemetryProvider] identify', record);
+        }
+    }
+
+    track(event, payload) {
+        const record = { event, payload, timestamp: Date.now() };
+        this.events.push(record);
+        if (this.log) {
+            console.info('[ConsoleTelemetryProvider] track', record);
+        }
+    }
+
+    flush() {
+        if (this.log && this.events.length) {
+            console.table(this.events);
+        }
+        this.events = [];
+    }
+}

--- a/src/product/telemetry/HttpTelemetryProvider.js
+++ b/src/product/telemetry/HttpTelemetryProvider.js
@@ -1,0 +1,37 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class HttpTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: 'http', metadata: { storage: 'remote', ...options.metadata } });
+        this.endpoint = options.endpoint;
+        this.headers = options.headers || { 'Content-Type': 'application/json' };
+        this.queue = [];
+    }
+
+    identify(identity, traits = {}) {
+        this.queue.push({ type: 'identify', identity, traits, timestamp: Date.now() });
+    }
+
+    track(event, payload) {
+        this.queue.push({ type: 'track', event, payload, timestamp: Date.now() });
+    }
+
+    async flush() {
+        if (!this.endpoint || this.queue.length === 0) {
+            this.queue = [];
+            return;
+        }
+
+        const payload = { events: this.queue };
+        this.queue = [];
+        try {
+            await fetch(this.endpoint, {
+                method: 'POST',
+                headers: this.headers,
+                body: JSON.stringify(payload)
+            });
+        } catch (error) {
+            console.warn('[HttpTelemetryProvider] Failed to deliver telemetry', error);
+        }
+    }
+}

--- a/src/product/telemetry/PartnerTelemetryProvider.js
+++ b/src/product/telemetry/PartnerTelemetryProvider.js
@@ -1,0 +1,20 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class PartnerTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: options.id || 'partner', metadata: { storage: 'external', partner: options.partner || 'unspecified', ...options.metadata } });
+        this.forward = options.forward ?? (() => Promise.resolve());
+    }
+
+    identify(identity, traits = {}) {
+        return this.forward({ type: 'identify', identity, traits, timestamp: Date.now() });
+    }
+
+    track(event, payload) {
+        return this.forward({ type: 'track', event, payload, timestamp: Date.now() });
+    }
+
+    flush() {
+        return this.forward({ type: 'flush', timestamp: Date.now() });
+    }
+}

--- a/src/product/telemetry/TelemetryProvider.js
+++ b/src/product/telemetry/TelemetryProvider.js
@@ -1,0 +1,15 @@
+export class TelemetryProvider {
+    constructor({ id, metadata = {} } = {}) {
+        if (!id) {
+            throw new Error('TelemetryProvider requires an `id`.');
+        }
+        this.id = id;
+        this.metadata = metadata;
+    }
+
+    identify() {}
+
+    track() {}
+
+    flush() {}
+}

--- a/src/ui/adaptive/InterfacePatternRegistry.js
+++ b/src/ui/adaptive/InterfacePatternRegistry.js
@@ -1,0 +1,92 @@
+/**
+ * InterfacePatternRegistry
+ * ------------------------------------------------------------
+ * Catalogues adaptive UI patterns that can be rendered by the engine. These
+ * patterns expose metadata for monetizable add-ons and integration with design
+ * tooling.
+ */
+
+const DEFAULT_PATTERNS = [
+    {
+        id: 'neuro-glance-feed',
+        name: 'Neuro Glance Feed',
+        category: 'perception',
+        subscriptionTier: 'pro',
+        description: 'Micro-summaries that respond to attention bursts and biometric calmness.',
+        components: ['glanceable-card', 'pulse-strip'],
+        telemetry: {
+            trackEngagement: true,
+            metrics: ['dwell', 'confidence']
+        }
+    },
+    {
+        id: 'holo-command-ring',
+        name: 'Holo Command Ring',
+        category: 'interaction',
+        subscriptionTier: 'enterprise',
+        description: 'Circular intent-driven command palette for neural or gestural activation.',
+        components: ['adaptive-controls', 'intent-feedback'],
+        telemetry: {
+            trackEngagement: true,
+            metrics: ['activation', 'latency']
+        }
+    },
+    {
+        id: 'biometric-rituals',
+        name: 'Biometric Rituals',
+        category: 'wellness',
+        subscriptionTier: 'starter',
+        description: 'Ambient ambient rituals that respond to stress deltas and lighting changes.',
+        components: ['ambient-indicator', 'environmental-visualizer'],
+        telemetry: {
+            trackEngagement: false,
+            metrics: []
+        }
+    }
+];
+
+export class InterfacePatternRegistry {
+    constructor(initialPatterns = DEFAULT_PATTERNS) {
+        this.patterns = new Map();
+        initialPatterns.forEach(pattern => this.patterns.set(pattern.id, pattern));
+    }
+
+    addPattern(pattern) {
+        if (!pattern?.id) {
+            throw new Error('Pattern must include an id');
+        }
+        this.patterns.set(pattern.id, pattern);
+    }
+
+    removePattern(id) {
+        this.patterns.delete(id);
+    }
+
+    getPattern(id) {
+        return this.patterns.get(id) || null;
+    }
+
+    listPatterns(filter = {}) {
+        const entries = Array.from(this.patterns.values());
+        const { category, subscriptionTier } = filter;
+        return entries.filter(pattern => {
+            const matchesCategory = category ? pattern.category === category : true;
+            const matchesTier = subscriptionTier ? pattern.subscriptionTier === subscriptionTier : true;
+            return matchesCategory && matchesTier;
+        });
+    }
+
+    exportForMarketplace() {
+        return this.listPatterns().map(pattern => ({
+            id: pattern.id,
+            name: pattern.name,
+            tier: pattern.subscriptionTier,
+            metadata: {
+                description: pattern.description,
+                components: pattern.components,
+                telemetry: pattern.telemetry
+            }
+        }));
+    }
+}
+

--- a/src/ui/adaptive/SensoryInputBridge.js
+++ b/src/ui/adaptive/SensoryInputBridge.js
@@ -1,0 +1,250 @@
+/**
+ * SensoryInputBridge
+ * ------------------------------------------------------------
+ * Normalizes heterogeneous sensor and intent signals (eye tracking, neural
+ * gestures, biometrics, ambient context) into a common semantic layer that the
+ * adaptive interface engine can consume. Designed to be extended with
+ * wearables-specific adapters and remote data streams.
+ */
+
+import { SensorSchemaRegistry } from './sensors/SensorSchemaRegistry.js';
+
+export class SensoryInputBridge {
+    constructor(options = {}) {
+        const {
+            pollingInterval = 16,
+            decayHalfLife = 2800,
+            confidenceThreshold = 0.35,
+            schemaRegistry,
+            schemas
+        } = options;
+
+        this.pollingInterval = pollingInterval;
+        this.decayHalfLife = decayHalfLife;
+        this.confidenceThreshold = confidenceThreshold;
+
+        if (schemaRegistry instanceof SensorSchemaRegistry) {
+            this.schemaRegistry = schemaRegistry;
+        } else {
+            this.schemaRegistry = new SensorSchemaRegistry({ schemas });
+        }
+
+        this.channels = new Map();
+        this.subscribers = new Map();
+        this.adapters = new Map();
+        this.decayTimers = new Map();
+
+        this.state = {
+            focusVector: { x: 0.5, y: 0.5, depth: 0.3 },
+            intentionVector: { x: 0, y: 0, z: 0, w: 0 },
+            engagementLevel: 0.4,
+            biometricStress: 0.2,
+            gestureIntent: null,
+            environment: {
+                luminance: 0.5,
+                noiseLevel: 0.2,
+                motion: 0.1
+            },
+            updatedAt: performance.now()
+        };
+
+        this.loopHandle = null;
+    }
+
+    /**
+     * Registers a new sensor adapter. Adapters must implement a `read()` method
+     * that resolves with `{ confidence, payload }`.
+     */
+    registerAdapter(type, adapter) {
+        this.adapters.set(type, adapter);
+        if (!this.channels.has(type)) {
+            this.channels.set(type, []);
+        }
+    }
+
+    /**
+     * Subscribe to semantic updates.
+     */
+    subscribe(channel, callback) {
+        if (!this.subscribers.has(channel)) {
+            this.subscribers.set(channel, new Set());
+        }
+        this.subscribers.get(channel).add(callback);
+        return () => this.unsubscribe(channel, callback);
+    }
+
+    unsubscribe(channel, callback) {
+        const set = this.subscribers.get(channel);
+        if (!set) return;
+        set.delete(callback);
+    }
+
+    /**
+     * Manual ingestion hook for environments that push data instead of polling.
+     */
+    ingest(type, payload, confidence = 1) {
+        this.processSample(type, { confidence, payload });
+    }
+
+    /**
+     * Begin continuous polling of registered adapters.
+     */
+    start() {
+        if (this.loopHandle) return;
+        const loop = async () => {
+            for (const [type, adapter] of this.adapters) {
+                try {
+                    const sample = await adapter.read();
+                    if (sample) {
+                        this.processSample(type, sample);
+                    }
+                } catch (error) {
+                    console.warn(`[SensoryInputBridge] Adapter read failed for ${type}`, error);
+                }
+            }
+            this.loopHandle = setTimeout(loop, this.pollingInterval);
+        };
+        loop();
+    }
+
+    stop() {
+        if (this.loopHandle) {
+            clearTimeout(this.loopHandle);
+            this.loopHandle = null;
+        }
+    }
+
+    processSample(type, sample) {
+        if (!sample || typeof sample.confidence !== 'number') return;
+        if (sample.confidence < this.confidenceThreshold) return;
+
+        const now = performance.now();
+        const { payload: sanitizedPayload, issues } = this.schemaRegistry.validate(type, sample.payload);
+
+        if (issues.length > 0) {
+            console.warn(`[SensoryInputBridge] Schema validation issues for ${type}`, issues);
+        }
+
+        this.channels.get(type)?.push({ ...sample, payload: sanitizedPayload, issues, receivedAt: now });
+        this.applySemanticMapping(type, sanitizedPayload, sample.confidence, now);
+    }
+
+    applySemanticMapping(type, payload, confidence, timestamp) {
+        switch (type) {
+            case 'eye-tracking':
+                this.updateFocus(payload, confidence, timestamp);
+                break;
+            case 'neural-intent':
+                this.updateIntention(payload, confidence, timestamp);
+                break;
+            case 'biometric':
+                this.updateBiometrics(payload, confidence, timestamp);
+                break;
+            case 'ambient':
+                this.updateEnvironment(payload, confidence, timestamp);
+                break;
+            case 'gesture':
+                this.updateGestures(payload, confidence, timestamp);
+                break;
+            default:
+                // Allow custom adapters to emit semantic channel names directly
+                this.emit(type, { payload, confidence, timestamp });
+                break;
+        }
+    }
+
+    updateFocus(payload, confidence, timestamp) {
+        const { x = 0.5, y = 0.5, depth = 0.3 } = payload || {};
+        this.state.focusVector = {
+            x: this.lerp(this.state.focusVector.x, x, confidence),
+            y: this.lerp(this.state.focusVector.y, y, confidence),
+            depth: this.lerp(this.state.focusVector.depth, depth, confidence)
+        };
+        this.state.updatedAt = timestamp;
+        this.emit('focus', this.state.focusVector);
+        this.scheduleDecay('focus');
+    }
+
+    updateIntention(payload, confidence, timestamp) {
+        const { x = 0, y = 0, z = 0, w = 0, engagement = 0.4 } = payload || {};
+        this.state.intentionVector = {
+            x: this.lerp(this.state.intentionVector.x, x, confidence),
+            y: this.lerp(this.state.intentionVector.y, y, confidence),
+            z: this.lerp(this.state.intentionVector.z, z, confidence),
+            w: this.lerp(this.state.intentionVector.w, w, confidence)
+        };
+        this.state.engagementLevel = this.lerp(this.state.engagementLevel, engagement, confidence);
+        this.state.updatedAt = timestamp;
+        this.emit('intention', this.state.intentionVector);
+        this.emit('engagement', this.state.engagementLevel);
+        this.scheduleDecay('intention');
+        this.scheduleDecay('engagement');
+    }
+
+    updateBiometrics(payload, confidence, timestamp) {
+        const { stress = 0.2, heartRate = 68, temperature = 36.4 } = payload || {};
+        this.state.biometricStress = this.lerp(this.state.biometricStress, stress, confidence);
+        this.state.updatedAt = timestamp;
+        this.emit('biometrics', { stress: this.state.biometricStress, heartRate, temperature });
+        this.scheduleDecay('biometrics');
+    }
+
+    updateEnvironment(payload, confidence, timestamp) {
+        const { luminance = 0.5, noiseLevel = 0.2, motion = 0.1 } = payload || {};
+        this.state.environment = {
+            luminance: this.lerp(this.state.environment.luminance, luminance, confidence),
+            noiseLevel: this.lerp(this.state.environment.noiseLevel, noiseLevel, confidence),
+            motion: this.lerp(this.state.environment.motion, motion, confidence)
+        };
+        this.state.updatedAt = timestamp;
+        this.emit('environment', this.state.environment);
+        this.scheduleDecay('environment');
+    }
+
+    updateGestures(payload, confidence, timestamp) {
+        const { intent = null, vector = { x: 0, y: 0, z: 0 } } = payload || {};
+        this.state.gestureIntent = intent;
+        this.state.updatedAt = timestamp;
+        this.emit('gesture', { intent, vector, confidence });
+        this.scheduleDecay('gesture');
+    }
+
+    scheduleDecay(channel) {
+        if (this.decayTimers.has(channel)) {
+            clearTimeout(this.decayTimers.get(channel));
+        }
+        const timeout = setTimeout(() => {
+            this.emit(`${channel}:decay`, { channel, timestamp: performance.now() });
+        }, this.decayHalfLife);
+        this.decayTimers.set(channel, timeout);
+    }
+
+    emit(channel, payload) {
+        const listeners = this.subscribers.get(channel);
+        if (!listeners) return;
+        for (const callback of listeners) {
+            try {
+                callback(payload);
+            } catch (error) {
+                console.error(`[SensoryInputBridge] subscriber error on ${channel}`, error);
+            }
+        }
+    }
+
+    lerp(start, end, alpha) {
+        return start + (end - start) * alpha;
+    }
+
+    getSnapshot() {
+        return { ...this.state };
+    }
+
+    registerSchema(type, schema) {
+        this.schemaRegistry.register(type, schema);
+    }
+
+    getSchemaRegistry() {
+        return this.schemaRegistry;
+    }
+}
+

--- a/src/ui/adaptive/SpatialLayoutSynthesizer.js
+++ b/src/ui/adaptive/SpatialLayoutSynthesizer.js
@@ -1,0 +1,126 @@
+import { FocusWeightedStrategy } from './strategies/FocusWeightedStrategy.js';
+import { PeripheralHandoffStrategy } from './strategies/PeripheralHandoffStrategy.js';
+import { HapticFallbackStrategy } from './strategies/HapticFallbackStrategy.js';
+import { StressAlertAnnotation } from './annotations/StressAlertAnnotation.js';
+
+const DEFAULT_SURFACES = [
+    { id: 'primary', curvature: 0.12, visibility: 1 },
+    { id: 'peripheral', curvature: 0.38, visibility: 0.6 },
+    { id: 'ambient', curvature: 0.72, visibility: 0.45 }
+];
+
+export class SpatialLayoutSynthesizer {
+    constructor(options = {}) {
+        const {
+            surfaces = DEFAULT_SURFACES,
+            strategies = [],
+            annotations = [],
+            useDefaultStrategies = true,
+            useDefaultAnnotations = true
+        } = options;
+
+        this.surfaces = surfaces.map(surface => ({ ...surface }));
+        this.strategies = [];
+        this.annotations = [];
+
+        if (useDefaultStrategies) {
+            this.registerStrategy(new FocusWeightedStrategy(options.focusStrategy || {}));
+            this.registerStrategy(new PeripheralHandoffStrategy(options.peripheralStrategy || {}));
+            this.registerStrategy(new HapticFallbackStrategy(options.hapticStrategy || {}));
+        }
+
+        strategies.forEach(strategy => this.registerStrategy(strategy));
+
+        if (useDefaultAnnotations) {
+            this.registerAnnotation(new StressAlertAnnotation(options.stressAnnotation || {}));
+        }
+
+        annotations.forEach(annotation => this.registerAnnotation(annotation));
+    }
+
+    registerStrategy(strategy) {
+        this.strategies = [...this.strategies.filter(item => item.id !== strategy.id), strategy]
+            .sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100));
+    }
+
+    registerAnnotation(annotation) {
+        this.annotations = [...this.annotations.filter(item => item.id !== annotation.id), annotation]
+            .sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100));
+    }
+
+    clearStrategies() {
+        this.strategies = [];
+    }
+
+    clearAnnotations() {
+        this.annotations = [];
+    }
+
+    generateLayout(context = {}) {
+        const shared = {};
+        const layout = this.createBaseLayout();
+
+        for (const strategy of this.strategies) {
+            strategy.prepare?.({ context, layout, shared, surfaces: this.surfaces });
+        }
+
+        for (const strategy of this.strategies) {
+            strategy.compose?.({ context, layout, shared, surfaces: this.surfaces });
+        }
+
+        layout.annotations = this.resolveAnnotations({ context, layout, shared });
+
+        return layout;
+    }
+
+    resolveAnnotations({ context, layout, shared }) {
+        const appliedIds = new Set();
+        const annotations = [];
+
+        for (const annotation of this.annotations) {
+            const dependenciesSatisfied = annotation.dependsOn?.every(dep => appliedIds.has(dep)) ?? true;
+            if (!dependenciesSatisfied) continue;
+
+            const shouldApply = annotation.shouldApply?.({ context, layout, shared }) ?? true;
+            if (!shouldApply) continue;
+
+            try {
+                const built = annotation.build?.({ context, layout, shared });
+                if (built) {
+                    annotations.push({ id: annotation.id, ...built });
+                    appliedIds.add(annotation.id);
+                }
+            } catch (error) {
+                console.warn(`[SpatialLayoutSynthesizer] Annotation ${annotation.id} failed`, error);
+            }
+        }
+
+        return annotations;
+    }
+
+    createBaseLayout() {
+        return {
+            intensity: 0.5,
+            zones: this.surfaces.map(surface => ({
+                id: surface.id,
+                curvature: surface.curvature,
+                visibility: surface.visibility,
+                occupancy: 0.45,
+                layeringDepth: surface.id === 'primary' ? 0.18 : surface.id === 'peripheral' ? 0.34 : 0.6,
+                recommendedComponents: []
+            })),
+            motion: {
+                velocity: 0,
+                bias: { x: 0, y: 0, z: 0 },
+                easing: 'ease-in-out'
+            },
+            typographyScale: 1,
+            colorAdaptation: {
+                hueShift: 180,
+                saturation: 60,
+                lightness: 48
+            },
+            annotations: []
+        };
+    }
+}

--- a/src/ui/adaptive/annotations/LayoutAnnotation.js
+++ b/src/ui/adaptive/annotations/LayoutAnnotation.js
@@ -1,0 +1,18 @@
+export class LayoutAnnotation {
+    constructor({ id, priority = 100, dependsOn = [] } = {}) {
+        if (!id) {
+            throw new Error('LayoutAnnotation requires an `id`.');
+        }
+        this.id = id;
+        this.priority = priority;
+        this.dependsOn = dependsOn;
+    }
+
+    shouldApply() {
+        return true;
+    }
+
+    build() {
+        return null;
+    }
+}

--- a/src/ui/adaptive/annotations/StressAlertAnnotation.js
+++ b/src/ui/adaptive/annotations/StressAlertAnnotation.js
@@ -1,0 +1,25 @@
+import { LayoutAnnotation } from './LayoutAnnotation.js';
+
+export class StressAlertAnnotation extends LayoutAnnotation {
+    constructor(options = {}) {
+        super({ id: 'stress-alert', priority: options.priority ?? 20 });
+        this.threshold = options.threshold ?? 0.5;
+    }
+
+    shouldApply({ shared }) {
+        return (shared.focus?.stress ?? 0) >= this.threshold;
+    }
+
+    build({ context, shared }) {
+        const stress = shared.focus?.stress ?? context.biometricStress ?? 0;
+        return {
+            type: 'alert',
+            severity: stress > 0.75 ? 'critical' : 'elevated',
+            message: 'Biometric stress trending high – enable haptic reassurance.',
+            data: {
+                stress,
+                timestamp: Date.now()
+            }
+        };
+    }
+}

--- a/src/ui/adaptive/sensors/SensorSchemaRegistry.js
+++ b/src/ui/adaptive/sensors/SensorSchemaRegistry.js
@@ -1,0 +1,257 @@
+const clamp = (value, min, max) => {
+    if (typeof min === 'number' && value < min) {
+        return min;
+    }
+    if (typeof max === 'number' && value > max) {
+        return max;
+    }
+    return value;
+};
+
+export class SensorSchemaRegistry {
+    constructor(options = {}) {
+        const { registerDefaults = true, schemas } = options;
+        this.schemas = new Map();
+
+        if (registerDefaults) {
+            this.registerDefaultSchemas();
+        }
+
+        if (schemas) {
+            this.loadCustomSchemas(schemas);
+        }
+    }
+
+    register(type, schema) {
+        if (!type || typeof type !== 'string') {
+            throw new Error('SensorSchemaRegistry.register requires a sensor type string');
+        }
+
+        const normalizedSchema = typeof schema === 'function' ? { normalize: schema } : schema;
+        if (!normalizedSchema || typeof normalizedSchema.normalize !== 'function') {
+            throw new Error(`Sensor schema for ${type} must provide a normalize(payload) function`);
+        }
+
+        this.schemas.set(type, normalizedSchema);
+    }
+
+    validate(type, payload) {
+        const schema = this.schemas.get(type);
+        if (!schema) {
+            return { payload: payload ?? {}, issues: [] };
+        }
+
+        try {
+            const result = schema.normalize(payload ?? {}, this);
+            if (!result || typeof result !== 'object') {
+                return { payload: {}, issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }] };
+            }
+
+            if ('payload' in result) {
+                return {
+                    payload: result.payload ?? {},
+                    issues: Array.isArray(result.issues) ? result.issues : []
+                };
+            }
+
+            return { payload: result, issues: [] };
+        } catch (error) {
+            return {
+                payload: schema.fallback ?? {},
+                issues: [{ field: '*', code: 'schema-error', message: error.message }]
+            };
+        }
+    }
+
+    registerDefaultSchemas() {
+        this.register('eye-tracking', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    x: this.ensureNumber(payload.x, {
+                        field: 'x',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.5,
+                        issues
+                    }),
+                    y: this.ensureNumber(payload.y, {
+                        field: 'y',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.5,
+                        issues
+                    }),
+                    depth: this.ensureNumber(payload.depth, {
+                        field: 'depth',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.3,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { x: 0.5, y: 0.5, depth: 0.3 }
+        });
+
+        this.register('neural-intent', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    x: this.ensureNumber(payload.x, { field: 'x', min: -1, max: 1, defaultValue: 0, issues }),
+                    y: this.ensureNumber(payload.y, { field: 'y', min: -1, max: 1, defaultValue: 0, issues }),
+                    z: this.ensureNumber(payload.z, { field: 'z', min: -1, max: 1, defaultValue: 0, issues }),
+                    w: this.ensureNumber(payload.w, { field: 'w', min: -1, max: 1, defaultValue: 0, issues }),
+                    engagement: this.ensureNumber(payload.engagement, {
+                        field: 'engagement',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.4,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { x: 0, y: 0, z: 0, w: 0, engagement: 0.4 }
+        });
+
+        this.register('biometric', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    stress: this.ensureNumber(payload.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, issues }),
+                    heartRate: this.ensureInteger(payload.heartRate, {
+                        field: 'heartRate',
+                        min: 30,
+                        max: 220,
+                        defaultValue: 68,
+                        issues
+                    }),
+                    temperature: this.ensureNumber(payload.temperature, {
+                        field: 'temperature',
+                        min: 32,
+                        max: 40,
+                        defaultValue: 36.4,
+                        precision: 1,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { stress: 0.2, heartRate: 68, temperature: 36.4 }
+        });
+
+        this.register('ambient', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    luminance: this.ensureNumber(payload.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, issues }),
+                    noiseLevel: this.ensureNumber(payload.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, issues }),
+                    motion: this.ensureNumber(payload.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, issues })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 }
+        });
+
+        this.register('gesture', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    intent: this.ensureString(payload.intent, { field: 'intent', allowEmpty: true, issues }),
+                    vector: this.ensureVector(payload.vector, {
+                        field: 'vector',
+                        min: -1,
+                        max: 1,
+                        defaultValue: 0,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { intent: null, vector: { x: 0, y: 0, z: 0 } }
+        });
+    }
+
+    loadCustomSchemas(schemas) {
+        if (Array.isArray(schemas)) {
+            for (const entry of schemas) {
+                if (entry && typeof entry === 'object' && entry.type) {
+                    this.register(entry.type, entry.schema);
+                }
+            }
+            return;
+        }
+
+        if (typeof schemas === 'object') {
+            for (const [type, schema] of Object.entries(schemas)) {
+                this.register(type, schema);
+            }
+        }
+    }
+
+    ensureNumber(value, { field, min, max, defaultValue = 0, precision, issues }) {
+        let numberValue = Number(value);
+        if (value === undefined || value === null || Number.isNaN(numberValue)) {
+            issues?.push({ field, code: 'type', message: 'Expected numeric value.' });
+            numberValue = defaultValue;
+        }
+
+        const clamped = clamp(numberValue, min, max);
+        if (typeof min === 'number' && clamped === min && numberValue < min) {
+            issues?.push({ field, code: 'min', message: `Value below minimum; clamped to ${min}.` });
+        }
+        if (typeof max === 'number' && clamped === max && numberValue > max) {
+            issues?.push({ field, code: 'max', message: `Value above maximum; clamped to ${max}.` });
+        }
+
+        let finalValue = clamped;
+        if (typeof precision === 'number') {
+            const factor = 10 ** precision;
+            finalValue = Math.round(finalValue * factor) / factor;
+        }
+
+        return finalValue;
+    }
+
+    ensureInteger(value, { field, min, max, defaultValue = 0, issues }) {
+        const numberValue = this.ensureNumber(value, { field, min, max, defaultValue, issues });
+        return Math.round(numberValue);
+    }
+
+    ensureString(value, { field, allowEmpty = false, fallback = null, issues }) {
+        if (typeof value !== 'string') {
+            if (value == null) {
+                if (!allowEmpty) {
+                    issues?.push({ field, code: 'type', message: 'Expected string value.' });
+                }
+                return fallback;
+            }
+
+            try {
+                value = String(value);
+            } catch (error) {
+                issues?.push({ field, code: 'type', message: 'Value is not coercible to string.' });
+                return fallback;
+            }
+        }
+
+        const normalized = value.trim();
+        if (!allowEmpty && normalized.length === 0) {
+            issues?.push({ field, code: 'empty', message: 'String value cannot be empty.' });
+            return fallback;
+        }
+
+        return normalized.length === 0 ? fallback : normalized;
+    }
+
+    ensureVector(value, { field, min, max, defaultValue = 0, issues }) {
+        const base = value && typeof value === 'object' ? value : {};
+        return {
+            x: this.ensureNumber(base.x, { field: `${field}.x`, min, max, defaultValue, issues }),
+            y: this.ensureNumber(base.y, { field: `${field}.y`, min, max, defaultValue, issues }),
+            z: this.ensureNumber(base.z, { field: `${field}.z`, min, max, defaultValue, issues })
+        };
+    }
+}

--- a/src/ui/adaptive/strategies/FocusWeightedStrategy.js
+++ b/src/ui/adaptive/strategies/FocusWeightedStrategy.js
@@ -1,0 +1,84 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class FocusWeightedStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'focus-weighted', priority: options.priority ?? 10 });
+        this.focusAmplifier = options.focusAmplifier ?? 1.2;
+        this.engagementWeight = options.engagementWeight ?? 0.65;
+        this.motionSensitivity = options.motionSensitivity ?? 0.35;
+    }
+
+    prepare({ context, layout, shared }) {
+        const { focusVector = { x: 0.5, y: 0.5, depth: 0.3 }, engagementLevel = 0.4, biometricStress = 0 } = context;
+        const focusMagnitude = Math.sqrt(
+            Math.pow((focusVector.x ?? 0.5) - 0.5, 2) +
+            Math.pow((focusVector.y ?? 0.5) - 0.5, 2) +
+            Math.pow(((focusVector.depth ?? 0.3)) - 0.3, 2)
+        );
+        const invertedFocus = 1 - Math.min(focusMagnitude * this.focusAmplifier, 1);
+        const engagementBoost = engagementLevel * this.engagementWeight;
+        const stressPenalty = biometricStress * 0.45;
+        const intensity = Math.max(0.1, Math.min(1, invertedFocus + engagementBoost - stressPenalty));
+
+        layout.intensity = intensity;
+        layout.typographyScale = Math.max(0.8, 1.0 + engagementLevel * 0.15 - biometricStress * 0.1);
+
+        shared.focus = {
+            intensity,
+            stress: biometricStress
+        };
+    }
+
+    compose({ context, layout }) {
+        const { intentionVector = { x: 0, y: 0, z: 0, w: 0 }, gestureIntent, environment = { luminance: 0.4, noiseLevel: 0.2, motion: 0.2 } } = context;
+        const vectorMagnitude = Math.sqrt(
+            Math.pow(intentionVector.x ?? 0, 2) +
+            Math.pow(intentionVector.y ?? 0, 2) +
+            Math.pow(intentionVector.z ?? 0, 2) +
+            Math.pow(intentionVector.w ?? 0, 2)
+        );
+        const baseVelocity = Math.min(1, vectorMagnitude * this.motionSensitivity + 0.1);
+        layout.motion = {
+            velocity: baseVelocity,
+            bias: gestureIntent?.vector || { x: 0, y: 0, z: 0 },
+            easing: gestureIntent?.intent === 'hold' ? 'ease-out' : 'ease-in-out'
+        };
+
+        layout.zones = (layout.zones || []).map(zone => {
+            const visibility = (zone.visibility ?? 0.6) * (0.6 + layout.intensity * 0.4);
+            const luminanceCompensation = 1 - (environment.luminance ?? 0) * 0.3;
+            const noiseCompensation = 1 - (environment.noiseLevel ?? 0) * 0.2;
+            const occupancy = Math.max(0.1, Math.min(1, visibility * luminanceCompensation * noiseCompensation));
+
+            return {
+                ...zone,
+                occupancy,
+                layeringDepth: this.computeLayering(zone.id, layout.intensity),
+                recommendedComponents: this.recommendComponents(zone.id, layout.intensity)
+            };
+        });
+
+        const ambientInfluence = (environment.luminance ?? 0) * 0.5 + (environment.motion ?? 0) * 0.35;
+        const stressTint = (context.biometricStress ?? 0) * 12;
+        layout.colorAdaptation = {
+            hueShift: Math.round((ambientInfluence * 45 + 180) % 360),
+            saturation: Math.max(40, 75 - stressTint),
+            lightness: Math.max(30, 60 - (environment.luminance ?? 0) * 20)
+        };
+    }
+
+    computeLayering(zoneId, intensity) {
+        const base = zoneId === 'primary' ? 0.15 : zoneId === 'peripheral' ? 0.32 : 0.58;
+        return Math.min(1, base + intensity * 0.4);
+    }
+
+    recommendComponents(zoneId, intensity) {
+        if (zoneId === 'primary') {
+            return intensity > 0.65 ? ['holographic-panel', 'adaptive-controls'] : ['glanceable-card'];
+        }
+        if (zoneId === 'peripheral') {
+            return intensity > 0.5 ? ['ambient-indicator', 'intent-feedback'] : ['pulse-strip'];
+        }
+        return ['environmental-visualizer'];
+    }
+}

--- a/src/ui/adaptive/strategies/HapticFallbackStrategy.js
+++ b/src/ui/adaptive/strategies/HapticFallbackStrategy.js
@@ -1,0 +1,27 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class HapticFallbackStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'haptic-fallback', priority: options.priority ?? 40 });
+        this.activationStress = options.activationStress ?? 0.45;
+        this.minIntensity = options.minIntensity ?? 0.35;
+    }
+
+    compose({ layout, shared }) {
+        const stress = shared.focus?.stress ?? 0;
+        const intensity = layout.intensity ?? shared.focus?.intensity ?? 0.5;
+        if (stress < this.activationStress && intensity > this.minIntensity) {
+            return;
+        }
+
+        layout.zones = (layout.zones || []).map(zone => {
+            const updated = { ...zone };
+            updated.recommendedComponents = [...(zone.recommendedComponents || [])];
+            if (!updated.recommendedComponents.includes('haptic-pulse')) {
+                updated.recommendedComponents.push('haptic-pulse');
+            }
+            updated.layeringDepth = Math.min(1, (zone.layeringDepth ?? 0.4) + 0.12);
+            return updated;
+        });
+    }
+}

--- a/src/ui/adaptive/strategies/LayoutStrategy.js
+++ b/src/ui/adaptive/strategies/LayoutStrategy.js
@@ -1,0 +1,17 @@
+export class LayoutStrategy {
+    constructor({ id, priority = 100 } = {}) {
+        if (!id) {
+            throw new Error('LayoutStrategy requires an `id`.');
+        }
+        this.id = id;
+        this.priority = priority;
+    }
+
+    prepare() {
+        return undefined;
+    }
+
+    compose() {
+        return undefined;
+    }
+}

--- a/src/ui/adaptive/strategies/PeripheralHandoffStrategy.js
+++ b/src/ui/adaptive/strategies/PeripheralHandoffStrategy.js
@@ -1,0 +1,50 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class PeripheralHandoffStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'peripheral-handoff', priority: options.priority ?? 30 });
+        this.primaryBias = options.primaryBias ?? 0.6;
+        this.handoffThreshold = options.handoffThreshold ?? 0.55;
+    }
+
+    prepare({ context, shared }) {
+        shared.environment = context.environment || { luminance: 0.4, noiseLevel: 0.2 };
+    }
+
+    compose({ layout, shared }) {
+        if (!layout.zones) return;
+
+        const environment = shared.environment;
+        const intensity = shared.focus?.intensity ?? layout.intensity ?? 0.5;
+        const noiseInfluence = environment.noiseLevel ?? 0;
+        const luminanceInfluence = environment.luminance ?? 0;
+
+        const primary = layout.zones.find(zone => zone.id === 'primary');
+        const peripheral = layout.zones.find(zone => zone.id === 'peripheral');
+        const ambient = layout.zones.find(zone => zone.id === 'ambient');
+
+        if (!primary) return;
+
+        if (intensity > this.handoffThreshold && noiseInfluence > 0.25) {
+            const shift = Math.min(0.2, (intensity - this.handoffThreshold) * 0.4 + noiseInfluence * 0.1);
+            primary.occupancy = Math.max(0.35, primary.occupancy - shift);
+            if (peripheral) {
+                peripheral.occupancy = Math.min(0.95, peripheral.occupancy + shift * 0.7);
+            }
+            if (ambient) {
+                ambient.occupancy = Math.min(0.8, ambient.occupancy + shift * 0.3);
+            }
+        } else {
+            primary.occupancy = Math.max(this.primaryBias, primary.occupancy);
+        }
+
+        if (peripheral) {
+            peripheral.recommendedComponents = peripheral.recommendedComponents || [];
+            if (intensity < 0.45 && luminanceInfluence < 0.35) {
+                if (!peripheral.recommendedComponents.includes('glow-band')) {
+                    peripheral.recommendedComponents.push('glow-band');
+                }
+            }
+        }
+    }
+}

--- a/tests/vitest/sensory-input-bridge.test.js
+++ b/tests/vitest/sensory-input-bridge.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SensoryInputBridge } from '../../src/ui/adaptive/SensoryInputBridge.js';
+import { SensorSchemaRegistry } from '../../src/ui/adaptive/sensors/SensorSchemaRegistry.js';
+
+describe('SensoryInputBridge schema validation', () => {
+  let bridge;
+
+  beforeEach(() => {
+    bridge = new SensoryInputBridge({ confidenceThreshold: 0 });
+  });
+
+  it('clamps invalid focus payloads and emits sanitized values', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const focusUpdates = [];
+
+    bridge.subscribe('focus', payload => focusUpdates.push(payload));
+    bridge.ingest('eye-tracking', { x: 2.6, y: -0.4, depth: 'bad' }, 1);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Schema validation issues for eye-tracking'),
+      expect.any(Array)
+    );
+
+    const snapshot = bridge.getSnapshot();
+    expect(snapshot.focusVector.x).toBe(1);
+    expect(snapshot.focusVector.y).toBe(0);
+    expect(snapshot.focusVector.depth).toBeCloseTo(0.3);
+
+    expect(focusUpdates.at(-1)).toEqual({ x: 1, y: 0, depth: 0.3 });
+
+    warnSpy.mockRestore();
+  });
+
+  it('normalizes neural intent engagement and maintains engagement state', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    bridge.subscribe('engagement', () => {});
+    bridge.ingest('neural-intent', { x: '0.5', engagement: 1.7 }, 1);
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    const snapshot = bridge.getSnapshot();
+    expect(snapshot.intentionVector.x).toBeCloseTo(0.5);
+    expect(snapshot.engagementLevel).toBeCloseTo(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('supports runtime schema registration via registerSchema', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = new SensorSchemaRegistry({ registerDefaults: false });
+    const customBridge = new SensoryInputBridge({ schemaRegistry: registry, confidenceThreshold: 0 });
+
+    let emitted;
+    customBridge.subscribe('custom', payload => {
+      emitted = payload;
+    });
+
+    customBridge.registerSchema('custom', {
+      normalize: payload => {
+        const issues = [];
+        const numericValue = typeof payload.value === 'number' ? payload.value : 42;
+        if (typeof payload.value !== 'number') {
+          issues.push({ field: 'value', code: 'type' });
+        }
+        return { payload: { value: numericValue }, issues };
+      },
+      fallback: { value: 0 }
+    });
+
+    customBridge.ingest('custom', { value: 'abc' }, 1);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Schema validation issues for custom'),
+      expect.any(Array)
+    );
+    expect(emitted).toMatchObject({ payload: { value: 42 }, confidence: 1 });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/vitest/spatial-layout-synthesizer.test.js
+++ b/tests/vitest/spatial-layout-synthesizer.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SpatialLayoutSynthesizer } from '../../src/ui/adaptive/SpatialLayoutSynthesizer.js';
+import { LayoutStrategy } from '../../src/ui/adaptive/strategies/LayoutStrategy.js';
+import { LayoutAnnotation } from '../../src/ui/adaptive/annotations/LayoutAnnotation.js';
+
+const baseContext = {
+  focusVector: { x: 0.52, y: 0.47, depth: 0.28 },
+  intentionVector: { x: 0.1, y: 0.2, z: 0.05, w: 0.08 },
+  engagementLevel: 0.6,
+  biometricStress: 0.2,
+  gestureIntent: { intent: 'swipe', vector: { x: 0.3, y: 0.1, z: 0 } },
+  environment: { luminance: 0.4, noiseLevel: 0.1, motion: 0.2 }
+};
+
+class VelocityBoostStrategy extends LayoutStrategy {
+  constructor() {
+    super({ id: 'velocity-boost', priority: 1 });
+  }
+
+  prepare({ layout }) {
+    layout.intensity = 0.9;
+  }
+
+  compose({ layout }) {
+    layout.motion = {
+      velocity: 0.92,
+      bias: { x: 0.4, y: 0.1, z: 0 },
+      easing: 'ease-in'
+    };
+  }
+}
+
+class DebugAnnotation extends LayoutAnnotation {
+  constructor() {
+    super({ id: 'debug', priority: 1 });
+  }
+
+  shouldApply() {
+    return true;
+  }
+
+  build({ layout }) {
+    return { message: `intensity:${layout.intensity}` };
+  }
+}
+
+describe('SpatialLayoutSynthesizer', () => {
+  let synthesizer;
+
+  beforeEach(() => {
+    synthesizer = new SpatialLayoutSynthesizer();
+  });
+
+  it('generates layout with baseline zones and motion details', () => {
+    const layout = synthesizer.generateLayout(baseContext);
+
+    expect(layout.intensity).toBeGreaterThan(0);
+    expect(layout.intensity).toBeLessThanOrEqual(1);
+    expect(layout.zones).toHaveLength(3);
+    expect(layout.motion.velocity).toBeGreaterThan(0);
+    expect(['ease-in-out', 'ease-out']).toContain(layout.motion.easing);
+
+    const primaryZone = layout.zones.find(zone => zone.id === 'primary');
+    expect(primaryZone).toBeDefined();
+    expect(primaryZone.recommendedComponents.length).toBeGreaterThan(0);
+  });
+
+  it('supports runtime strategy swapping without touching core class', () => {
+    const customSynth = new SpatialLayoutSynthesizer({ useDefaultStrategies: false });
+    customSynth.registerStrategy(new VelocityBoostStrategy());
+
+    const layout = customSynth.generateLayout(baseContext);
+
+    expect(layout.intensity).toBe(0.9);
+    expect(layout.motion.velocity).toBeCloseTo(0.92);
+    expect(layout.motion.easing).toBe('ease-in');
+  });
+
+  it('supports annotations and guards against annotation failures', () => {
+    const annotation = new DebugAnnotation();
+    synthesizer.registerAnnotation(annotation);
+
+    const layout = synthesizer.generateLayout(baseContext);
+    expect(layout.annotations).toContainEqual({ id: 'debug', message: expect.stringContaining('intensity:') });
+
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    synthesizer.registerAnnotation(
+      new (class BrokenAnnotation extends LayoutAnnotation {
+        constructor() {
+          super({ id: 'broken' });
+        }
+        build() {
+          throw new Error('fail');
+        }
+      })()
+    );
+
+    const layoutWithFailure = synthesizer.generateLayout(baseContext);
+    expect(layoutWithFailure.annotations).toEqual(expect.arrayContaining([{ id: 'debug', message: expect.any(String) }]));
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Annotation broken failed'),
+      expect.any(Error)
+    );
+
+    consoleWarn.mockRestore();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/vitest/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html']
+    }
+  }
+});

--- a/wearable-designer.html
+++ b/wearable-designer.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VIB34D Adaptive Wearable Designer</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: radial-gradient(circle at 20% 20%, #101826, #04060b 65%);
+            --panel-bg: rgba(12, 18, 32, 0.85);
+            --accent: #4c9fff;
+            --muted: rgba(255, 255, 255, 0.55);
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Inter', system-ui;
+            background: var(--bg);
+            color: #f5f7fb;
+            height: 100vh;
+            display: grid;
+            grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.6fr);
+        }
+
+        .canvas-stack {
+            position: relative;
+            display: grid;
+            place-items: center;
+            overflow: hidden;
+        }
+
+        .canvas-stack canvas {
+            position: absolute;
+            width: 88vmin;
+            height: 88vmin;
+            max-width: 880px;
+            max-height: 880px;
+            border-radius: 28px;
+            backdrop-filter: blur(20px);
+        }
+
+        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.35; }
+        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.45; }
+        .canvas-stack canvas:nth-child(3) { mix-blend-mode: normal; }
+        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.6; }
+        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.8; }
+
+        aside {
+            padding: 32px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            background: linear-gradient(160deg, rgba(8, 10, 20, 0.9), rgba(12, 18, 32, 0.75));
+            border-left: 1px solid rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(24px);
+        }
+
+        .panel {
+            background: var(--panel-bg);
+            border-radius: 20px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            box-shadow: 0 20px 40px rgba(10, 20, 40, 0.35);
+        }
+
+        .panel h2 {
+            font-size: 1rem;
+            letter-spacing: 0.08em;
+            margin: 0 0 12px;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .metric-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .metric {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            background: rgba(255, 255, 255, 0.03);
+            padding: 12px 14px;
+            border-radius: 14px;
+        }
+
+        .metric span:first-child {
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+            color: var(--muted);
+        }
+
+        .metric span:last-child {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        .pattern-card {
+            display: grid;
+            gap: 12px;
+        }
+
+        .pattern-card h3 {
+            margin: 0;
+            font-size: 1.2rem;
+        }
+
+        .pattern-card p {
+            margin: 0;
+            color: rgba(255, 255, 255, 0.65);
+            line-height: 1.4;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            padding: 6px 10px;
+            border-radius: 999px;
+            background: rgba(76, 159, 255, 0.1);
+            color: var(--accent);
+        }
+
+        button {
+            background: rgba(76, 159, 255, 0.1);
+            border: 1px solid rgba(76, 159, 255, 0.3);
+            color: var(--accent);
+            padding: 12px 16px;
+            border-radius: 14px;
+            font-size: 0.85rem;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: rgba(76, 159, 255, 0.2);
+        }
+
+        .variation-controls {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .variation-controls input[type="range"] {
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div class="canvas-stack" id="canvasStack">
+        <canvas id="background-canvas"></canvas>
+        <canvas id="shadow-canvas"></canvas>
+        <canvas id="content-canvas"></canvas>
+        <canvas id="highlight-canvas"></canvas>
+        <canvas id="accent-canvas"></canvas>
+    </div>
+    <aside>
+        <section class="panel">
+            <h2>Adaptive Intent</h2>
+            <div class="metric-grid" id="intentMetrics">
+                <div class="metric"><span>Focus</span><span id="focusMetric">0.50</span></div>
+                <div class="metric"><span>Engagement</span><span id="engagementMetric">0.40</span></div>
+                <div class="metric"><span>Velocity</span><span id="velocityMetric">0.00</span></div>
+                <div class="metric"><span>Stress</span><span id="stressMetric">0.20</span></div>
+            </div>
+        </section>
+        <section class="panel">
+            <h2>Pattern Activation</h2>
+            <div class="pattern-card">
+                <span class="tag" id="patternTier">STARTER</span>
+                <h3 id="patternName">Neuro Glance Feed</h3>
+                <p id="patternDescription">Micro-summaries that respond to attention bursts and biometric calmness.</p>
+                <div class="tag" id="integrationTag">Figma: vib34d-neuro-glance-feed</div>
+            </div>
+        </section>
+        <section class="panel">
+            <h2>Variations</h2>
+            <div class="variation-controls">
+                <input type="range" min="0" max="99" value="0" id="variationSlider">
+                <button id="randomizeBtn">Randomize</button>
+            </div>
+            <p style="margin-top: 12px; color: rgba(255,255,255,0.6); font-size: 0.85rem;" id="variationLabel">1 - TETRAHEDRON LATTICE</p>
+        </section>
+    </aside>
+
+    <script type="module">
+        import { createAdaptiveSDK } from './src/core/AdaptiveSDK.js';
+        import { LayoutAnnotation } from './src/ui/adaptive/annotations/LayoutAnnotation.js';
+
+        const { engine, registerLayoutAnnotation } = createAdaptiveSDK({
+            telemetry: { enabled: false },
+            marketplaceHooks: {
+                onPatternChange: updatePatternPanel,
+                onAdaptiveUpdate: handleAdaptiveUpdate
+            }
+        });
+
+        registerLayoutAnnotation(new class extends LayoutAnnotation {
+            constructor() {
+                super({ id: 'demo-insight', priority: 5 });
+            }
+
+            shouldApply({ layout }) {
+                return layout.intensity > 0.7;
+            }
+
+            build({ layout }) {
+                return {
+                    type: 'insight',
+                    message: `High intent detected (${layout.intensity.toFixed(2)})`
+                };
+            }
+        }());
+
+        window.vib34dEngine = engine;
+
+        const variationSlider = document.getElementById('variationSlider');
+        const randomizeBtn = document.getElementById('randomizeBtn');
+        const variationLabel = document.getElementById('variationLabel');
+        const focusMetric = document.getElementById('focusMetric');
+        const engagementMetric = document.getElementById('engagementMetric');
+        const velocityMetric = document.getElementById('velocityMetric');
+        const stressMetric = document.getElementById('stressMetric');
+
+        variationSlider.addEventListener('input', (event) => {
+            const value = Number(event.target.value);
+            engine.setVariation(value);
+            variationLabel.textContent = `${value + 1} - ${engine.variationManager.getVariationName(value)}`;
+        });
+
+        randomizeBtn.addEventListener('click', () => {
+            engine.randomVariation();
+            variationSlider.value = engine.currentVariation;
+            variationLabel.textContent = `${engine.currentVariation + 1} - ${engine.variationManager.getVariationName(engine.currentVariation)}`;
+        });
+
+        function updatePatternPanel(spec) {
+            document.getElementById('patternTier').textContent = spec.monetization.tier.toUpperCase();
+            document.getElementById('patternName').textContent = spec.pattern?.name || 'Adaptive Pattern';
+            document.getElementById('patternDescription').textContent = spec.pattern?.description || 'Dynamic mapping ready for commercialization.';
+            document.getElementById('integrationTag').textContent = `Figma: ${spec.integration.figmaPlugin}`;
+        }
+
+        function handleAdaptiveUpdate({ context, layout }) {
+            focusMetric.textContent = context.focusVector.x.toFixed(2);
+            engagementMetric.textContent = context.engagementLevel.toFixed(2);
+            velocityMetric.textContent = layout.motion.velocity.toFixed(2);
+            stressMetric.textContent = context.biometricStress.toFixed(2);
+        }
+
+        document.addEventListener('pointermove', event => {
+            const x = event.clientX / window.innerWidth;
+            const y = event.clientY / window.innerHeight;
+            engine.sensoryBridge.ingest('eye-tracking', { x, y, depth: 0.25 + 0.15 * Math.sin(x * Math.PI) }, 0.9);
+            engine.sensoryBridge.ingest('neural-intent', { x: (x - 0.5) * 0.8, y: (0.5 - y) * 0.8, engagement: 0.5 + (0.5 - Math.abs(0.5 - x)) * 0.3 }, 0.7);
+        });
+
+        setInterval(() => {
+            const stress = 0.15 + Math.random() * 0.15;
+            engine.sensoryBridge.ingest('biometric', { stress, heartRate: 70 + Math.random() * 6 }, 0.6);
+            engine.sensoryBridge.ingest('ambient', { luminance: 0.4 + Math.random() * 0.2, motion: Math.random() * 0.3 }, 0.5);
+        }, 2400);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce a SensorSchemaRegistry with default gaze, neural, biometric, ambient, and gesture schemas plus runtime validation hooks in the SensoryInputBridge
- expose schema registration through AdaptiveInterfaceEngine/createAdaptiveSDK and document the new boundary in the README, architecture review, SDK proposal, tracker, and session log
- add Vitest coverage for sensor sanitization flows and record the completed backlog item for schema validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e42c1a9cbc83298976ba15f587c766