### PR TITLE
Add column order controls to performance layout

### DIFF
--- a/DOCS/PERFORMANCE_SUITE_DEVELOPMENT_NOTES.md
+++ b/DOCS/PERFORMANCE_SUITE_DEVELOPMENT_NOTES.md
@@ -1,0 +1,167 @@
+# Performance Suite Development Notes
+
+This memo documents every subsystem introduced while building the live Performance Suite, how
+those pieces collaborate on stage, and the follow-on ideas queued for future releases.
+It complements the reference guide by focusing on implementation intent and the rationale
+behind each addition.
+
+## Foundational Architecture
+
+### Parameter Management & Engine Hooks
+- **`src/core/Parameters.js`** was expanded with rich metadata (labels, tags, ranges,
+  curves) and change listeners so UI controllers can present readable names, validate
+  ranges, and broadcast updates without touching engine internals.
+- Engine shells (`src/core/Engine.js`, `src/core/CanvasManager.js`, and system-specific
+  subclasses) were adapted to hydrate the shared `PerformanceSuiteHost`, preserve state
+  across engine swaps, and accept live audio/theme/preset payloads triggered from the suite.
+
+### Shared Messaging Layer
+- **`src/ui/PerformanceHub.js`** exposes a tiny event bus that synchronizes pads, audio,
+  presets, themes, and planner cues. All UI modules publish and subscribe via the hub to
+  avoid direct coupling.
+- The hub is published globally through `PerformanceSuite` so external extensions (MIDI
+  bridges, OSC listeners, lighting rigs) can listen in or dispatch custom events.
+
+## Live Control Surface
+
+### Touch Pad Controller
+- **`src/ui/TouchPadController.js`** renders multi-touch pads with:
+  - Axis pickers backed by the parameter registry and a search/tag filter panel.
+  - Per-axis curve, smoothing, and inversion controls that pre-shape gesture data.
+  - Layout presets, template selector (Orbital Sculpt, Chromatic Wash, Geometry Chisel),
+    and pad count slider so rigs can swap between curated arrangements quickly.
+  - Import/export helpers that keep mappings portable across presets and shows.
+
+### Audio Reactivity Pipeline
+- **`src/ui/AudioReactivityPanel.js`** exposes mic/line-in routing, smoothing, gain,
+  beat detection, band weighting, and flourish triggers so the engine can modulate
+  parameters using live music analysis.
+- Engines receive reactivity payloads through `setLiveAudioSettings`, apply weighting per
+  band (bass/mid/treble/energy), and emit flourish hooks for choreographed bursts.
+
+### Hardware Bridge & MIDI Learn
+- **`src/ui/PerformanceMidiBridge.js`** requests Web MIDI access, lists connected inputs,
+  and lets performers “learn” hardware knobs/faders to any parameter in the registry.
+- Mappings persist locally, publish hub events (`hardware:midi-value`), and smooth incoming
+  CC values before converting them to engine-friendly ranges to prevent on-stage jumps.
+- The bridge feeds directly into `ParameterManager.setParameter`, letting tactile rigs sit
+  alongside multi-touch pads and audio-driven modulation.
+- **Earlier enhancement:** presets capture hardware mappings alongside pads/audio so tactile
+  rigs restore instantly when loading shows or planner cues.
+
+### Network / OSC Bridge
+- **`src/ui/PerformanceOscBridge.js`** opens a WebSocket connection to companion bridges or
+  OSC gateways so suite events (touch pads, audio reactivity, presets, show cues, themes,
+  hardware, and gestures) mirror to lighting desks or remote control rigs.
+- Operators can toggle which event families forward, define a namespace for OSC-style
+  addressing, enable auto-connect, and review a rolling message log to confirm traffic.
+- Heartbeat triggers allow quick connectivity tests while disconnected events queue in the log
+  for visibility, making it easier to diagnose when remote listeners fall offline mid-show.
+
+### Telemetry & Diagnostics Monitor
+- **`src/ui/PerformanceTelemetryPanel.js`** renders the new telemetry block that charts 4D
+  rotation vectors, dimensional blend, speed, chaos, and intensity with live normalization.
+- The panel listens to parameter change events plus hub pulses (`touchpad:update`,
+  `hardware:midi-value`, gesture playback, and cue triggers) to show which subsystem is
+  currently driving the engine.
+- Rotation energy and activity indices are trended in a short history list so operators can
+  confirm responsiveness during rehearsals or troubleshoot rigs mid-show.
+
+### Gesture Recorder & Flourish Library
+- **`src/ui/PerformanceGestureRecorder.js`** records touch pad and MIDI gestures with
+  timestamped events, smoothing, and replay. Takes are persisted, exported/imported,
+  and broadcast over the hub so extensions can mirror playback.
+- Recording status updates feed the suite status badge while playback re-injects parameter
+  values for quick flourish recall during shows.
+- Gestures can be assigned to show planner cues, letting timed sequences fire curated motion
+  sweeps alongside presets, playlists, and audio-reactive modulation.
+
+## Library & Playback Stack
+
+### Performance Preset Manager
+- **`src/ui/PerformancePresetManager.js`** snapshots the entire suite state—pads, audio,
+  show planner, theme palettes, and transition curves—into a persistent library with
+  playlist support, renaming, tagging, and summary badges.
+- Presets can be loaded without overriding the current theme when a cue specifically
+  instructs the suite to “hold current glow.”
+- **New in this revision:** gesture libraries are bundled with presets so live flourish
+  clips travel with shows, MIDI rigs, and pad layouts.
+
+### Show Planner & Cue Sequencer
+- **`src/ui/PerformanceShowPlanner.js`** choreographs live sets with tempo, beats-per-bar,
+  looping, cue stacks, notes, auto-advance, and keyboard shortcuts. Cues can trigger presets,
+  adopt preset palettes, enforce palette overrides, hold the active theme, and now trigger
+  specific gesture takes captured in the recorder.
+- Theme transitions (duration + easing) were threaded end-to-end so cues can define how the
+  glow fades between palettes.
+- **Earlier enhancement:** a timeline overview renders estimated runtime, beat totals,
+  per-cue progress bars, and highlights the currently running cue while surfacing preset accents
+  for at-a-glance navigation.
+- **New in this revision:** cue forms include gesture selectors that follow the recorder’s
+  library and auto-play flourishes when cues fire, whether manually or via auto-advance.
+
+## Theme & Atmosphere System
+
+### Theme Utilities & Panel
+- **`src/ui/PerformanceThemeUtils.js`** centralizes palette catalogs, transition defaults,
+  easing presets, normalization, equality checks, and theme diffing helpers.
+- **`src/ui/PerformanceThemePanel.js`** lets operators swap curated palettes, tweak accent
+  overrides, adjust bloom strength, and dial transition curves before broadcasting the
+  normalized theme state through the hub.
+
+### Theme Host & Persistence
+- **`src/ui/PerformanceSuiteHost.js`** caches active themes, re-applies them whenever the
+  engine switches (faceted, quantum, holographic, polychora), and pushes CSS variables into
+  the global stylesheet so the glow animates consistently.
+- Presets and show planner cues persist theme snapshots—including transition metadata—so
+  palettes, fades, and overrides travel between rehearsals and venues.
+
+### Performance Suite Shell & Styling
+- **`src/ui/PerformanceSuite.js`** orchestrates module instantiation, status messaging,
+  import/export, hub wiring, and exposes suite state for extensions.
+- **`styles/performance.css`** delivers the stage-ready UI: gradient panels, glowing buttons,
+  theme-aware borders, planner accents, the timeline visuals, and the latest responsive
+  tweaks.
+- **New in this revision:** the suite shell adds a Layout & Display panel with density, pad surface
+  scale, text sizing, and column emphasis controls that persist through the shared layout storage
+  key. Collapsed stack choices are now saved, and the stylesheet was refactored around layout-driven
+  CSS variables so spacing, typography, and pad dimensions update live when operators tweak the
+  controls. The panel now layers on viewport preview toggles (Live/Desktop/Tablet/Phone) wired into
+  new `PerformanceSuite` preview utilities, letting operators simulate breakpoints with an inline
+  width clamp and status messaging—perfect for mobile ergonomics and visual QA without leaving the
+  dashboard.
+- **This follow-up adds:** a saved layout profile manager. Profiles capture density, surface scale,
+  font scale, column emphasis, default mobile panel, breakpoint, and preview mode. They live under a
+  dedicated `profileStorageKey`, surface in the Layout & Display panel with Apply/Update/Delete
+  controls, and flow through `PerformanceSuite.getState/applyState` so presets, exports, and remote
+  extensions can rehydrate ergonomics alongside pad/audio/theme data. Styling refreshed to cover the
+  new selector, action buttons, and input field while keeping the suite’s glow-forward aesthetic.
+- **Latest enhancement:** the Layout & Display panel introduces a desktop column order manager. The
+  UI renders the three columns as reorderable chips with up/down controls, updates
+  `PerformanceSuite.applyColumnOrder`, keeps the mobile tab navigation in sync, persists the sequence
+  in layout state/presets, and surfaces a summary string so operators can sanity-check the order
+  during rehearsals.
+
+## Documentation
+- **`DOCS/PERFORMANCE_SUITE_REFERENCE.md`** describes the module layout, feature set, and
+  data contracts for integrators.
+- **`DOCS/PERFORMANCE_SUITE_DEVELOPMENT_NOTES.md`** (this memo) captures the motivations,
+  cross-module wiring, and upgrade history—including the latest timeline overview and telemetry monitor.
+- **`DOCS/PERFORMANCE_SUITE_VISUAL_TESTING.md`** outlines manual viewport sweeps, module
+  collapse/expand checks, theming steps, and the new layout density/profile passes so visual
+  regressions are easy to spot during QA.
+
+## Intended Future Enhancements
+- **Network Sync Director:** Layer on peer discovery and session leadership so multiple suites
+  can sync cue clocks over the new OSC/WebSocket bridge for distributed crews.
+- **OSC & HID Expansion:** Extend the hardware bridge to WebHID devices and add inbound OSC
+  listeners so tactile rigs and lighting desks can drive suite parameters bi-directionally.
+- **DMX & Lighting Hooks:** Export theme palettes and cue timings over Art-Net/sACN to sync
+  moving lights and LED walls with projection cues.
+- **Gesture Layers & Blending:** Stack multiple gesture takes with blend curves so performers
+  can layer sweeps, ramp intensities, or fade between recorded clips during playback.
+- **Show Analytics:** Capture performance logs (trigger times, manual overrides) for post-show
+  review and to refine choreography.
+
+These notes should help reviewers, collaborators, and future contributors understand the full
+surface area of the performance suite and the roadmap ahead.

--- a/DOCS/PERFORMANCE_SUITE_REFERENCE.md
+++ b/DOCS/PERFORMANCE_SUITE_REFERENCE.md
@@ -1,0 +1,209 @@
+# Performance Suite Architecture & Feature Guide
+
+This document summarizes the live control system that powers the upgraded performance suite,
+explains how each module cooperates during shows, and records follow-on ideas that should keep
+the tool evolving for touring crews.
+
+## Top-Level Layout
+
+The suite mounts inside `PerformanceSuite` and is composed of three stacked columns:
+
+* **Multi-touch pad column** – driven by `TouchPadController`, exposes every pad mapping,
+  axis curve, invert toggle, smoothing window, pad count, and pad template selector.
+* **Audio & atmosphere column** – hosts the `PerformanceThemePanel`, `AudioReactivityPanel`,
+  `PerformanceMidiBridge`, and new `PerformanceOscBridge` stack so palette, audio reactivity,
+  hardware mappings, and outbound network relays live in the same lane.
+* **Library & planner column** – renders the `PerformancePresetManager` for snapshots / playlists
+  and the `PerformanceShowPlanner` for choreographing cues, sequences, and live playback.
+
+`PerformanceSuite` also mediates shared state by wiring a `PerformanceHub` event bus, publishing
+status notices, persisting module state, and exposing import/export helpers for external tools.
+
+### Responsive Layout & Ergonomics
+
+* The suite now renders a mobile tab bar (Control Deck, Audio & Atmosphere, Library & Planner)
+  when the viewport width drops below the configurable breakpoint. Selecting a tab switches the
+  active column while keeping the other modules mounted, so multi-touch pads remain usable on
+  phones and small tablets.
+* Every stack inside the columns ships with a collapsible header that surfaces a quick summary
+  (“Multi-touch surfaces, templates, and axis response”, “OSC/WebSocket relays and remote
+  diagnostics”, etc.). Toggling the header updates the suite status badge for quick operator
+  feedback and sets `aria-expanded`/`aria-hidden` attributes for assistive tech.
+* Layout defaults (`mobileBreakpoint`, `defaultPanel`, `collapsedStacks`) live under
+  `PerformanceConfig.layout`, letting custom builds tune when the mobile nav activates or which
+  stacks start collapsed.
+* A dedicated Layout & Display panel lets operators adjust interface density, pad surface scale,
+  column emphasis, desktop column order, text sizing, the responsive breakpoint, and now trigger
+  viewport preview modes.
+  Layout choices persist between sessions (including collapsed stack states and the last preview
+  mode) so the suite reopens with the preferred ergonomics on every device.
+* Responsive styling in `styles/performance.css` tightens padding, reflows the header, and adjusts
+  toggle density so the suite remains ergonomic in portrait orientations without sacrificing the
+  stage-ready aesthetic.
+
+## Module Responsibilities
+
+### Layout & Display Controls
+
+* `PerformanceLayoutPanel` exposes interface density, pad surface scaling, text size, column
+  emphasis profiles, a desktop column order manager, and viewport preview toggles
+  (Live/Desktop/Tablet/Phone) alongside the default mobile panel selector. It writes changes through
+  the layout storage key so ergonomics—and preview choices—persist between reloads and across engine
+  swaps.
+* The column order manager renders the three desktop columns (Control Deck, Audio & Atmosphere,
+  Library & Planner) as reorderable chips with Move Up/Move Down controls. Adjustments apply
+  instantly through `PerformanceSuite.applyColumnOrder`, update the dashboard grid and mobile tab
+  order, and surface a textual "Columns: ..." summary so operators can confirm the sequence during
+  presets or cues.
+* A saved layout profile manager lets operators capture the current density/surface/text/breakpoint
+  mix under a custom label, re-apply it later, overwrite existing presets, or delete unused entries.
+  Profiles persist through the dedicated `profileStorageKey`, include preview mode defaults, and can
+  be exported/imported alongside other suite state via `PerformanceSuite.getState` / `applyState`.
+* Preview selections call into `PerformanceSuite.applyPreviewMode`, which constrains the shell width,
+  flips responsive mode, and surfaces status messaging without needing external device emulation.
+* Layout adjustments drive a dedicated CSS variable map (`--performance-shell-padding`,
+  `--performance-column-template`, `--performance-pad-min-width`, etc.), ensuring spacing and sizing
+  refresh instantly without forcing module reinitialization.
+
+#### Layout Profile Workflow
+
+* The Saved Layout Profiles select lists every stored configuration; Apply immediately rehydrates the
+  chosen state (density, surface scale, font scale, column focus, default mobile panel, breakpoint,
+  and preview mode) and announces the change in the status footer.
+* Update rewrites the highlighted profile with the current control values—useful after tweaking pad
+  spacing for a new projector rig—while Save New records an additional profile using the provided
+  label (auto-generating “Layout Snapshot N” when left blank).
+* Delete removes the highlighted profile and collapses the selector to the next available entry. All
+  operations persist through the `vib34d-performance-layout-profiles` storage key so saved ergonomics
+  follow the operator between browser sessions and engine swaps.
+
+### Parameter & Mapping Control
+
+* `TouchPadController` normalizes pad templates, allows performers to rename pads, change axis
+  assignments through the filtered parameter palette, and tune per-axis response curves, inversion,
+  and smoothing. Layout templates, pad count controls, and gesture processing are synchronized
+  through the shared hub.
+* Touch pad metadata (labels, tags, curve defaults) originate from `PerformanceConfig` so new
+  controllers inherit curated mappings with minimal setup time.
+
+### Audio Reactivity
+
+* `AudioReactivityPanel` captures live mic / line-in settings including beat sync, smoothing,
+  sensitivity, per-band weighting, and flourish trigger thresholding. Settings are broadcast over the
+  hub and handed directly to the active engine via `setLiveAudioSettings`.
+
+### Hardware Controllers
+
+* `PerformanceMidiBridge` detects Web MIDI devices, surfaces input selection, and provides a “learn”
+  workflow so any CC message can be bound to suite parameters. Incoming values are smoothed and
+  normalized before driving `ParameterManager.setParameter` calls to avoid sudden jumps.
+* Hardware mappings persist in `localStorage`, emit `hardware:midi-value` hub events, and are bundled
+  into presets so tactile rigs reload alongside pad layouts and audio settings.
+
+### Network / OSC Bridge
+
+* `PerformanceOscBridge` exposes a WebSocket-powered relay so hub events stream to external tools
+  such as OSC translators, lighting consoles, or secondary operator dashboards.
+* Operators can toggle which event families forward (touch pads, audio reactivity, presets, show cues,
+  hardware, gestures, and theme updates), adjust the OSC-style namespace, and enable auto-connect.
+* A rolling message log, status badge, and manual heartbeat trigger provide quick diagnostics when
+  verifying remote listeners before a show.
+
+### Gesture Capture & Playback
+
+* `PerformanceGestureRecorder` records touch pad and MIDI gestures into timestamped takes with
+  smoothing, export/import helpers, and playback scheduling. It publishes library summaries over the
+  hub and re-injects parameter values when clips are played.
+* Gesture takes can be assigned to show planner cues; playback automatically fires when cues trigger,
+  allowing choreographed flourishes to sit alongside presets, playlists, and audio-reactive changes.
+
+### Live Telemetry & Diagnostics
+
+* `PerformanceTelemetryPanel` visualizes real-time 4D rotation vectors, dynamic parameters, and
+  incoming control pulses from touch pads, MIDI devices, gesture playback, and cue triggers.
+* Rotation energy and activity indices are trended in a compact history list so operators can review
+  how aggressively pads or hardware are driving the engine mid-show.
+
+### Presets & Library Management
+
+* `PerformancePresetManager` snapshots the entire live state (pads, audio, show planner, and theme
+  palette). It persists the library, generates playlist metadata with active theme badges, and can
+  replay presets while optionally letting the show planner override themes.
+* Theme data saved with each preset contains normalized transition curves so fades restore with the
+  same timing dialed in during rehearsal, and gesture libraries are bundled so flourish clips travel
+  with shows.
+
+### Show Planner & Cue Playback
+
+* `PerformanceShowPlanner` stores tempo, looping, cue stacks, manual notes, and integrates tightly
+  with the preset library for quick lookups.
+* Each cue captures its theme strategy (hold current, adopt preset palette, enforce a palette
+  override, or lock the current glow), along with preset ID, gesture take, duration (beats),
+  auto-advance flag, and run-state metadata.
+* Cue editors expose transition duration/easing selectors plus gesture drop-downs fed by the recorder
+  so flourishes auto-play when cues fire. Transition metadata and gesture IDs travel with exports,
+  hub events, and manual trigger actions.
+* The planner’s run controls support start/stop, prev/next, looping, auto-advance, tempo changes,
+  and keyboard shortcuts while emitting status badges and timeline notifications across the suite.
+
+### Theme & Atmosphere System
+
+* `PerformanceThemePanel` centralizes palette selection, accent overrides, highlight bloom, glow
+  strength, and now transition timing. The slider + easing selector update CSS variables so the entire
+  dashboard animates between palettes with consistent cross-fades.
+* Theme state (palette, overrides, transition) is cached in `PerformanceSuiteHost`. The host keeps
+  settings alive while engines swap, reapplies them to every system tab, and exports normalized theme
+  bundles for extensions.
+* `PerformanceThemeUtils` standardizes default palettes, easing presets, transition normalization,
+  and palette resolution so every module works from the same schema.
+
+### Styling & Atmosphere
+
+* `styles/performance.css` delivers the glow-heavy aesthetic, gradient backgrounds, and responsive
+  layout for each module. With this update, the sheet uses new transition variables so backgrounds,
+  borders, badges, and status pills animate smoothly whenever palettes or cues change.
+
+## Cross-Module Messaging
+
+* `PerformanceHub` brokers touch pad gestures, audio reactivity updates, preset loads, playlist
+  events, show planner triggers, and theme updates. Modules subscribe to only the messages they need
+  and never directly mutate each other’s state.
+* `PerformanceSuiteHost` exposes the suite to every rendering system (faceted, quantum, holographic,
+  polychora). It snapshots module state during engine teardown, reapplies it when engines boot, and
+  updates CSS variables for accent, highlight, glow, and transition timing.
+
+## Storage & Persistence
+
+* Touch pad layouts, audio settings, themes, preset libraries, playlists, and show planner stacks
+  all persist via `localStorage` using keys defined in `PerformanceConfig`.
+* Export/import helpers are available through the hub so external extensions (OSC bridges, MIDI
+  routers, timeline sequencers) can sync or drive the same state objects.
+
+## Latest Enhancements (This Iteration)
+
+* Introduced the `PerformanceLayoutPanel` with density, pad surface scale, text sizing, and column
+  emphasis controls so the suite can be tuned for club booths, festival FOH, or rehearsal studios in
+  seconds.
+* Persist layout preferences (including collapsed stacks and default mobile panel) via the shared
+  layout storage key, allowing ergonomics to follow operators as engines swap or browsers reload.
+* Refactored `styles/performance.css` to consume layout-driven CSS variables, ensuring responsive
+  spacing, pad sizing, and typography react instantly to panel adjustments without reinitializing
+  modules.
+* Expanded documentation and visual QA flows to cover layout profiles, responsive breakpoint tuning,
+  and regression sweeps across the new density and scale ranges.
+
+## Future Ideas & Extensions
+
+* **Cue Timeline Editor:** add a drag-and-drop timeline with beat snapping for planners who want to
+  schedule cues visually against a song structure.
+* **Network Sync:** build on the OSC bridge to coordinate multiple operators (lighting, visuals, VJ)
+  over WebRTC/WebSocket with session leadership and cue clock sharing.
+* **Analytics Overlay:** capture gesture heat maps, cue trigger history, and audio-reactivity stats
+  to refine presets after each performance.
+* **Automation Scripts:** expose a scripting layer for pre/post cue hooks (e.g., trigger lighting
+  macros, fire DMX scenes, schedule automated theme sweeps).
+* **Gesture Morphing:** blend between multiple gesture takes with weighted curves so performers can
+  improvise transitions between recorded flourishes.
+
+Keeping this document updated will help onboarding operators, integrators, and future contributors
+understand how the suite fits together and where the roadmap is heading.

--- a/DOCS/PERFORMANCE_SUITE_VISUAL_TESTING.md
+++ b/DOCS/PERFORMANCE_SUITE_VISUAL_TESTING.md
@@ -1,0 +1,103 @@
+# Performance Suite Visual Testing Protocol
+
+This checklist documents the manual sweeps we run whenever the live performance suite UI
+changes. Follow these steps before shipping visual updates or when verifying bug fixes so the
+stage-ready dashboard stays ergonomic across devices.
+
+## 1. Pre-Flight Setup
+
+1. Run `npm install` (if dependencies are missing) and start the viewer with `npm run dev`.
+2. Open the viewer in a Chromium-based browser with device emulation tools available.
+3. Clear `localStorage` keys prefixed with `vib34d-` to avoid stale presets or layout settings.
+4. Load the performance suite via the control panel toggle to ensure every module mounts.
+
+## 2. Viewport Sweep
+
+Perform the following viewport checks, refreshing between each size if layout glitches appear:
+
+| Viewport | Expectations |
+| --- | --- |
+| **1440×900 desktop** | Three-column layout visible, all stacks expanded, header copy readable. |
+| **1024×768 tablet** | Mobile tab bar appears, "Control Deck" column active by default, other columns hidden. |
+| **834×1112 portrait tablet** | Tabs stack into two rows, collapsible toggles remain accessible, pads stay usable. |
+| **428×926 phone** | Tabs stack vertically, padding tightens, status badge stretches full width without overlap. |
+
+At each breakpoint, confirm the mobile tab bar highlights the active column and that `aria-pressed`
+updates in the accessibility tree (inspect with devtools).
+
+> 💡 Tip: The Layout & Display panel now exposes **Viewport Preview** buttons (Live/Desktop/Tablet/Phone).
+> Use them for quick breakpoint spot checks—the suite clamps to the simulated width, updates the status
+> badge, and mirrors mobile tab behaviour without needing browser emulation.
+
+## 3. Layout & Density Controls
+
+1. Open the **Layout & Display** panel at the top of the Touch Pads stack.
+2. Sweep the **Interface Density** slider from airy (0) to compact (100) and confirm column spacing,
+   block padding, and pad grid gaps adjust smoothly without clipping content.
+3. Drag the **Pad Surface Size** and **Text Scale** sliders; verify pad minimum widths grow/shrink,
+   pad surface heights update, and typography scales while maintaining readability.
+4. Cycle through each **Column Emphasis** profile and ensure column widths rebalance according to the
+   description, with the suite status badge reporting "Layout updated".
+5. Change the **Default Mobile Panel** and **Mobile Breakpoint**, reload the page, and confirm the
+   selected panel becomes active on mobile viewports at the new breakpoint.
+6. Collapse two stacks (e.g., Telemetry and Network), refresh the viewer, and verify they remain
+   collapsed thanks to the persisted layout state.
+7. Toggle each **Viewport Preview** button and confirm the suite constrains to 1440px (Desktop), 1024px
+   (Tablet), and 428px (Phone) while updating the status badge with the selected mode. Return to **Live**
+   to resume full-width behaviour.
+8. Enter a name in **Saved Layout Profiles → Profile name**, press **Save New**, reload the page, and
+   verify the new profile remains in the list with the status badge announcing "Layout profile saved".
+9. Select the saved profile and choose **Apply**; confirm density/text/pad scale/default panel snap to
+   the stored values, preview mode updates, and the status badge reports "Layout profile applied".
+10. Adjust controls (e.g., increase Pad Surface Size), press **Update**, and confirm the profile summary
+    reflects the new values. Use **Delete** to remove the profile and ensure the selector collapses to
+    the remaining entry with a "Layout profile deleted" status message.
+11. Use the **Column Order** Move Up/Move Down controls to reorder the columns (e.g., move Library &
+    Planner to the first slot). Confirm the desktop grid reflows immediately, the "Columns:" summary
+    updates, the mobile tab order matches the new sequence when switching to Tablet preview, and after
+    refreshing the viewer the chosen order persists.
+
+## 4. Stack Collapse Behaviour
+
+1. Expand and collapse each stack header (Touch Pads, Telemetry, Gestures, Theme, Audio,
+   Hardware, Network, Presets, Planner).
+2. Verify the suite status badge announces the action ("Touch Pads & Layout collapsed").
+3. Ensure `aria-expanded`/`aria-hidden` toggle correctly in devtools.
+4. Re-open collapsed stacks and confirm content renders without layout jumps.
+
+## 5. Module Spot Checks
+
+* **Touch Pads** – Change pad count, switch templates, and drag inside each pad to confirm
+  pointer overlays stay aligned after responsive transitions.
+* **Audio Reactivity** – Toggle enabled state and adjust smoothing sliders; verify labels wrap
+  correctly on narrow widths.
+* **Hardware Bridge** – Run the MIDI “learn” prompt; ensure dialogs stay inside the viewport.
+* **Network Bridge** – Toggle the OSC relay, check the log area for overflow or clipped badges.
+* **Telemetry & Gesture Recorder** – Confirm charts and lists resize without horizontal scroll.
+* **Preset Manager & Show Planner** – Switch between presets, open cue editors, and verify the
+  timeline progress bars remain legible on tablet widths.
+
+## 6. Theme & Color Regression
+
+1. Cycle through palette presets in the Color Atmosphere panel.
+2. Override accent and glow sliders to ensure CSS variables propagate to headers, buttons, and
+   the mobile tab bar.
+3. Trigger a preset that changes the theme and verify the tab bar, stack toggles, and status badge
+   animate to the new palette without flashes.
+
+## 7. Accessibility & Keyboard
+
+1. Tab through the mobile tab bar and stack toggles; focus rings should appear and match the
+   accent color.
+2. Use keyboard activation (`Enter`/`Space`) on stack toggles to confirm collapse behaviour mirrors
+   pointer clicks.
+3. Check that screen readers announce the stack headers as buttons with proper expanded state.
+
+## 8. Capture & Reporting
+
+* Take annotated screenshots for any anomalies, noting viewport size and reproduction steps.
+* File regressions against the relevant module with screenshots attached.
+* When fixes land, re-run the viewport sweep plus the affected module checklist before closing the issue.
+
+Adhering to this protocol keeps the suite reliable for performers moving between laptops, tablets,
+and phones during rehearsals and shows.

--- a/index-clean.html
+++ b/index-clean.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="styles/reactivity.css">
     <link rel="stylesheet" href="styles/mobile.css">
     <link rel="stylesheet" href="styles/animations.css">
+    <link rel="stylesheet" href="styles/performance.css">
 </head>
 <body class="loading">
     <!-- Top Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VIB34D Engine - Canvas Explosion FIXED</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/performance.css">
     <style>
         * {
             margin: 0;

--- a/src/core/CanvasManager.js
+++ b/src/core/CanvasManager.js
@@ -3,6 +3,8 @@
  * No canvas destruction - HTML canvases stay put, just switch visibility
  */
 
+import { getPerformanceSuiteHost } from '../ui/PerformanceSuiteHost.js';
+
 export class CanvasManager {
   constructor() {
     this.currentSystem = null;
@@ -11,9 +13,14 @@ export class CanvasManager {
 
   async switchToSystem(systemName, engineClasses) {
     console.log(`🔄 DESTROY OLD → CREATE NEW: ${systemName}`);
-    
+
+    const suiteHost = typeof document !== 'undefined' ? getPerformanceSuiteHost() : null;
+
     // STEP 1: DESTROY current engine completely
     if (this.currentEngine) {
+      if (suiteHost) {
+        suiteHost.prepareForEngineSwitch(this.currentEngine);
+      }
       if (this.currentEngine.setActive) {
         this.currentEngine.setActive(false);
       }
@@ -31,6 +38,10 @@ export class CanvasManager {
     
     // STEP 4: CREATE fresh engine
     const engine = await this.createFreshEngine(systemName, engineClasses);
+
+    if (engine && suiteHost) {
+      suiteHost.activateEngine(engine, { systemName });
+    }
     
     // STEP 5: Start new engine
     if (engine && engine.setActive) {

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -11,6 +11,7 @@ import { GallerySystem } from '../gallery/GallerySystem.js';
 import { ExportManager } from '../export/ExportManager.js';
 // InteractionHandler removed - each system handles its own interactions
 import { StatusManager } from '../ui/StatusManager.js';
+import { getPerformanceSuiteHost } from '../ui/PerformanceSuiteHost.js';
 
 export class VIB34DIntegratedEngine {
     constructor() {
@@ -22,6 +23,12 @@ export class VIB34DIntegratedEngine {
         this.exportManager = new ExportManager(this);
         // Each system handles its own interactions - no central handler needed
         this.statusManager = new StatusManager();
+
+        // Live performance controls
+        this.performanceSuite = null;
+        this.liveAudioSettings = null;
+        this.audioSmoothingState = {};
+        this.lastFlourishTrigger = 0;
         
         // Active state for reactivity
         this.isActive = false;
@@ -59,6 +66,7 @@ export class VIB34DIntegratedEngine {
             this.setupInteractions();
             this.loadCustomVariations();
             this.populateVariationGrid();
+            this.initializePerformanceSuite();
             this.startRenderLoop();
             
             this.statusManager.setStatus('VIB34D Engine initialized successfully', 'success');
@@ -142,7 +150,36 @@ export class VIB34DIntegratedEngine {
             });
         });
     }
-    
+
+    initializePerformanceSuite() {
+        if (typeof document === 'undefined') return;
+
+        try {
+            const host = getPerformanceSuiteHost();
+            this.performanceSuite = host.activateEngine(this, {
+                systemName: 'faceted',
+                parameterManager: this.parameterManager
+            });
+        } catch (error) {
+            console.warn('⚠️ Performance suite initialization failed:', error);
+        }
+    }
+
+    setLiveAudioSettings(settings) {
+        if (!settings) {
+            this.liveAudioSettings = null;
+            return;
+        }
+
+        try {
+            this.liveAudioSettings = JSON.parse(JSON.stringify(settings));
+        } catch (error) {
+            this.liveAudioSettings = settings;
+        }
+
+        this.audioSmoothingState = {};
+    }
+
     /**
      * Set up mouse/touch interactions
      */
@@ -605,88 +642,141 @@ export class VIB34DIntegratedEngine {
     /**
      * Apply audio reactivity grid settings (similar to holographic system)
      */
-    applyAudioReactivityGrid(audioData) {
-        const settings = this.audioReactivitySettings || window.audioReactivitySettings;
-        if (!settings) return;
-        
-        // Get sensitivity multiplier
-        const sensitivityMultiplier = settings.sensitivity[settings.activeSensitivity];
-        
-        // Apply audio changes to different visual modes based on grid selection
-        settings.activeVisualModes.forEach(modeKey => {
-            const [sensitivity, visualMode] = modeKey.split('-');
-            
-            if (visualMode === 'color') {
-                // COLOR MODE: Affect hue, saturation, intensity
-                const audioIntensity = (audioData.energy * sensitivityMultiplier);
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const rhythmIntensity = (audioData.rhythm * sensitivityMultiplier);
-                
-                // Modulate hue based on audio frequency spread
-                if (audioData.mid > 0.2) {
-                    const currentHue = this.parameterManager.getParameter('hue') || 180;
-                    const hueShift = audioData.mid * sensitivityMultiplier * 30;
-                    this.parameterManager.setParameter('hue', (currentHue + hueShift) % 360);
-                }
-                
-                // Boost intensity on energy spikes
-                if (audioIntensity > 0.3) {
-                    this.parameterManager.setParameter('intensity', Math.min(1.0, 0.5 + audioIntensity * 0.8));
-                }
-                
-                // Boost saturation on bass hits
-                if (bassIntensity > 0.4) {
-                    this.parameterManager.setParameter('saturation', Math.min(1.0, 0.7 + bassIntensity * 0.3));
-                }
-                
-            } else if (visualMode === 'geometry') {
-                // GEOMETRY MODE: Affect morphFactor, gridDensity, chaos
-                const bassIntensity = (audioData.bass * sensitivityMultiplier);
-                const highIntensity = (audioData.high * sensitivityMultiplier);
-                
-                // Bass affects grid density
-                if (bassIntensity > 0.3) {
-                    const currentDensity = this.parameterManager.getParameter('gridDensity') || 15;
-                    this.parameterManager.setParameter('gridDensity', Math.min(100, currentDensity + bassIntensity * 25));
-                }
-                
-                // Mid frequencies affect morph factor
-                if (audioData.mid > 0.2) {
-                    const morphBoost = audioData.mid * sensitivityMultiplier * 0.5;
-                    this.parameterManager.setParameter('morphFactor', Math.min(2.0, morphBoost));
-                }
-                
-                // High frequencies add chaos
-                if (highIntensity > 0.4) {
-                    this.parameterManager.setParameter('chaos', Math.min(1.0, highIntensity * 0.6));
-                }
-                
-            } else if (visualMode === 'movement') {
-                // MOVEMENT MODE: Affect speed, 4D rotations
-                const energyIntensity = (audioData.energy * sensitivityMultiplier);
-                
-                // Energy affects animation speed
-                if (energyIntensity > 0.2) {
-                    this.parameterManager.setParameter('speed', Math.min(3.0, 0.5 + energyIntensity * 1.5));
-                }
-                
-                // Audio frequencies affect 4D rotations
-                if (audioData.bass > 0.3) {
-                    const currentXW = this.parameterManager.getParameter('rot4dXW') || 0;
-                    this.parameterManager.setParameter('rot4dXW', currentXW + audioData.bass * sensitivityMultiplier * 0.1);
-                }
-                
-                if (audioData.mid > 0.3) {
-                    const currentYW = this.parameterManager.getParameter('rot4dYW') || 0;
-                    this.parameterManager.setParameter('rot4dYW', currentYW + audioData.mid * sensitivityMultiplier * 0.08);
-                }
-                
-                if (audioData.high > 0.3) {
-                    const currentZW = this.parameterManager.getParameter('rot4dZW') || 0;
-                    this.parameterManager.setParameter('rot4dZW', currentZW + audioData.high * sensitivityMultiplier * 0.06);
-                }
+    applyAudioReactivityGrid(audioData = {}) {
+        const settings = this.liveAudioSettings;
+        if (!settings || !settings.enabled || !this.parameterManager) return;
+
+        const sensitivity = this.clamp01(typeof settings.sensitivity === 'number' ? settings.sensitivity : 0.75);
+        const smoothing = this.clamp01(typeof settings.smoothing === 'number' ? settings.smoothing : 0.3);
+
+        const readBand = (bandName, defaultValue = 0) => {
+            const value = typeof audioData?.[bandName] === 'number' ? audioData[bandName] : defaultValue;
+            return this.smoothBandValue(bandName, value, smoothing);
+        };
+
+        const resolveBand = (bandName) => {
+            const raw = settings.bands?.[bandName];
+            if (typeof raw === 'object' && raw !== null) {
+                return {
+                    enabled: raw.enabled !== undefined ? Boolean(raw.enabled) : true,
+                    weight: this.clamp01(typeof raw.weight === 'number' ? raw.weight / 2 : 0.5) * 2
+                };
             }
-        });
+            if (typeof raw === 'number') {
+                return {
+                    enabled: raw > 0,
+                    weight: this.clamp01(raw / 2) * 2
+                };
+            }
+            if (typeof raw === 'boolean') {
+                return {
+                    enabled: raw,
+                    weight: raw ? 1 : 0
+                };
+            }
+            return { enabled: false, weight: 0 };
+        };
+
+        const sampleBand = (bandName, alias = bandName) => {
+            const config = resolveBand(bandName);
+            if (!config.enabled) return { value: 0, config };
+            const rawValue = readBand(alias);
+            const weighted = Math.min(1, Math.max(0, rawValue * Math.max(0, config.weight)));
+            return { value: weighted, config };
+        };
+
+        const { value: bass, config: bassConfig } = sampleBand('bass');
+        const { value: mid, config: midConfig } = sampleBand('mid');
+        const { value: treble, config: trebleConfig } = sampleBand('treble', 'high');
+        const { value: energy, config: energyConfig } = sampleBand('energy');
+
+        if (bassConfig.enabled) {
+            this.setParameterNormalized('gridDensity', 0.25 + bass * sensitivity, 'audio');
+            this.setParameterNormalized('morphFactor', 0.2 + bass * sensitivity, 'audio');
+        }
+
+        if (midConfig.enabled) {
+            const baseHue = this.parameterManager.getParameter('hue') || 0;
+            const hueShift = (mid - 0.5) * 120 * sensitivity;
+            const nextHue = (baseHue + hueShift + 360) % 360;
+            this.parameterManager.setParameter('hue', nextHue, 'audio');
+        }
+
+        if (trebleConfig.enabled) {
+            this.setParameterNormalized('intensity', 0.4 + treble * 0.6 * sensitivity, 'audio');
+            this.setParameterNormalized('saturation', 0.45 + treble * 0.5 * sensitivity, 'audio');
+        }
+
+        if (energyConfig.enabled) {
+            this.setParameterNormalized('speed', 0.35 + energy * 0.65 * sensitivity, 'audio');
+        }
+
+        if (settings.beatSync && energy > 0.4) {
+            const wobble = (energy - 0.4) * 0.15 * sensitivity;
+            const base = this.parameterManager.getParameter('rot4dXW') || 0;
+            this.parameterManager.setParameter('rot4dXW', base + wobble, 'audio');
+        }
+
+        this.triggerFlourish(settings, energy);
+    }
+
+    smoothBandValue(band, value, smoothing) {
+        if (!Number.isFinite(value)) return 0;
+        if (!smoothing) {
+            this.audioSmoothingState[band] = value;
+            return value;
+        }
+
+        const blend = this.clamp01(smoothing);
+        const previous = this.audioSmoothingState[band];
+        const smoothed = previous === undefined ? value : previous * blend + value * (1 - blend);
+        this.audioSmoothingState[band] = smoothed;
+        return smoothed;
+    }
+
+    setParameterNormalized(name, normalized, source = 'audio') {
+        const definition = this.parameterManager.getParameterDefinition(name);
+        if (!definition) return;
+        const value = definition.min + (definition.max - definition.min) * this.clamp01(normalized);
+        this.parameterManager.setParameter(name, value, source);
+    }
+
+    triggerFlourish(settings, energyLevel) {
+        const flourish = settings.flourish;
+        if (!flourish?.enabled) return;
+
+        const threshold = typeof flourish.threshold === 'number' ? flourish.threshold : 0.65;
+        if (energyLevel < threshold) return;
+
+        const now = performance.now();
+        if (now - this.lastFlourishTrigger < 800) return;
+
+        const parameter = flourish.parameter || 'intensity';
+        const definition = this.parameterManager.getParameterDefinition(parameter);
+        if (!definition) return;
+
+        const current = this.parameterManager.getParameter(parameter) ?? definition.min;
+        const span = definition.max - definition.min;
+        const boost = this.clamp01(typeof flourish.amount === 'number' ? flourish.amount : 0.35);
+        const boosted = Math.min(definition.max, current + span * boost);
+
+        this.parameterManager.setParameter(parameter, boosted, 'audio-flourish');
+
+        setTimeout(() => {
+            const relaxed = current + (boosted - current) * 0.35;
+            this.parameterManager.setParameter(parameter, this.clampToRange(relaxed, definition), 'audio-flourish-return');
+        }, 420);
+
+        this.lastFlourishTrigger = now;
+    }
+
+    clampToRange(value, definition) {
+        if (!definition) return value;
+        return Math.max(definition.min, Math.min(definition.max, value));
+    }
+
+    clamp01(value) {
+        return Math.max(0, Math.min(1, value));
     }
     
     /**
@@ -730,7 +820,13 @@ export class VIB34DIntegratedEngine {
         if (window.universalReactivity) {
             window.universalReactivity.disconnectSystem('faceted');
         }
-        
+
+        const host = typeof window !== 'undefined' ? window.performanceSuiteHost : null;
+        if (host?.detachEngine) {
+            host.detachEngine(this);
+            this.performanceSuite = null;
+        }
+
         if (this.animationId) {
             cancelAnimationFrame(this.animationId);
         }

--- a/src/core/Parameters.js
+++ b/src/core/Parameters.js
@@ -3,131 +3,250 @@
  * Unified parameter control for both holographic and polytopal systems
  */
 
+const PARAMETER_GROUPS = {
+    show: 'Show Control',
+    rotation: '4D Rotation',
+    structure: 'Structure',
+    dynamics: 'Dynamics',
+    color: 'Color'
+};
+
 export class ParameterManager {
     constructor() {
         // Default parameter set combining both systems
         this.params = {
             // Current variation
             variation: 0,
-            
+
             // 4D Polytopal Mathematics
             rot4dXW: 0.0,      // X-W plane rotation (-2 to 2)
-            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2) 
+            rot4dYW: 0.0,      // Y-W plane rotation (-2 to 2)
             rot4dZW: 0.0,      // Z-W plane rotation (-2 to 2)
             dimension: 3.5,    // Dimensional level (3.0 to 4.5)
-            
+
             // Holographic Visualization
-            gridDensity: 15,   // Geometric detail (4 to 30)
+            gridDensity: 15,   // Geometric detail (4 to 100)
             morphFactor: 1.0,  // Shape transformation (0 to 2)
             chaos: 0.2,        // Randomization level (0 to 1)
             speed: 1.0,        // Animation speed (0.1 to 3)
             hue: 200,          // Color rotation (0 to 360)
             intensity: 0.5,    // Visual intensity (0 to 1)
             saturation: 0.8,   // Color saturation (0 to 1)
-            
+
             // Geometry selection
             geometry: 0        // Current geometry type (0-7)
         };
-        
+
         // Parameter definitions for validation and UI
         this.parameterDefs = {
-            variation: { min: 0, max: 99, step: 1, type: 'int' },
-            rot4dXW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dYW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            rot4dZW: { min: -2, max: 2, step: 0.01, type: 'float' },
-            dimension: { min: 3.0, max: 4.5, step: 0.01, type: 'float' },
-            gridDensity: { min: 4, max: 100, step: 0.1, type: 'float' },
-            morphFactor: { min: 0, max: 2, step: 0.01, type: 'float' },
-            chaos: { min: 0, max: 1, step: 0.01, type: 'float' },
-            speed: { min: 0.1, max: 3, step: 0.01, type: 'float' },
-            hue: { min: 0, max: 360, step: 1, type: 'int' },
-            intensity: { min: 0, max: 1, step: 0.01, type: 'float' },
-            saturation: { min: 0, max: 1, step: 0.01, type: 'float' },
-            geometry: { min: 0, max: 7, step: 1, type: 'int' }
+            variation: {
+                min: 0,
+                max: 99,
+                step: 1,
+                type: 'int',
+                label: 'Variation Index',
+                group: PARAMETER_GROUPS.show,
+                tags: ['variation', 'preset']
+            },
+            rot4dXW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation X↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            rot4dYW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Y↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            rot4dZW: {
+                min: -2,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Rotation Z↔W',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['rotation', 'performance']
+            },
+            dimension: {
+                min: 3.0,
+                max: 4.5,
+                step: 0.01,
+                type: 'float',
+                label: 'Dimensional Blend',
+                group: PARAMETER_GROUPS.rotation,
+                tags: ['geometry', 'morph']
+            },
+            gridDensity: {
+                min: 4,
+                max: 100,
+                step: 0.1,
+                type: 'float',
+                label: 'Grid Density',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['structure', 'resolution', 'audio']
+            },
+            morphFactor: {
+                min: 0,
+                max: 2,
+                step: 0.01,
+                type: 'float',
+                label: 'Morph Factor',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['morph', 'performance']
+            },
+            chaos: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Chaos',
+                group: PARAMETER_GROUPS.dynamics,
+                tags: ['randomness', 'audio']
+            },
+            speed: {
+                min: 0.1,
+                max: 3,
+                step: 0.01,
+                type: 'float',
+                label: 'Animation Speed',
+                group: PARAMETER_GROUPS.dynamics,
+                tags: ['tempo', 'audio', 'performance']
+            },
+            hue: {
+                min: 0,
+                max: 360,
+                step: 1,
+                type: 'int',
+                label: 'Hue Rotation',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color', 'audio']
+            },
+            intensity: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Light Intensity',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color', 'dynamics', 'audio']
+            },
+            saturation: {
+                min: 0,
+                max: 1,
+                step: 0.01,
+                type: 'float',
+                label: 'Saturation',
+                group: PARAMETER_GROUPS.color,
+                tags: ['color']
+            },
+            geometry: {
+                min: 0,
+                max: 7,
+                step: 1,
+                type: 'int',
+                label: 'Geometry Index',
+                group: PARAMETER_GROUPS.structure,
+                tags: ['structure', 'preset']
+            }
         };
-        
+
         // Default parameter backup for reset
         this.defaults = { ...this.params };
+
+        // Registered listeners for live control modules
+        this.listeners = new Set();
     }
-    
+
     /**
      * Get all current parameters
      */
     getAllParameters() {
         return { ...this.params };
     }
-    
-    /**
-     * Set a specific parameter with validation
-     */
-    setParameter(name, value) {
-        if (this.parameterDefs[name]) {
-            const def = this.parameterDefs[name];
-            
-            // Clamp value to valid range
-            value = Math.max(def.min, Math.min(def.max, value));
-            
-            // Apply type conversion
-            if (def.type === 'int') {
-                value = Math.round(value);
-            }
-            
-            this.params[name] = value;
-            return true;
-        }
-        
-        console.warn(`Unknown parameter: ${name}`);
-        return false;
-    }
-    
-    /**
-     * Set multiple parameters at once
-     */
-    setParameters(paramObj) {
-        for (const [name, value] of Object.entries(paramObj)) {
-            this.setParameter(name, value);
-        }
-    }
-    
+
     /**
      * Get a specific parameter value
      */
     getParameter(name) {
         return this.params[name];
     }
-    
+
     /**
-     * Set geometry type with validation
+     * Retrieve the definition for a parameter
      */
-    setGeometry(geometryType) {
-        this.setParameter('geometry', geometryType);
+    getParameterDefinition(name) {
+        return this.parameterDefs[name] || null;
     }
-    
+
+    /**
+     * Set a specific parameter with validation
+     */
+    setParameter(name, value, source = 'manual') {
+        if (!this.parameterDefs[name]) {
+            console.warn(`Unknown parameter: ${name}`);
+            return false;
+        }
+
+        const def = this.parameterDefs[name];
+        const clampedValue = this.clampToDefinition(def, value);
+        const previousValue = this.params[name];
+
+        if (!this.hasMeaningfulChange(previousValue, clampedValue, def)) {
+            return false;
+        }
+
+        this.params[name] = clampedValue;
+        this.emitChange(name, clampedValue, source);
+        return true;
+    }
+
+    /**
+     * Set multiple parameters at once
+     */
+    setParameters(paramObj, options = {}) {
+        if (!paramObj || typeof paramObj !== 'object') return;
+        const { source = 'manual' } = options;
+
+        Object.entries(paramObj).forEach(([name, value]) => {
+            this.setParameter(name, value, source);
+        });
+    }
+
+    /**
+     * Helper used by geometry button controls
+     */
+    setGeometry(geometryType, source = 'manual') {
+        this.setParameter('geometry', geometryType, source);
+    }
+
     /**
      * Update parameters from UI controls
      */
     updateFromControls() {
         const controlIds = [
             'variationSlider', 'rot4dXW', 'rot4dYW', 'rot4dZW', 'dimension',
-            'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue'
+            'gridDensity', 'morphFactor', 'chaos', 'speed', 'hue',
+            'intensity', 'saturation'
         ];
-        
+
         controlIds.forEach(id => {
             const element = document.getElementById(id);
-            if (element) {
-                const value = parseFloat(element.value);
-                
-                // Map slider IDs to parameter names
-                let paramName = id;
-                if (id === 'variationSlider') {
-                    paramName = 'variation';
-                }
-                
-                this.setParameter(paramName, value);
-            }
+            if (!element) return;
+
+            const value = parseFloat(element.value);
+            const paramName = id === 'variationSlider' ? 'variation' : id;
+            this.setParameter(paramName, value, 'ui');
         });
     }
-    
+
     /**
      * Update UI display values from current parameters
      */
@@ -143,7 +262,9 @@ export class ParameterManager {
         this.updateSliderValue('chaos', this.params.chaos);
         this.updateSliderValue('speed', this.params.speed);
         this.updateSliderValue('hue', this.params.hue);
-        
+        this.updateSliderValue('intensity', this.params.intensity);
+        this.updateSliderValue('saturation', this.params.saturation);
+
         // Update display texts
         this.updateDisplayText('rot4dXWDisplay', this.params.rot4dXW.toFixed(2));
         this.updateDisplayText('rot4dYWDisplay', this.params.rot4dYW.toFixed(2));
@@ -153,219 +274,207 @@ export class ParameterManager {
         this.updateDisplayText('morphFactorDisplay', this.params.morphFactor.toFixed(2));
         this.updateDisplayText('chaosDisplay', this.params.chaos.toFixed(2));
         this.updateDisplayText('speedDisplay', this.params.speed.toFixed(2));
-        this.updateDisplayText('hueDisplay', this.params.hue + '°');
-        
+        this.updateDisplayText('hueDisplay', `${this.params.hue}°`);
+
         // Update variation info
         this.updateVariationInfo();
-        
+
         // Update geometry preset buttons
         this.updateGeometryButtons();
     }
-    
+
     updateSliderValue(id, value) {
         const element = document.getElementById(id);
         if (element) {
             element.value = value;
         }
     }
-    
+
     updateDisplayText(id, text) {
         const element = document.getElementById(id);
         if (element) {
             element.textContent = text;
         }
     }
-    
+
     updateVariationInfo() {
         const variationDisplay = document.getElementById('currentVariationDisplay');
-        if (variationDisplay) {
-            const geometryNames = [
-                'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
-                'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
-            ];
-            
-            const geometryType = Math.floor(this.params.variation / 4);
-            const geometryLevel = (this.params.variation % 4) + 1;
-            const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
-            
-            variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
-            
-            if (this.params.variation < 30) {
-                variationDisplay.textContent += ` ${geometryLevel}`;
-            }
+        if (!variationDisplay) return;
+
+        const geometryNames = [
+            'TETRAHEDRON LATTICE', 'HYPERCUBE LATTICE', 'SPHERE LATTICE', 'TORUS LATTICE',
+            'KLEIN BOTTLE LATTICE', 'FRACTAL LATTICE', 'WAVE LATTICE', 'CRYSTAL LATTICE'
+        ];
+
+        const geometryType = Math.floor(this.params.variation / 4);
+        const geometryLevel = (this.params.variation % 4) + 1;
+        const geometryName = geometryNames[geometryType] || 'CUSTOM VARIATION';
+
+        variationDisplay.textContent = `${this.params.variation + 1} - ${geometryName}`;
+
+        if (this.params.variation < 30) {
+            variationDisplay.textContent += ` ${geometryLevel}`;
         }
     }
-    
+
     updateGeometryButtons() {
         document.querySelectorAll('[data-geometry]').forEach(btn => {
-            btn.classList.toggle('active', parseInt(btn.dataset.geometry) === this.params.geometry);
+            btn.classList.toggle('active', parseInt(btn.dataset.geometry, 10) === this.params.geometry);
         });
     }
-    
+
     /**
      * Randomize all parameters
      */
     randomizeAll() {
-        this.params.rot4dXW = Math.random() * 4 - 2;
-        this.params.rot4dYW = Math.random() * 4 - 2;
-        this.params.rot4dZW = Math.random() * 4 - 2;
-        this.params.dimension = 3.0 + Math.random() * 1.5;
-        this.params.gridDensity = 4 + Math.random() * 26;
-        this.params.morphFactor = Math.random() * 2;
-        this.params.chaos = Math.random();
-        this.params.speed = 0.1 + Math.random() * 2.9;
-        this.params.hue = Math.random() * 360;
-        this.params.geometry = Math.floor(Math.random() * 8);
+        this.setParameter('rot4dXW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('rot4dYW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('rot4dZW', Math.random() * 4 - 2, 'randomize');
+        this.setParameter('dimension', 3.0 + Math.random() * 1.5, 'randomize');
+        this.setParameter('gridDensity', 4 + Math.random() * 96, 'randomize');
+        this.setParameter('morphFactor', Math.random() * 2, 'randomize');
+        this.setParameter('chaos', Math.random(), 'randomize');
+        this.setParameter('speed', 0.1 + Math.random() * 2.9, 'randomize');
+        this.setParameter('hue', Math.random() * 360, 'randomize');
+        this.setParameter('geometry', Math.floor(Math.random() * 8), 'randomize');
     }
-    
+
     /**
      * Reset to default parameters
      */
     resetToDefaults() {
-        this.params = { ...this.defaults };
+        this.setParameters(this.defaults, { source: 'reset' });
     }
-    
+
     /**
      * Load parameter configuration
      */
-    loadConfiguration(config) {
-        if (config && typeof config === 'object') {
-            // Validate and apply configuration
-            for (const [key, value] of Object.entries(config)) {
-                if (this.parameterDefs[key]) {
-                    this.setParameter(key, value);
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-    
-    /**
-     * Export current configuration
-     */
-    exportConfiguration() {
-        return {
-            type: 'vib34d-integrated-config',
-            version: '1.0.0',
-            timestamp: new Date().toISOString(),
-            name: `VIB34D Config ${new Date().toLocaleDateString()}`,
-            parameters: { ...this.params }
-        };
-    }
-    
-    /**
-     * Generate variation-specific parameters
-     */
-    generateVariationParameters(variationIndex) {
-        if (variationIndex < 30) {
-            // Default variations with consistent patterns
-            const geometryType = Math.floor(variationIndex / 4);
-            const level = variationIndex % 4;
-            
-            return {
-                geometry: geometryType,
-                gridDensity: 8 + (level * 4),
-                morphFactor: 0.5 + (level * 0.3),
-                chaos: level * 0.15,
-                speed: 0.8 + (level * 0.2),
-                hue: (geometryType * 45 + level * 15) % 360,
-                rot4dXW: (level - 1.5) * 0.5,
-                rot4dYW: (geometryType % 2) * 0.3,
-                rot4dZW: ((geometryType + level) % 3) * 0.2,
-                dimension: 3.2 + (level * 0.2)
-            };
-        } else {
-            // Custom variations - return current parameters
-            return { ...this.params };
-        }
-    }
-    
-    /**
-     * Apply variation to current parameters
-     */
-    applyVariation(variationIndex) {
-        const variationParams = this.generateVariationParameters(variationIndex);
-        this.setParameters(variationParams);
-        this.params.variation = variationIndex;
-    }
-    
-    /**
-     * Get HSV color values for current hue
-     */
-    getColorHSV() {
-        return {
-            h: this.params.hue,
-            s: 0.8, // Fixed saturation
-            v: 0.9  // Fixed value
-        };
-    }
-    
-    /**
-     * Get RGB color values for current hue
-     */
-    getColorRGB() {
-        const hsv = this.getColorHSV();
-        return this.hsvToRgb(hsv.h, hsv.s, hsv.v);
-    }
-    
-    /**
-     * Convert HSV to RGB
-     */
-    hsvToRgb(h, s, v) {
-        h = h / 60;
-        const c = v * s;
-        const x = c * (1 - Math.abs((h % 2) - 1));
-        const m = v - c;
-        
-        let r, g, b;
-        if (h < 1) {
-            [r, g, b] = [c, x, 0];
-        } else if (h < 2) {
-            [r, g, b] = [x, c, 0];
-        } else if (h < 3) {
-            [r, g, b] = [0, c, x];
-        } else if (h < 4) {
-            [r, g, b] = [0, x, c];
-        } else if (h < 5) {
-            [r, g, b] = [x, 0, c];
-        } else {
-            [r, g, b] = [c, 0, x];
-        }
-        
-        return {
-            r: Math.round((r + m) * 255),
-            g: Math.round((g + m) * 255),
-            b: Math.round((b + m) * 255)
-        };
-    }
-    
-    /**
-     * Validate parameter configuration
-     */
-    validateConfiguration(config) {
+    loadConfiguration(config, options = {}) {
         if (!config || typeof config !== 'object') {
-            return { valid: false, error: 'Configuration must be an object' };
+            return false;
         }
-        
-        if (config.type !== 'vib34d-integrated-config') {
-            return { valid: false, error: 'Invalid configuration type' };
-        }
-        
-        if (!config.parameters) {
-            return { valid: false, error: 'Missing parameters object' };
-        }
-        
-        // Validate individual parameters
-        for (const [key, value] of Object.entries(config.parameters)) {
+
+        const { source = 'import' } = options;
+        Object.entries(config).forEach(([key, value]) => {
             if (this.parameterDefs[key]) {
-                const def = this.parameterDefs[key];
-                if (typeof value !== 'number' || value < def.min || value > def.max) {
-                    return { valid: false, error: `Invalid value for parameter ${key}: ${value}` };
-                }
+                this.setParameter(key, value, source);
             }
+        });
+        return true;
+    }
+
+    /**
+     * Register a listener that fires whenever a parameter changes.
+     */
+    addChangeListener(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
         }
-        
-        return { valid: true };
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    emitChange(name, value, source) {
+        const payload = { name, value, source };
+        this.listeners.forEach(listener => {
+            try {
+                listener(payload);
+            } catch (error) {
+                console.warn('Parameter listener error', error);
+            }
+        });
+    }
+
+    /**
+     * List parameter keys for UI builders
+     */
+    listParameters() {
+        return Object.keys(this.parameterDefs);
+    }
+
+    /**
+     * Retrieve metadata for a parameter key
+     */
+    getParameterMetadata(name) {
+        const def = this.parameterDefs[name];
+        if (!def) return null;
+
+        return {
+            id: name,
+            key: name,
+            label: def.label || this.formatParameterLabel(name),
+            group: def.group || 'General',
+            min: def.min,
+            max: def.max,
+            step: def.step,
+            type: def.type,
+            tags: Array.isArray(def.tags) ? [...def.tags] : []
+        };
+    }
+
+    /**
+     * List parameter metadata for UI builders with optional filtering
+     */
+    listParameterMetadata(filter = {}) {
+        const { groups = null, tags = null } = filter;
+        const groupFilter = Array.isArray(groups) && groups.length ? new Set(groups) : null;
+        const tagFilter = Array.isArray(tags) && tags.length ? new Set(tags) : null;
+
+        return Object.keys(this.parameterDefs)
+            .map(name => this.getParameterMetadata(name))
+            .filter(meta => {
+                if (!meta) return false;
+                if (groupFilter && !groupFilter.has(meta.group)) return false;
+                if (tagFilter) {
+                    const hasTag = meta.tags.some(tag => tagFilter.has(tag));
+                    if (!hasTag) return false;
+                }
+                return true;
+            })
+            .sort((a, b) => {
+                if (a.group === b.group) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.group.localeCompare(b.group);
+            });
+    }
+
+    /**
+     * Format a readable parameter label from its key
+     */
+    formatParameterLabel(name) {
+        if (!name) return '';
+        return name
+            .replace(/rot4d/gi, '4D ')
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/_/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .replace(/^./, char => char.toUpperCase());
+    }
+
+    /**
+     * Clamp a value according to its parameter definition
+     */
+    clampToDefinition(def, value) {
+        if (!def) return value;
+
+        let clampedValue = Math.max(def.min, Math.min(def.max, value));
+        if (def.type === 'int') {
+            clampedValue = Math.round(clampedValue);
+        }
+        return clampedValue;
+    }
+
+    /**
+     * Determine if a change is meaningful (prevents micro-noise)
+     */
+    hasMeaningfulChange(previousValue, nextValue, def) {
+        if (previousValue === undefined) return true;
+        if (def?.type === 'int') {
+            return previousValue !== nextValue;
+        }
+        const epsilon = def?.step ? def.step / 10 : 1e-4;
+        return Math.abs(previousValue - nextValue) > epsilon;
     }
 }

--- a/src/core/PolychoraSystemNew.js
+++ b/src/core/PolychoraSystemNew.js
@@ -12,6 +12,7 @@
  */
 
 import { ParameterManager } from './Parameters.js';
+import { getPerformanceSuiteHost } from '../ui/PerformanceSuiteHost.js';
 
 /**
  * True4DPolychoraVisualizer - Individual layer renderer for 4D polytopes
@@ -514,8 +515,9 @@ export class NewPolychoraEngine {
         this.parameters.setParameter('saturation', 0.9);
         this.parameters.setParameter('gridDensity', 25); // Good for 4D detail
         this.parameters.setParameter('morphFactor', 1.0);
-        
+
         this.init();
+        this.initializePerformanceSuite();
     }
     
     init() {
@@ -524,6 +526,20 @@ export class NewPolychoraEngine {
         this.setup4DInteractivity(); // Unique 4D interaction system
         this.startRenderLoop();
         console.log('✨ TRUE 4D Polychora Engine initialized with VIB34D DNA');
+    }
+
+    initializePerformanceSuite() {
+        if (typeof document === 'undefined') return;
+
+        try {
+            const host = getPerformanceSuiteHost();
+            this.performanceSuite = host.activateEngine(this, {
+                systemName: 'polychora',
+                parameterManager: this.parameters
+            });
+        } catch (error) {
+            console.warn('⚠️ Polychora performance suite initialization failed:', error);
+        }
     }
     
     createVisualizers() {
@@ -741,7 +757,13 @@ export class NewPolychoraEngine {
             visualizer.cleanup();
         });
         this.visualizers = [];
-        
+
+        const host = typeof window !== 'undefined' ? window.performanceSuiteHost : null;
+        if (host?.detachEngine) {
+            host.detachEngine(this);
+            this.performanceSuite = null;
+        }
+
         console.log('🧹 4D Polychora Engine cleaned up');
     }
 }

--- a/src/holograms/RealHolographicSystem.js
+++ b/src/holograms/RealHolographicSystem.js
@@ -4,6 +4,7 @@
  * Audio reactive only - no mouse/touch/scroll interference
  */
 import { HolographicVisualizer } from './HolographicVisualizer.js';
+import { getPerformanceSuiteHost } from '../ui/PerformanceSuiteHost.js';
 
 export class RealHolographicSystem {
     constructor() {
@@ -42,8 +43,9 @@ export class RealHolographicSystem {
             // 26-29: CRYSTAL variations
             'CRYSTAL LATTICE', 'CRYSTAL FIELD', 'CRYSTAL MATRIX', 'CRYSTAL QUANTUM'
         ];
-        
+
         this.initialize();
+        this.initializePerformanceSuite();
     }
     
     initialize() {
@@ -52,6 +54,19 @@ export class RealHolographicSystem {
         this.setupCenterDistanceReactivity(); // NEW: Center-distance grid density changes
         this.updateVariantDisplay();
         this.startRenderLoop();
+    }
+
+    initializePerformanceSuite() {
+        if (typeof document === 'undefined') return;
+
+        try {
+            const host = getPerformanceSuiteHost();
+            this.performanceSuite = host.activateEngine(this, {
+                systemName: 'holographic'
+            });
+        } catch (error) {
+            console.warn('⚠️ Holographic performance suite initialization failed:', error);
+        }
     }
     
     createVisualizers() {
@@ -717,7 +732,13 @@ export class RealHolographicSystem {
         if (this.audioContext) {
             this.audioContext.close();
         }
-        
+
+        const host = typeof window !== 'undefined' ? window.performanceSuiteHost : null;
+        if (host?.detachEngine) {
+            host.detachEngine(this);
+            this.performanceSuite = null;
+        }
+
         console.log('🧹 REAL Holographic System destroyed');
     }
 }

--- a/src/quantum/QuantumEngine.js
+++ b/src/quantum/QuantumEngine.js
@@ -6,6 +6,7 @@
 import { QuantumHolographicVisualizer } from './QuantumVisualizer.js';
 import { ParameterManager } from '../core/Parameters.js';
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { getPerformanceSuiteHost } from '../ui/PerformanceSuiteHost.js';
 
 export class QuantumEngine {
     constructor() {
@@ -34,8 +35,9 @@ export class QuantumEngine {
         this.parameters.setParameter('saturation', 0.9); // More vivid
         this.parameters.setParameter('gridDensity', 20); // Denser patterns
         this.parameters.setParameter('morphFactor', this.baseMorphFactor);
-        
+
         this.init();
+        this.initializePerformanceSuite();
     }
     
     /**
@@ -47,6 +49,20 @@ export class QuantumEngine {
         this.setupGestureVelocityReactivity(); // Additional gesture system
         this.startRenderLoop();
         console.log('✨ Quantum Engine initialized with audio + gesture velocity reactivity');
+    }
+
+    initializePerformanceSuite() {
+        if (typeof document === 'undefined') return;
+
+        try {
+            const host = getPerformanceSuiteHost();
+            this.performanceSuite = host.activateEngine(this, {
+                systemName: 'quantum',
+                parameterManager: this.parameters
+            });
+        } catch (error) {
+            console.warn('⚠️ Quantum performance suite initialization failed:', error);
+        }
     }
     
     /**
@@ -573,6 +589,12 @@ export class QuantumEngine {
             }
         });
         this.visualizers = [];
+
+        const host = typeof window !== 'undefined' ? window.performanceSuiteHost : null;
+        if (host?.detachEngine) {
+            host.detachEngine(this);
+            this.performanceSuite = null;
+        }
         console.log('🧹 Quantum Engine destroyed');
     }
 }

--- a/src/ui/AudioReactivityPanel.js
+++ b/src/ui/AudioReactivityPanel.js
@@ -1,0 +1,295 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+const BAND_LABELS = {
+    bass: 'Bass',
+    mid: 'Mid',
+    treble: 'Treble',
+    energy: 'Energy'
+};
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export class AudioReactivityPanel {
+    constructor({
+        parameterManager = null,
+        container = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.audio,
+        hub = null,
+        onSettingsChange = null,
+        settings = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.hub = hub;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.audio, ...(config || {}) };
+        this.onSettingsChange = typeof onSettingsChange === 'function' ? onSettingsChange : () => {};
+
+        this.container = container || this.ensureContainer();
+        const defaults = clone(this.config.defaults || {});
+        this.settings = Object.assign(defaults, clone(settings || {}));
+
+        this.render();
+        this.applySettingsToForm();
+        this.emitChange();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-audio');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-audio';
+        return section;
+    }
+
+    render() {
+        if (!this.container) return;
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Audio Reactivity</h3>
+                <p class="performance-block__subtitle">Blend live sound with your choreography. Toggle bands, tune weights, and launch flourishes.</p>
+            </div>
+            <div class="performance-block__actions">
+                <button type="button" class="audio-reset">Reset</button>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        header.querySelector('.audio-reset').addEventListener('click', () => {
+            this.settings = clone(this.config.defaults || {});
+            this.applySettingsToForm();
+            this.emitChange();
+        });
+
+        const form = document.createElement('form');
+        form.className = 'audio-panel';
+        form.addEventListener('submit', (event) => event.preventDefault());
+
+        form.appendChild(this.renderMasterSection());
+        form.appendChild(this.renderBandSection());
+        form.appendChild(this.renderFlourishSection());
+
+        this.container.appendChild(form);
+        this.form = form;
+    }
+
+    renderMasterSection() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-panel__fieldset';
+        fieldset.innerHTML = `
+            <legend>Master</legend>
+            <label class="toggle-pill">
+                <input type="checkbox" name="enabled">
+                <span>Enable audio reactivity</span>
+            </label>
+            <label class="toggle-pill">
+                <input type="checkbox" name="beatSync">
+                <span>Beat sync</span>
+            </label>
+            <label class="slider-control">
+                <span>Sensitivity</span>
+                <input type="range" name="sensitivity" min="0" max="1" step="0.05">
+            </label>
+            <label class="slider-control">
+                <span>Smoothing</span>
+                <input type="range" name="smoothing" min="0" max="0.9" step="0.05">
+            </label>
+        `;
+
+        fieldset.querySelectorAll('input').forEach(input => {
+            input.addEventListener('input', () => this.handleMasterChange());
+            input.addEventListener('change', () => this.handleMasterChange());
+        });
+
+        return fieldset;
+    }
+
+    renderBandSection() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-panel__fieldset';
+        fieldset.innerHTML = '<legend>Bands</legend>';
+
+        Object.keys(BAND_LABELS).forEach(band => {
+            const row = document.createElement('div');
+            row.className = 'audio-panel__band-row';
+            row.innerHTML = `
+                <div class="audio-panel__band-label">
+                    <span>${BAND_LABELS[band]}</span>
+                </div>
+                <label class="toggle-pill">
+                    <input type="checkbox" name="band-${band}">
+                    <span>Active</span>
+                </label>
+                <label class="slider-control">
+                    <span>Weight</span>
+                    <input type="range" name="band-${band}-weight" min="0" max="1" step="0.05">
+                </label>
+            `;
+
+            row.querySelectorAll('input').forEach(input => {
+                input.addEventListener('input', () => this.handleBandChange(band));
+                input.addEventListener('change', () => this.handleBandChange(band));
+            });
+
+            fieldset.appendChild(row);
+        });
+
+        return fieldset;
+    }
+
+    renderFlourishSection() {
+        const fieldset = document.createElement('fieldset');
+        fieldset.className = 'audio-panel__fieldset';
+        fieldset.innerHTML = `
+            <legend>Flourish</legend>
+            <label class="toggle-pill">
+                <input type="checkbox" name="flourish-enabled">
+                <span>Enable flourish boost</span>
+            </label>
+            <label class="audio-select">
+                <span>Parameter</span>
+                <select name="flourish-parameter"></select>
+            </label>
+            <label class="slider-control">
+                <span>Trigger threshold</span>
+                <input type="range" name="flourish-threshold" min="0" max="1" step="0.05">
+            </label>
+            <label class="slider-control">
+                <span>Boost amount</span>
+                <input type="range" name="flourish-amount" min="0" max="1" step="0.05">
+            </label>
+            <div class="audio-panel__flourish-actions">
+                <button type="button" class="flourish-trigger">Trigger flourish</button>
+            </div>
+        `;
+
+        fieldset.querySelector('.flourish-trigger').addEventListener('click', () => {
+            this.triggerFlourish();
+        });
+
+        const select = fieldset.querySelector('select');
+        this.populateParameterOptions(select);
+        this.ensureFlourishParameter(select);
+        select.addEventListener('change', (event) => {
+            this.settings.flourish.parameter = event.target.value;
+            this.emitChange();
+        });
+
+        fieldset.querySelectorAll('input').forEach(input => {
+            input.addEventListener('input', () => this.handleFlourishChange());
+            input.addEventListener('change', () => this.handleFlourishChange());
+        });
+
+        return fieldset;
+    }
+
+    populateParameterOptions(select) {
+        if (!select) return;
+        const options = this.parameterManager?.listParameterMetadata({ tags: ['performance', 'dynamics', 'color'] })
+            || this.parameterManager?.listParameterMetadata()
+            || [];
+        select.innerHTML = options.map(meta => `<option value="${meta.id}">${meta.label}</option>`).join('');
+    }
+
+    ensureFlourishParameter(select) {
+        if (!select) return;
+        const available = Array.from(select.options).map(option => option.value);
+        if (!available.length) {
+            this.settings.flourish.parameter = '';
+            return;
+        }
+        if (available.includes(this.settings.flourish?.parameter)) {
+            select.value = this.settings.flourish.parameter;
+            return;
+        }
+        select.value = available[0];
+        if (!this.settings.flourish) {
+            this.settings.flourish = {};
+        }
+        this.settings.flourish.parameter = select.value;
+    }
+
+    applySettingsToForm() {
+        if (!this.form) return;
+        const settings = this.settings;
+        this.form.querySelector('[name="enabled"]').checked = Boolean(settings.enabled);
+        this.form.querySelector('[name="beatSync"]').checked = Boolean(settings.beatSync);
+        this.form.querySelector('[name="sensitivity"]').value = settings.sensitivity ?? 0.5;
+        this.form.querySelector('[name="smoothing"]').value = settings.smoothing ?? 0.2;
+
+        Object.keys(BAND_LABELS).forEach(band => {
+            const bandSettings = settings.bands?.[band] || { enabled: false, weight: 0 };
+            this.form.querySelector(`[name="band-${band}"]`).checked = Boolean(bandSettings.enabled);
+            this.form.querySelector(`[name="band-${band}-weight"]`).value = bandSettings.weight ?? 0;
+        });
+
+        const flourish = settings.flourish || {};
+        this.form.querySelector('[name="flourish-enabled"]').checked = Boolean(flourish.enabled);
+        const select = this.form.querySelector('[name="flourish-parameter"]');
+        this.ensureFlourishParameter(select);
+        this.form.querySelector('[name="flourish-threshold"]').value = flourish.threshold ?? 0.5;
+        this.form.querySelector('[name="flourish-amount"]').value = flourish.amount ?? 0.3;
+    }
+
+    handleMasterChange() {
+        const formData = new FormData(this.form);
+        this.settings.enabled = formData.get('enabled') === 'on';
+        this.settings.beatSync = formData.get('beatSync') === 'on';
+        const sensitivity = Number(formData.get('sensitivity'));
+        const smoothing = Number(formData.get('smoothing'));
+        this.settings.sensitivity = Math.max(0, Math.min(1, sensitivity));
+        this.settings.smoothing = Math.max(0, Math.min(0.9, smoothing));
+        this.emitChange();
+    }
+
+    handleBandChange(band) {
+        if (!this.settings.bands) {
+            this.settings.bands = {};
+        }
+        const enabled = this.form.querySelector(`[name="band-${band}"]`).checked;
+        const weight = Number(this.form.querySelector(`[name="band-${band}-weight"]`).value);
+        const clampedWeight = Math.max(0, Math.min(1, weight));
+        this.settings.bands[band] = { enabled, weight: clampedWeight };
+        this.emitChange();
+    }
+
+    handleFlourishChange() {
+        const flourish = this.settings.flourish || (this.settings.flourish = {});
+        flourish.enabled = this.form.querySelector('[name="flourish-enabled"]').checked;
+        const threshold = Number(this.form.querySelector('[name="flourish-threshold"]').value);
+        const amount = Number(this.form.querySelector('[name="flourish-amount"]').value);
+        flourish.threshold = Math.max(0, Math.min(1, threshold));
+        flourish.amount = Math.max(0, Math.min(1, amount));
+        this.emitChange();
+    }
+
+    triggerFlourish() {
+        const flourish = this.settings.flourish || {};
+        if (!flourish.enabled) return;
+        this.hub?.emit?.('audio:flourish', clone(flourish));
+    }
+
+    emitChange() {
+        const settings = this.getSettings();
+        this.onSettingsChange(settings);
+        this.hub?.emit?.('audio:settings', settings);
+    }
+
+    getSettings() {
+        return clone(this.settings);
+    }
+
+    applySettings(settings = {}) {
+        this.settings = Object.assign(clone(this.config.defaults || {}), clone(settings));
+        this.applySettingsToForm();
+        this.emitChange();
+    }
+}

--- a/src/ui/PerformanceConfig.js
+++ b/src/ui/PerformanceConfig.js
@@ -1,0 +1,185 @@
+import { DEFAULT_THEME_TRANSITION } from './PerformanceThemeUtils.js';
+
+const DEFAULT_TOUCHPAD_MAPPINGS = [
+    {
+        id: 'pad-1',
+        label: 'Orbit Sculpt',
+        axes: {
+            x: { parameter: 'rot4dXW', invert: false, smoothing: 0.2 },
+            y: { parameter: 'rot4dYW', invert: false, smoothing: 0.2 },
+            spread: { parameter: 'speed', invert: false, smoothing: 0.3 }
+        }
+    },
+    {
+        id: 'pad-2',
+        label: 'Chromatic Wash',
+        axes: {
+            x: { parameter: 'hue', invert: false, smoothing: 0.15 },
+            y: { parameter: 'intensity', invert: false, smoothing: 0.2 },
+            spread: { parameter: 'saturation', invert: false, smoothing: 0.25 }
+        }
+    },
+    {
+        id: 'pad-3',
+        label: 'Geometry Chisel',
+        axes: {
+            x: { parameter: 'gridDensity', invert: false, smoothing: 0.25 },
+            y: { parameter: 'morphFactor', invert: false, smoothing: 0.25 },
+            spread: { parameter: 'chaos', invert: false, smoothing: 0.35 }
+        }
+    }
+];
+
+const DEFAULT_AUDIO_SETTINGS = {
+    enabled: true,
+    beatSync: true,
+    smoothing: 0.25,
+    sensitivity: 0.75,
+    bands: {
+        bass: { enabled: true, weight: 0.9 },
+        mid: { enabled: true, weight: 0.6 },
+        treble: { enabled: true, weight: 0.5 },
+        energy: { enabled: true, weight: 0.7 }
+    },
+    flourish: {
+        enabled: true,
+        parameter: 'intensity',
+        threshold: 0.65,
+        amount: 0.4
+    }
+};
+
+const DEFAULT_PRESET_CONFIG = {
+    storageKey: 'vib34d-performance-presets',
+    playlistKey: 'vib34d-performance-playlist'
+};
+
+const DEFAULT_HARDWARE_CONFIG = {
+    storageKey: 'vib34d-hardware-mappings',
+    autoConnect: false,
+    pickupThreshold: 0.04,
+    smoothing: 0.18,
+    channel: 'omni'
+};
+
+const DEFAULT_NETWORK_CONFIG = {
+    storageKey: 'vib34d-performance-osc',
+    defaults: {
+        enabled: false,
+        autoConnect: false,
+        endpoint: 'ws://localhost:3030',
+        namespace: '/performance',
+        forward: {
+            touchpad: true,
+            audio: true,
+            show: true,
+            presets: true,
+            hardware: true,
+            gestures: true,
+            theme: true
+        }
+    }
+};
+
+const DEFAULT_GESTURE_CONFIG = {
+    storageKey: 'vib34d-performance-gestures',
+    captureEvents: ['touchpad:update', 'hardware:midi-value'],
+    maxDuration: 120000,
+    maxEvents: 2200,
+    autoNamePrefix: 'Take',
+    quantizeBeats: false
+};
+
+const DEFAULT_TELEMETRY_CONFIG = {
+    rotationParameters: ['rot4dXW', 'rot4dYW', 'rot4dZW'],
+    dynamicsParameters: ['dimension', 'speed', 'chaos', 'intensity'],
+    historySize: 180,
+    pulseFadeMs: 2600
+};
+
+const DEFAULT_SHOW_PLANNER_CONFIG = {
+    storageKey: 'vib34d-show-planner',
+    defaults: {
+        tempo: 120,
+        beatsPerBar: 4,
+        autoAdvance: false,
+        loop: false
+    }
+};
+
+const DEFAULT_THEME_CONFIG = {
+    storageKey: 'vib34d-performance-theme',
+    palettes: [
+        { id: 'aurora', label: 'Aurora Bloom', accent: '#6df9ff', highlightAlpha: 0.28, glowStrength: 0.8 },
+        { id: 'sunset', label: 'Crimson Sunset', accent: '#ff5e9f', highlightAlpha: 0.23, glowStrength: 0.55 },
+        { id: 'atmos', label: 'Atmos Drift', accent: '#8f6dff', highlightAlpha: 0.3, glowStrength: 0.72 }
+    ],
+    transitionDefaults: DEFAULT_THEME_TRANSITION
+};
+
+const DEFAULT_TOUCHPAD_CONFIG = {
+    padCount: 3,
+    parameterTags: ['performance', 'rotation', 'structure', 'color', 'dynamics'],
+    defaults: DEFAULT_TOUCHPAD_MAPPINGS,
+    storageKey: 'vib34d-touchpads',
+    surface: {
+        minWidth: 220,
+        aspectRatio: 1,
+        gap: 16
+    }
+};
+
+const DEFAULT_LAYOUT_CONFIG = {
+    storageKey: 'vib34d-performance-layout',
+    profileStorageKey: 'vib34d-performance-layout-profiles',
+    mobileBreakpoint: 1100,
+    defaultPanel: 'pads',
+    collapsedStacks: [],
+    profile: 'balanced',
+    density: 0.45,
+    fontScale: 1,
+    surfaceScale: 1,
+    columnOrder: ['pads', 'audio', 'presets']
+};
+
+const DEFAULT_PERFORMANCE_CONFIG = {
+    touchPads: DEFAULT_TOUCHPAD_CONFIG,
+    audio: {
+        defaults: DEFAULT_AUDIO_SETTINGS
+    },
+    presets: DEFAULT_PRESET_CONFIG,
+    hardware: DEFAULT_HARDWARE_CONFIG,
+    network: DEFAULT_NETWORK_CONFIG,
+    gestures: DEFAULT_GESTURE_CONFIG,
+    telemetry: DEFAULT_TELEMETRY_CONFIG,
+    showPlanner: DEFAULT_SHOW_PLANNER_CONFIG,
+    theme: DEFAULT_THEME_CONFIG,
+    layout: DEFAULT_LAYOUT_CONFIG
+};
+
+function deepMerge(base, override) {
+    if (!override) {
+        return JSON.parse(JSON.stringify(base));
+    }
+
+    if (Array.isArray(base)) {
+        return override.slice();
+    }
+
+    const result = { ...base };
+    Object.keys(override).forEach(key => {
+        const value = override[key];
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            result[key] = deepMerge(base[key] || {}, value);
+        } else {
+            result[key] = value;
+        }
+    });
+    return result;
+}
+
+export function mergePerformanceConfig(overrides = {}) {
+    return deepMerge(DEFAULT_PERFORMANCE_CONFIG, overrides);
+}
+
+export { DEFAULT_PERFORMANCE_CONFIG, DEFAULT_GESTURE_CONFIG, DEFAULT_LAYOUT_CONFIG };

--- a/src/ui/PerformanceGestureRecorder.js
+++ b/src/ui/PerformanceGestureRecorder.js
@@ -1,0 +1,815 @@
+import { DEFAULT_GESTURE_CONFIG } from './PerformanceConfig.js';
+
+const DEFAULT_CAPTURE_EVENTS = ['touchpad:update', 'hardware:midi-value'];
+const DEFAULT_MAX_DURATION = 120000;
+const DEFAULT_MAX_EVENTS = 2200;
+
+function clone(value) {
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+        return null;
+    }
+}
+
+function createId(prefix = 'take') {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function now() {
+    if (typeof performance !== 'undefined' && performance.now) {
+        return performance.now();
+    }
+    return Date.now();
+}
+
+function formatDuration(ms) {
+    if (!ms || ms <= 0) {
+        return '0.0s';
+    }
+    if (ms < 1000) {
+        return `${ms.toFixed(0)}ms`;
+    }
+    const seconds = ms / 1000;
+    if (seconds < 60) {
+        return `${seconds.toFixed(1)}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainder = (seconds % 60).toFixed(0).padStart(2, '0');
+    return `${minutes}:${remainder}`;
+}
+
+function formatBeats(ms, tempo) {
+    if (!tempo || tempo <= 0) {
+        return null;
+    }
+    const beats = (ms / 60000) * tempo;
+    if (beats < 1) {
+        return null;
+    }
+    if (beats < 16) {
+        return `≈${beats.toFixed(1)} beats`;
+    }
+    return `≈${beats.toFixed(0)} beats`;
+}
+
+function sanitizeEvents(events = []) {
+    if (!Array.isArray(events)) {
+        return [];
+    }
+    return events
+        .map(event => {
+            if (!event || typeof event !== 'object') {
+                return null;
+            }
+            const time = typeof event.time === 'number' && event.time >= 0 ? event.time : 0;
+            const type = typeof event.type === 'string' ? event.type : 'custom';
+            const payload = clone(event.payload) || {};
+            const normalized = typeof event.normalized === 'number' ? event.normalized : undefined;
+            if (typeof normalized === 'number' && typeof payload.normalized !== 'number') {
+                payload.normalized = normalized;
+            }
+            return { time, type, payload };
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.time - b.time);
+}
+
+function normalizeRecording(record = {}, index = 0) {
+    const id = typeof record.id === 'string' && record.id ? record.id : createId('take');
+    const name = typeof record.name === 'string' && record.name
+        ? record.name
+        : `Take ${index + 1}`;
+    const events = sanitizeEvents(record.events);
+    const duration = typeof record.duration === 'number' && record.duration > 0
+        ? record.duration
+        : events.length
+            ? events[events.length - 1].time
+            : 0;
+    const createdAt = typeof record.createdAt === 'number' ? record.createdAt : Date.now();
+    const updatedAt = typeof record.updatedAt === 'number' ? record.updatedAt : createdAt;
+    const sources = Array.isArray(record.sources) ? record.sources.filter(Boolean) : [];
+
+    return {
+        id,
+        name,
+        duration,
+        events,
+        createdAt,
+        updatedAt,
+        sources
+    };
+}
+
+function describeSources(sources = []) {
+    if (!sources.length) {
+        return 'custom';
+    }
+    const labels = sources.map(source => {
+        switch (source) {
+            case 'touchpad:update':
+                return 'Touch Pad';
+            case 'hardware:midi-value':
+                return 'MIDI';
+            case 'audio:flourish':
+                return 'Audio';
+            default:
+                return source;
+        }
+    });
+    return Array.from(new Set(labels)).join(' + ');
+}
+
+export class PerformanceGestureRecorder {
+    constructor({
+        parameterManager = null,
+        hub = null,
+        container = null,
+        config = DEFAULT_GESTURE_CONFIG,
+        onStatusChange = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.hub = hub;
+        this.config = { ...DEFAULT_GESTURE_CONFIG, ...(config || {}) };
+        this.onStatusChange = typeof onStatusChange === 'function' ? onStatusChange : () => {};
+
+        this.container = container || this.ensureContainer();
+        this.statusEl = null;
+        this.tempoEl = null;
+        this.listEl = null;
+        this.recordButton = null;
+        this.stopButton = null;
+        this.playButton = null;
+        this.clearButton = null;
+        this.importInput = null;
+
+        this.recordings = [];
+        this.selectedId = null;
+        this.isRecording = false;
+        this.isPlaying = false;
+        this.currentRecording = null;
+        this.playbackTimers = [];
+        this.statusState = 'idle';
+        this.statusMessage = 'Ready';
+        this.subscriptions = [];
+        this.currentTempo = null;
+        this.beatsPerBar = null;
+        this.showRunning = false;
+
+        this.loadState();
+        this.render();
+        this.bindHub();
+        this.emitGestureSummaries();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-gestures');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-gestures';
+        return section;
+    }
+
+    bindHub() {
+        if (!this.hub || typeof this.hub.on !== 'function') {
+            return;
+        }
+        const captureEvents = Array.isArray(this.config.captureEvents) && this.config.captureEvents.length
+            ? this.config.captureEvents
+            : DEFAULT_CAPTURE_EVENTS;
+        captureEvents.forEach(eventName => {
+            this.subscriptions.push(this.hub.on(eventName, payload => this.captureEvent(eventName, payload)));
+        });
+        this.subscriptions.push(this.hub.on('audio:flourish', payload => this.captureEvent('audio:flourish', payload)));
+        this.subscriptions.push(this.hub.on('show:start', meta => this.handleShowStart(meta)));
+        this.subscriptions.push(this.hub.on('show:stop', () => this.handleShowStop()));
+        this.subscriptions.push(this.hub.on('show:cue-trigger', ({ cue } = {}) => this.handleCueTrigger(cue)));
+    }
+
+    unbindHub() {
+        this.subscriptions.forEach(unsubscribe => {
+            try {
+                unsubscribe?.();
+            } catch (error) {
+                // ignore cleanup failures
+            }
+        });
+        this.subscriptions = [];
+    }
+
+    render() {
+        if (!this.container) {
+            return;
+        }
+        this.container.classList.add('performance-block', 'gesture-recorder');
+        this.container.innerHTML = `
+            <header class="performance-block__header gesture-recorder__header">
+                <div>
+                    <h3 class="performance-block__title">Gesture Recorder</h3>
+                    <p class="performance-block__subtitle">
+                        Capture touch pad and hardware moves into reusable flourishes.
+                        <span class="gesture-recorder__tempo" data-role="tempo"></span>
+                    </p>
+                </div>
+                <div class="gesture-recorder__status" data-role="status">Ready</div>
+            </header>
+            <div class="gesture-recorder__controls">
+                <button type="button" data-action="record">Record</button>
+                <button type="button" data-action="stop" disabled>Stop</button>
+                <button type="button" data-action="play" disabled>Play</button>
+                <button type="button" data-action="clear" disabled>Clear</button>
+                <div class="gesture-recorder__library-actions">
+                    <button type="button" data-action="export" class="gesture-recorder__export" disabled>Export</button>
+                    <label class="gesture-recorder__import">
+                        Import
+                        <input type="file" accept="application/json" data-action="import" hidden />
+                    </label>
+                </div>
+            </div>
+            <section class="gesture-recorder__takes">
+                <header class="gesture-recorder__takes-header">
+                    <h4>Captured Gestures</h4>
+                    <span class="gesture-recorder__hint">Double-click a take to rename it.</span>
+                </header>
+                <ul class="gesture-recorder__list" data-role="list"></ul>
+            </section>
+        `;
+
+        this.statusEl = this.container.querySelector('[data-role="status"]');
+        this.tempoEl = this.container.querySelector('[data-role="tempo"]');
+        this.listEl = this.container.querySelector('[data-role="list"]');
+        this.recordButton = this.container.querySelector('[data-action="record"]');
+        this.stopButton = this.container.querySelector('[data-action="stop"]');
+        this.playButton = this.container.querySelector('[data-action="play"]');
+        this.clearButton = this.container.querySelector('[data-action="clear"]');
+        this.exportButton = this.container.querySelector('[data-action="export"]');
+        this.importInput = this.container.querySelector('[data-action="import"]');
+
+        this.recordButton.addEventListener('click', () => this.toggleRecording());
+        this.stopButton.addEventListener('click', () => this.stopRecording());
+        this.playButton.addEventListener('click', () => this.togglePlayback());
+        this.clearButton.addEventListener('click', () => this.clearRecordings());
+        this.exportButton.addEventListener('click', () => this.exportRecordings());
+        this.importInput.addEventListener('change', event => this.importRecordings(event));
+
+        this.renderList();
+        this.updateTempoDisplay();
+        this.updateControls();
+        this.updateStatusDisplay();
+    }
+
+    renderList() {
+        if (!this.listEl) return;
+        this.listEl.innerHTML = '';
+        if (!this.recordings.length) {
+            const empty = document.createElement('li');
+            empty.className = 'gesture-recorder__empty';
+            empty.textContent = 'Record a take to build your flourish library.';
+            this.listEl.appendChild(empty);
+            return;
+        }
+
+        this.recordings.forEach(recording => {
+            const item = document.createElement('li');
+            item.className = 'gesture-recorder__take';
+            if (recording.id === this.selectedId) {
+                item.classList.add('gesture-recorder__take--selected');
+            }
+            item.dataset.id = recording.id;
+            const durationLabel = formatDuration(recording.duration);
+            const beatsLabel = formatBeats(recording.duration, this.currentTempo);
+            const metaParts = [durationLabel, `${recording.events.length} events`, describeSources(recording.sources)];
+            if (beatsLabel) {
+                metaParts.splice(1, 0, beatsLabel);
+            }
+            const meta = metaParts.join(' • ');
+            item.innerHTML = `
+                <button type="button" class="gesture-recorder__take-select" data-action="select">
+                    <span class="gesture-recorder__take-name">${recording.name}</span>
+                    <span class="gesture-recorder__take-meta">${meta}</span>
+                </button>
+                <div class="gesture-recorder__take-actions">
+                    <button type="button" data-action="duplicate">Duplicate</button>
+                    <button type="button" data-action="delete">Delete</button>
+                </div>
+            `;
+
+            item.querySelector('[data-action="select"]').addEventListener('click', () => this.selectRecording(recording.id));
+            item.querySelector('[data-action="select"]').addEventListener('dblclick', () => this.renameRecording(recording.id));
+            item.querySelector('[data-action="duplicate"]').addEventListener('click', () => this.duplicateRecording(recording.id));
+            item.querySelector('[data-action="delete"]').addEventListener('click', () => this.deleteRecording(recording.id));
+
+            this.listEl.appendChild(item);
+        });
+    }
+
+    updateControls() {
+        if (!this.recordButton || !this.stopButton || !this.playButton) {
+            return;
+        }
+        this.recordButton.disabled = this.isRecording;
+        this.stopButton.disabled = !this.isRecording && !this.isPlaying;
+        const hasSelection = Boolean(this.selectedId && this.recordings.find(record => record.id === this.selectedId));
+        this.playButton.disabled = !hasSelection;
+        this.playButton.textContent = this.isPlaying ? 'Stop' : 'Play';
+        this.clearButton.disabled = !this.recordings.length;
+        if (this.exportButton) {
+            this.exportButton.disabled = !this.recordings.length;
+        }
+    }
+
+    updateStatusDisplay() {
+        if (!this.statusEl) return;
+        const label = this.statusState === 'recording'
+            ? 'Recording'
+            : this.statusState === 'playing'
+                ? 'Playback'
+                : 'Ready';
+        this.statusEl.textContent = this.statusMessage || label;
+        if (this.container) {
+            this.container.classList.toggle('gesture-recorder--recording', this.statusState === 'recording');
+            this.container.classList.toggle('gesture-recorder--playing', this.statusState === 'playing');
+        }
+    }
+
+    updateTempoDisplay() {
+        if (!this.tempoEl) return;
+        if (!this.currentTempo) {
+            this.tempoEl.textContent = '';
+            return;
+        }
+        const tempo = `${Math.round(this.currentTempo)} BPM`;
+        const meter = this.beatsPerBar ? `${this.beatsPerBar} beats/bar` : null;
+        const running = this.showRunning ? '• Show running' : null;
+        const parts = [tempo];
+        if (meter) parts.push(meter);
+        if (running) parts.push(running);
+        this.tempoEl.textContent = parts.length ? `(${parts.join(' • ')})` : '';
+    }
+
+    setStatus(state, message) {
+        this.statusState = state || 'idle';
+        if (message) {
+            this.statusMessage = message;
+        } else if (this.statusState === 'idle') {
+            this.statusMessage = 'Ready';
+        }
+        this.updateStatusDisplay();
+        if (message) {
+            this.onStatusChange(message);
+        } else if (this.statusState === 'recording') {
+            this.onStatusChange('Recording gesture');
+        }
+    }
+
+    toggleRecording() {
+        if (this.isRecording) {
+            this.stopRecording();
+            return;
+        }
+        this.startRecording();
+    }
+
+    startRecording() {
+        if (this.isRecording) return;
+        if (this.isPlaying) {
+            this.stopPlayback();
+        }
+        const id = createId('take');
+        const name = this.generateRecordingName();
+        this.currentRecording = {
+            id,
+            name,
+            events: [],
+            duration: 0,
+            sources: [],
+            sourceSet: new Set(),
+            startedAt: now(),
+            createdAt: Date.now(),
+            updatedAt: Date.now()
+        };
+        this.isRecording = true;
+        this.setStatus('recording', `Recording ${name}`);
+        this.updateControls();
+        this.hub?.emit?.('gestures:recording-start', { id, name });
+    }
+
+    stopRecording({ reason = '', discard = false } = {}) {
+        if (!this.isRecording) {
+            return;
+        }
+        const recording = this.currentRecording;
+        this.isRecording = false;
+        this.currentRecording = null;
+
+        if (!recording) {
+            this.setStatus('idle');
+            this.updateControls();
+            return;
+        }
+
+        recording.duration = Math.max(recording.duration || 0, now() - recording.startedAt);
+        recording.events = sanitizeEvents(recording.events);
+        recording.sourceSet?.forEach(value => recording.sources.push(value));
+        recording.sources = Array.from(new Set(recording.sources));
+        recording.updatedAt = Date.now();
+        delete recording.startedAt;
+        delete recording.sourceSet;
+
+        if (discard || !recording.events.length) {
+            const message = discard ? 'Recording discarded' : 'Recording cancelled';
+            this.setStatus('idle', message);
+            this.updateControls();
+            return;
+        }
+
+        const maxEvents = typeof this.config.maxEvents === 'number' && this.config.maxEvents > 0
+            ? this.config.maxEvents
+            : DEFAULT_MAX_EVENTS;
+        if (recording.events.length > maxEvents) {
+            recording.events = recording.events.slice(0, maxEvents);
+            recording.duration = recording.events[recording.events.length - 1].time;
+        }
+
+        this.recordings.unshift(recording);
+        this.selectedId = recording.id;
+        this.persistState();
+        this.renderList();
+        this.emitGestureSummaries();
+        const message = reason
+            ? `Recording saved (${reason})`
+            : `Saved ${recording.name}`;
+        this.setStatus('idle', message);
+        this.updateControls();
+        this.hub?.emit?.('gestures:recording-stop', { id: recording.id, name: recording.name });
+    }
+
+    togglePlayback() {
+        if (this.isPlaying) {
+            this.stopPlayback();
+            return;
+        }
+        if (!this.selectedId) {
+            return;
+        }
+        this.playRecording(this.selectedId);
+    }
+
+    playRecording(id) {
+        const recording = this.recordings.find(item => item.id === id);
+        if (!recording || !recording.events.length) {
+            return;
+        }
+        this.stopPlayback();
+        if (this.isRecording) {
+            this.stopRecording({ discard: true });
+        }
+        this.isPlaying = true;
+        this.activePlaybackId = recording.id;
+        this.playbackStartedAt = now();
+        this.playbackTimers = [];
+        this.setStatus('playing', `Playing ${recording.name}`);
+        this.updateControls();
+        this.hub?.emit?.('gestures:playback-start', { id: recording.id, name: recording.name });
+
+        recording.events.forEach(event => {
+            const timer = setTimeout(() => {
+                this.applyPlaybackEvent(recording, event);
+            }, Math.max(0, event.time));
+            this.playbackTimers.push(timer);
+        });
+        const finalTimer = setTimeout(() => {
+            this.finishPlayback();
+        }, Math.max(16, recording.duration + 16));
+        this.playbackTimers.push(finalTimer);
+    }
+
+    applyPlaybackEvent(recording, event) {
+        if (!event) return;
+        const payload = clone(event.payload) || {};
+        const parameterId = payload.parameter;
+        const value = this.resolveEventValue(parameterId, payload);
+        if (parameterId && typeof value === 'number') {
+            this.parameterManager?.setParameter?.(parameterId, value, 'gesture');
+        }
+        this.hub?.emit?.('gestures:playback-event', {
+            recordingId: recording?.id,
+            name: recording?.name,
+            event: {
+                type: event.type,
+                time: event.time,
+                payload
+            }
+        });
+    }
+
+    resolveEventValue(parameterId, payload = {}) {
+        if (typeof payload.value === 'number') {
+            return payload.value;
+        }
+        const normalized = typeof payload.normalized === 'number' ? payload.normalized : null;
+        if (normalized === null || typeof this.parameterManager?.getParameterDefinition !== 'function') {
+            return normalized;
+        }
+        const def = this.parameterManager.getParameterDefinition(parameterId);
+        if (!def) {
+            return normalized;
+        }
+        const clamped = Math.max(0, Math.min(1, normalized));
+        const value = def.min + (def.max - def.min) * clamped;
+        if (def.type === 'int') {
+            return Math.round(value);
+        }
+        return value;
+    }
+
+    stopPlayback() {
+        if (!this.isPlaying) {
+            return;
+        }
+        this.playbackTimers.forEach(timer => clearTimeout(timer));
+        this.playbackTimers = [];
+        const wasActive = this.activePlaybackId;
+        this.isPlaying = false;
+        this.activePlaybackId = null;
+        this.setStatus('idle', 'Playback stopped');
+        this.updateControls();
+        if (wasActive) {
+            this.hub?.emit?.('gestures:playback-stop', { id: wasActive });
+        }
+    }
+
+    finishPlayback() {
+        if (!this.isPlaying) {
+            return;
+        }
+        const active = this.activePlaybackId;
+        this.isPlaying = false;
+        this.playbackTimers = [];
+        this.activePlaybackId = null;
+        this.setStatus('idle', 'Playback finished');
+        this.updateControls();
+        if (active) {
+            this.hub?.emit?.('gestures:playback-complete', { id: active });
+        }
+    }
+
+    selectRecording(id) {
+        if (!id) return;
+        this.selectedId = id;
+        this.renderList();
+        this.updateControls();
+        const recording = this.recordings.find(item => item.id === id);
+        if (recording) {
+            this.setStatus('idle', `Selected ${recording.name}`);
+        }
+    }
+
+    renameRecording(id) {
+        const recording = this.recordings.find(item => item.id === id);
+        if (!recording) return;
+        const next = window?.prompt ? window.prompt('Rename gesture', recording.name) : null;
+        if (!next || next === recording.name) {
+            return;
+        }
+        recording.name = next.trim();
+        recording.updatedAt = Date.now();
+        this.persistState();
+        this.renderList();
+        this.emitGestureSummaries();
+        this.setStatus('idle', `Renamed to ${recording.name}`);
+    }
+
+    deleteRecording(id) {
+        if (!id) return;
+        const index = this.recordings.findIndex(item => item.id === id);
+        if (index === -1) return;
+        const [removed] = this.recordings.splice(index, 1);
+        if (this.selectedId === id) {
+            this.selectedId = this.recordings[0]?.id || null;
+        }
+        this.persistState();
+        this.renderList();
+        this.updateControls();
+        this.emitGestureSummaries();
+        if (removed) {
+            this.setStatus('idle', `Deleted ${removed.name}`);
+        }
+    }
+
+    duplicateRecording(id) {
+        const recording = this.recordings.find(item => item.id === id);
+        if (!recording) return;
+        const copy = normalizeRecording({ ...recording, id: createId('take'), name: `${recording.name} (copy)` }, this.recordings.length);
+        this.recordings.unshift(copy);
+        this.selectedId = copy.id;
+        this.persistState();
+        this.renderList();
+        this.updateControls();
+        this.emitGestureSummaries();
+        this.setStatus('idle', `Duplicated ${recording.name}`);
+    }
+
+    clearRecordings() {
+        if (!this.recordings.length) return;
+        this.recordings = [];
+        this.selectedId = null;
+        this.persistState();
+        this.renderList();
+        this.updateControls();
+        this.emitGestureSummaries();
+        this.setStatus('idle', 'Cleared gesture library');
+    }
+
+    generateRecordingName() {
+        const prefix = this.config.autoNamePrefix || 'Take';
+        const total = this.recordings.length + 1;
+        return `${prefix} ${total}`;
+    }
+
+    captureEvent(type, payload) {
+        if (!this.isRecording || !this.currentRecording) {
+            return;
+        }
+        const timestamp = now() - this.currentRecording.startedAt;
+        const maxDuration = typeof this.config.maxDuration === 'number' && this.config.maxDuration > 0
+            ? this.config.maxDuration
+            : DEFAULT_MAX_DURATION;
+        if (timestamp > maxDuration) {
+            this.currentRecording.events.push({ type, time: maxDuration, payload: clone(payload) || {} });
+            this.currentRecording.duration = maxDuration;
+            this.stopRecording({ reason: 'duration limit reached' });
+            return;
+        }
+
+        const sanitizedPayload = clone(payload) || {};
+        this.currentRecording.events.push({ type, time: timestamp, payload: sanitizedPayload });
+        this.currentRecording.duration = timestamp;
+        this.currentRecording.sourceSet.add(type);
+
+        const maxEvents = typeof this.config.maxEvents === 'number' && this.config.maxEvents > 0
+            ? this.config.maxEvents
+            : DEFAULT_MAX_EVENTS;
+        if (this.currentRecording.events.length >= maxEvents) {
+            this.stopRecording({ reason: 'event limit reached' });
+        }
+    }
+
+    handleShowStart(meta = {}) {
+        if (typeof meta.tempo === 'number') {
+            this.currentTempo = meta.tempo;
+        }
+        if (typeof meta.beatsPerBar === 'number') {
+            this.beatsPerBar = meta.beatsPerBar;
+        }
+        this.showRunning = true;
+        this.updateTempoDisplay();
+    }
+
+    handleShowStop() {
+        this.showRunning = false;
+        this.updateTempoDisplay();
+    }
+
+    handleCueTrigger(cue) {
+        if (!cue || !cue.gestureId) {
+            return;
+        }
+        const recording = this.recordings.find(item => item.id === cue.gestureId);
+        if (recording) {
+            this.playRecording(recording.id);
+        }
+    }
+
+    getSummaries() {
+        return this.recordings.map(recording => ({
+            id: recording.id,
+            name: recording.name,
+            duration: recording.duration,
+            events: recording.events.length,
+            sources: recording.sources
+        }));
+    }
+
+    emitGestureSummaries() {
+        const summary = this.getSummaries();
+        this.hub?.emit?.('gestures:list', { gestures: summary });
+    }
+
+    exportRecordings() {
+        if (!this.recordings.length) {
+            return;
+        }
+        if (typeof Blob === 'undefined' || typeof URL === 'undefined') {
+            return;
+        }
+        const payload = { gestures: this.getState().recordings };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'vib34d-gesture-library.json';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    importRecordings(event) {
+        if (!event?.target?.files?.length || typeof FileReader === 'undefined') {
+            return;
+        }
+        const file = event.target.files[0];
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const parsed = JSON.parse(reader.result);
+                const list = Array.isArray(parsed?.gestures) ? parsed.gestures : Array.isArray(parsed) ? parsed : [];
+                this.recordings = list.map((record, index) => normalizeRecording(record, index));
+                this.selectedId = this.recordings[0]?.id || null;
+                this.persistState();
+                this.renderList();
+                this.updateControls();
+                this.emitGestureSummaries();
+                this.setStatus('idle', 'Imported gestures');
+            } catch (error) {
+                console.warn('PerformanceGestureRecorder failed to import gestures', error);
+                this.setStatus('idle', 'Failed to import gestures');
+            }
+        };
+        reader.readAsText(file);
+        event.target.value = '';
+    }
+
+    persistState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+        try {
+            const payload = JSON.stringify(this.getState());
+            window.localStorage.setItem(this.config.storageKey, payload);
+        } catch (error) {
+            console.warn('PerformanceGestureRecorder failed to persist state', error);
+        }
+    }
+
+    loadState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            this.recordings = [];
+            this.selectedId = null;
+            return;
+        }
+        try {
+            const raw = window.localStorage.getItem(this.config.storageKey);
+            if (!raw) {
+                this.recordings = [];
+                this.selectedId = null;
+                return;
+            }
+            const parsed = JSON.parse(raw);
+            const list = Array.isArray(parsed?.recordings)
+                ? parsed.recordings
+                : Array.isArray(parsed)
+                    ? parsed
+                    : [];
+            this.recordings = list.map((record, index) => normalizeRecording(record, index));
+            this.selectedId = typeof parsed?.selectedId === 'string' ? parsed.selectedId : this.recordings[0]?.id || null;
+        } catch (error) {
+            console.warn('PerformanceGestureRecorder failed to load state', error);
+            this.recordings = [];
+            this.selectedId = null;
+        }
+    }
+
+    getState() {
+        return {
+            recordings: this.recordings.map((record, index) => normalizeRecording(record, index)),
+            selectedId: this.selectedId
+        };
+    }
+
+    applyState(state = {}) {
+        this.stopPlayback();
+        this.stopRecording({ discard: true });
+        const list = Array.isArray(state.recordings) ? state.recordings : [];
+        this.recordings = list.map((record, index) => normalizeRecording(record, index));
+        this.selectedId = typeof state.selectedId === 'string' ? state.selectedId : this.recordings[0]?.id || null;
+        this.persistState();
+        this.renderList();
+        this.updateControls();
+        this.emitGestureSummaries();
+        this.setStatus('idle', 'Gestures loaded');
+    }
+
+    destroy() {
+        this.stopPlayback();
+        this.stopRecording({ discard: true });
+        this.unbindHub();
+        if (this.container) {
+            this.container.innerHTML = '';
+        }
+    }
+}

--- a/src/ui/PerformanceHub.js
+++ b/src/ui/PerformanceHub.js
@@ -1,0 +1,40 @@
+export class PerformanceHub {
+    constructor({ engine = null, parameterManager = null } = {}) {
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.listeners = new Map();
+    }
+
+    on(eventName, handler) {
+        if (!eventName || typeof handler !== 'function') {
+            return () => {};
+        }
+
+        if (!this.listeners.has(eventName)) {
+            this.listeners.set(eventName, new Set());
+        }
+
+        const handlers = this.listeners.get(eventName);
+        handlers.add(handler);
+
+        return () => {
+            handlers.delete(handler);
+            if (handlers.size === 0) {
+                this.listeners.delete(eventName);
+            }
+        };
+    }
+
+    emit(eventName, payload) {
+        const handlers = this.listeners.get(eventName);
+        if (!handlers) return;
+
+        handlers.forEach(handler => {
+            try {
+                handler(payload);
+            } catch (error) {
+                console.warn(`PerformanceHub listener for "${eventName}" failed`, error);
+            }
+        });
+    }
+}

--- a/src/ui/PerformanceLayoutPanel.js
+++ b/src/ui/PerformanceLayoutPanel.js
@@ -1,0 +1,704 @@
+import { DEFAULT_LAYOUT_CONFIG } from './PerformanceConfig.js';
+
+const COLUMN_LABELS = {
+    pads: 'Control Deck',
+    audio: 'Audio & Atmosphere',
+    presets: 'Library & Planner'
+};
+
+const ALLOWED_COLUMNS = Object.keys(COLUMN_LABELS);
+
+function clamp(value, min, max) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return min;
+    }
+    return Math.min(max, Math.max(min, value));
+}
+
+export const LAYOUT_PROFILES = [
+    {
+        id: 'balanced',
+        label: 'Balanced Grid',
+        template: '1.15fr 0.95fr 1fr',
+        description: 'Even distribution across control, audio, and library columns.'
+    },
+    {
+        id: 'control-forward',
+        label: 'Control Forward',
+        template: '1.45fr 0.85fr 0.85fr',
+        description: 'Widen the control deck for multi-touch focus while keeping other tools nearby.'
+    },
+    {
+        id: 'audio-forward',
+        label: 'Audio Forward',
+        template: '0.9fr 1.45fr 0.85fr',
+        description: 'Expand audio & atmosphere tools when reactive tuning is the priority.'
+    },
+    {
+        id: 'library-forward',
+        label: 'Library Forward',
+        template: '0.9fr 0.85fr 1.45fr',
+        description: 'Give preset management and show planning the widest column for cue-heavy sets.'
+    }
+];
+
+export function getLayoutProfile(profileId) {
+    return LAYOUT_PROFILES.find((profile) => profile.id === profileId) || LAYOUT_PROFILES[0];
+}
+
+export class PerformanceLayoutPanel {
+    constructor({
+        container = null,
+        config = {},
+        onChange = null,
+        onReset = null,
+        onPreview = null,
+        onSaveProfile = null,
+        onUpdateProfile = null,
+        onDeleteProfile = null,
+        onApplyProfile = null
+    } = {}) {
+        this.container = container || this.ensureContainer();
+        this.onChange = typeof onChange === 'function' ? onChange : () => {};
+        this.onReset = typeof onReset === 'function' ? onReset : () => {};
+        this.onPreview = typeof onPreview === 'function' ? onPreview : () => {};
+        this.onSaveProfile = typeof onSaveProfile === 'function' ? onSaveProfile : () => {};
+        this.onUpdateProfile = typeof onUpdateProfile === 'function' ? onUpdateProfile : () => {};
+        this.onDeleteProfile = typeof onDeleteProfile === 'function' ? onDeleteProfile : () => {};
+        this.onApplyProfile = typeof onApplyProfile === 'function' ? onApplyProfile : () => {};
+        this.state = this.normalizeState(config);
+        this.columnLabels = COLUMN_LABELS;
+        this.inputs = {};
+        this.handlers = [];
+        this.previewButtons = [];
+        this.columnOrderContainer = null;
+        this.columnOrderSummary = null;
+        this.previewMode = 'auto';
+        this.profiles = Array.isArray(config?.profiles) ? config.profiles.slice() : [];
+        this.selectedProfileId = null;
+        this.profileElements = {};
+
+        this.render();
+        this.applyState(this.state);
+        this.setPreviewMode(this.previewMode, { emit: false });
+        this.setProfiles(this.profiles);
+    }
+
+    ensureContainer() {
+        if (typeof document === 'undefined') {
+            return null;
+        }
+        const element = document.createElement('section');
+        return element;
+    }
+
+    normalizeState(state = {}) {
+        const fallback = DEFAULT_LAYOUT_CONFIG || {};
+        const normalized = { ...fallback, ...(state || {}) };
+        normalized.density = clamp(Number(normalized.density ?? fallback.density ?? 0.45), 0, 1);
+        normalized.fontScale = clamp(Number(normalized.fontScale ?? fallback.fontScale ?? 1), 0.85, 1.25);
+        normalized.surfaceScale = clamp(Number(normalized.surfaceScale ?? fallback.surfaceScale ?? 1), 0.7, 1.4);
+        normalized.profile = getLayoutProfile(normalized.profile)?.id || getLayoutProfile().id;
+        const breakpoint = Number(normalized.mobileBreakpoint ?? fallback.mobileBreakpoint ?? 1100);
+        normalized.mobileBreakpoint = clamp(Math.round(breakpoint), 720, 1600);
+        const allowedPanels = ['pads', 'audio', 'presets'];
+        normalized.defaultPanel = allowedPanels.includes(normalized.defaultPanel)
+            ? normalized.defaultPanel
+            : (fallback.defaultPanel || 'pads');
+
+        const fallbackOrder = Array.isArray(fallback.columnOrder) && fallback.columnOrder.length
+            ? fallback.columnOrder.filter((panel) => ALLOWED_COLUMNS.includes(panel))
+            : ALLOWED_COLUMNS.slice();
+        const requestedOrder = Array.isArray(normalized.columnOrder) && normalized.columnOrder.length
+            ? normalized.columnOrder
+            : fallbackOrder;
+        const columnOrder = [];
+        requestedOrder.forEach((panel) => {
+            if (ALLOWED_COLUMNS.includes(panel) && !columnOrder.includes(panel)) {
+                columnOrder.push(panel);
+            }
+        });
+        ALLOWED_COLUMNS.forEach((panel) => {
+            if (!columnOrder.includes(panel)) {
+                columnOrder.push(panel);
+            }
+        });
+        normalized.columnOrder = columnOrder;
+
+        return normalized;
+    }
+
+    render() {
+        if (!this.container) return;
+        this.container.classList.add('performance-block', 'performance-layout');
+        this.container.innerHTML = `
+            <header class="performance-block__header performance-layout__header">
+                <div>
+                    <h3 class="performance-block__title">Layout &amp; Display</h3>
+                    <p class="performance-block__subtitle">Dial in spacing, emphasis, and mobile ergonomics.</p>
+                </div>
+                <button type="button" class="performance-layout__reset" data-action="reset">Reset</button>
+            </header>
+            <div class="performance-layout__grid">
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-density">Interface Density</label>
+                    <input id="performance-layout-density" class="performance-layout__range" type="range" min="0" max="100" step="1" data-role="density" />
+                    <div class="performance-layout__scale" aria-hidden="true">
+                        <span>Airy</span>
+                        <span>Compact</span>
+                    </div>
+                </div>
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-surface">
+                        Pad Surface Size <span class="performance-layout__value" data-output="surface">100%</span>
+                    </label>
+                    <input id="performance-layout-surface" class="performance-layout__range" type="range" min="70" max="150" step="1" data-role="surface" />
+                    <div class="performance-layout__scale" aria-hidden="true">
+                        <span>Compact</span>
+                        <span>Expanded</span>
+                    </div>
+                </div>
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-font">
+                        Text Scale <span class="performance-layout__value" data-output="font">100%</span>
+                    </label>
+                    <input id="performance-layout-font" class="performance-layout__range" type="range" min="85" max="120" step="1" data-role="font" />
+                    <div class="performance-layout__scale" aria-hidden="true">
+                        <span>Smaller</span>
+                        <span>Larger</span>
+                    </div>
+                </div>
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-profile">Column Emphasis</label>
+                    <select id="performance-layout-profile" data-role="profile"></select>
+                    <p class="performance-layout__profile-description" data-role="profile-description"></p>
+                </div>
+                <div class="performance-layout__field performance-layout__field--columns">
+                    <div class="performance-layout__columns-header">
+                        <span class="performance-layout__label">Column Order</span>
+                        <span class="performance-layout__hint performance-layout__hint--inline">Desktop column sequence</span>
+                    </div>
+                    <div class="performance-layout__columns-list" data-role="column-order" role="list"></div>
+                    <p class="performance-layout__order-summary" data-output="column-order"></p>
+                </div>
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-default">Default Mobile Panel</label>
+                    <select id="performance-layout-default" data-role="default-panel">
+                        <option value="pads">Control Deck</option>
+                        <option value="audio">Audio &amp; Atmosphere</option>
+                        <option value="presets">Library &amp; Planner</option>
+                    </select>
+                </div>
+                <div class="performance-layout__field">
+                    <label class="performance-layout__label" for="performance-layout-breakpoint">
+                        Mobile Breakpoint <span class="performance-layout__value" data-output="breakpoint"></span>
+                    </label>
+                    <input id="performance-layout-breakpoint" type="number" min="720" max="1600" step="10" data-role="breakpoint" />
+                    <small class="performance-layout__hint">Viewport width where tabs replace the column grid.</small>
+                </div>
+                <div class="performance-layout__field performance-layout__field--preview">
+                    <span class="performance-layout__label">Viewport Preview</span>
+                    <div class="performance-layout__preview-buttons" role="group" aria-label="Viewport preview modes">
+                        <button type="button" class="performance-layout__preview" data-preview-mode="auto">Live</button>
+                        <button type="button" class="performance-layout__preview" data-preview-mode="desktop">Desktop</button>
+                        <button type="button" class="performance-layout__preview" data-preview-mode="tablet">Tablet</button>
+                        <button type="button" class="performance-layout__preview" data-preview-mode="phone">Phone</button>
+                    </div>
+                    <p class="performance-layout__preview-note" data-preview-note>Follows current viewport.</p>
+                </div>
+                <div class="performance-layout__field performance-layout__field--profiles">
+                    <label class="performance-layout__label" for="performance-layout-profile-select">Saved Layout Profiles</label>
+                    <div class="performance-layout__profiles-select">
+                        <select id="performance-layout-profile-select" data-role="saved-profile-select" aria-label="Saved layout profiles"></select>
+                        <div class="performance-layout__profile-actions" role="group" aria-label="Saved layout profile actions">
+                            <button type="button" data-action="apply-profile">Apply</button>
+                            <button type="button" data-action="update-profile">Update</button>
+                            <button type="button" data-action="delete-profile">Delete</button>
+                        </div>
+                    </div>
+                    <p class="performance-layout__empty" data-role="profile-empty">No saved profiles yet.</p>
+                    <p class="performance-layout__profile-description performance-layout__profile-description--saved" data-role="saved-profile-description"></p>
+                    <div class="performance-layout__profile-save">
+                        <input type="text" data-role="profile-name" placeholder="Profile name" maxlength="48" aria-label="Layout profile name" />
+                        <button type="button" data-action="save-profile">Save New</button>
+                    </div>
+                    <p class="performance-layout__hint">Profiles capture density, pad surface size, text scale, column focus, mobile panel, breakpoint, and preview mode.</p>
+                </div>
+            </div>
+        `;
+
+        const profileSelect = this.container.querySelector('[data-role="profile"]');
+        if (profileSelect) {
+            profileSelect.innerHTML = LAYOUT_PROFILES.map((profile) => `
+                <option value="${profile.id}">${profile.label}</option>
+            `).join('');
+        }
+
+        this.inputs = {
+            density: this.container.querySelector('[data-role="density"]'),
+            surface: this.container.querySelector('[data-role="surface"]'),
+            font: this.container.querySelector('[data-role="font"]'),
+            profile: profileSelect,
+            defaultPanel: this.container.querySelector('[data-role="default-panel"]'),
+            breakpoint: this.container.querySelector('[data-role="breakpoint"]')
+        };
+
+        this.columnOrderContainer = this.container.querySelector('[data-role="column-order"]');
+        this.columnOrderSummary = this.container.querySelector('[data-output="column-order"]');
+
+        this.previewButtons = Array.from(this.container.querySelectorAll('[data-preview-mode]'));
+        this.profileElements = {
+            select: this.container.querySelector('[data-role="saved-profile-select"]'),
+            description: this.container.querySelector('[data-role="saved-profile-description"]'),
+            empty: this.container.querySelector('[data-role="profile-empty"]'),
+            nameInput: this.container.querySelector('[data-role="profile-name"]'),
+            save: this.container.querySelector('[data-action="save-profile"]'),
+            apply: this.container.querySelector('[data-action="apply-profile"]'),
+            update: this.container.querySelector('[data-action="update-profile"]'),
+            delete: this.container.querySelector('[data-action="delete-profile"]')
+        };
+
+        const resetButton = this.container.querySelector('[data-action="reset"]');
+        if (resetButton) {
+            const handler = (event) => {
+                event.preventDefault();
+                this.onReset();
+            };
+            resetButton.addEventListener('click', handler);
+            this.handlers.push({ element: resetButton, type: 'click', handler });
+        }
+
+        this.bindInputs();
+        this.bindPreviewButtons();
+        this.bindProfileControls();
+        this.bindColumnOrderControls();
+    }
+
+    bindInputs() {
+        Object.entries(this.inputs).forEach(([key, element]) => {
+            if (!element) return;
+            const eventName = element.tagName === 'SELECT' ? 'change' : 'input';
+            const handler = () => {
+                this.state = this.normalizeState(this.readStateFromInputs());
+                this.updateOutputs();
+                this.onChange(this.state);
+            };
+            element.addEventListener(eventName, handler);
+            this.handlers.push({ element, type: eventName, handler });
+        });
+    }
+
+    bindPreviewButtons() {
+        if (!Array.isArray(this.previewButtons) || !this.previewButtons.length) {
+            return;
+        }
+        this.previewButtons.forEach((button) => {
+            const mode = button.getAttribute('data-preview-mode');
+            const handler = (event) => {
+                event.preventDefault();
+                this.setPreviewMode(mode, { emit: true });
+            };
+            button.addEventListener('click', handler);
+            this.handlers.push({ element: button, type: 'click', handler });
+        });
+    }
+
+    bindProfileControls() {
+        const { select, save, apply, update, delete: deleteButton, nameInput } = this.profileElements || {};
+        if (select) {
+            const handler = () => {
+                this.selectedProfileId = select.value || null;
+                this.updateProfileDescription();
+                this.updateProfileButtonsState();
+            };
+            select.addEventListener('change', handler);
+            this.handlers.push({ element: select, type: 'change', handler });
+        }
+        if (save) {
+            const handler = (event) => {
+                event.preventDefault();
+                const name = (nameInput?.value || '').trim();
+                this.onSaveProfile({
+                    name: name || null,
+                    state: { ...this.state, previewMode: this.previewMode }
+                });
+                this.clearProfileNameInput();
+            };
+            save.addEventListener('click', handler);
+            this.handlers.push({ element: save, type: 'click', handler });
+        }
+        if (apply) {
+            const handler = (event) => {
+                event.preventDefault();
+                if (!this.selectedProfileId) return;
+                this.onApplyProfile({ id: this.selectedProfileId });
+            };
+            apply.addEventListener('click', handler);
+            this.handlers.push({ element: apply, type: 'click', handler });
+        }
+        if (update) {
+            const handler = (event) => {
+                event.preventDefault();
+                if (!this.selectedProfileId) return;
+                const name = (nameInput?.value || '').trim();
+                this.onUpdateProfile({
+                    id: this.selectedProfileId,
+                    name: name || null,
+                    state: { ...this.state, previewMode: this.previewMode }
+                });
+            };
+            update.addEventListener('click', handler);
+            this.handlers.push({ element: update, type: 'click', handler });
+        }
+        if (deleteButton) {
+            const handler = (event) => {
+                event.preventDefault();
+                if (!this.selectedProfileId) return;
+                this.onDeleteProfile({ id: this.selectedProfileId });
+            };
+            deleteButton.addEventListener('click', handler);
+            this.handlers.push({ element: deleteButton, type: 'click', handler });
+        }
+    }
+
+    bindColumnOrderControls() {
+        if (!this.columnOrderContainer) {
+            return;
+        }
+        const handler = (event) => {
+            const button = event.target.closest('button[data-action="move-column"]');
+            if (!button || !this.columnOrderContainer.contains(button)) {
+                return;
+            }
+            event.preventDefault();
+            const item = button.closest('[data-column]');
+            if (!item) {
+                return;
+            }
+            const columnId = item.getAttribute('data-column');
+            if (!columnId) {
+                return;
+            }
+            const direction = button.getAttribute('data-direction');
+            const delta = direction === 'up' ? -1 : (direction === 'down' ? 1 : 0);
+            if (!delta) {
+                return;
+            }
+            this.moveColumn(columnId, delta);
+        };
+        this.columnOrderContainer.addEventListener('click', handler);
+        this.handlers.push({ element: this.columnOrderContainer, type: 'click', handler });
+    }
+
+    moveColumn(columnId, delta = 0) {
+        if (!delta) {
+            return;
+        }
+        const order = Array.isArray(this.state.columnOrder)
+            ? this.state.columnOrder.slice()
+            : ALLOWED_COLUMNS.slice();
+        const currentIndex = order.indexOf(columnId);
+        if (currentIndex === -1) {
+            return;
+        }
+        const targetIndex = currentIndex + delta;
+        if (targetIndex < 0 || targetIndex >= order.length) {
+            return;
+        }
+        const [moved] = order.splice(currentIndex, 1);
+        order.splice(targetIndex, 0, moved);
+        const nextState = this.normalizeState({ ...this.state, columnOrder: order });
+        const previousOrderKey = Array.isArray(this.state.columnOrder) ? this.state.columnOrder.join(',') : '';
+        const nextOrderKey = Array.isArray(nextState.columnOrder) ? nextState.columnOrder.join(',') : '';
+        if (nextOrderKey === previousOrderKey) {
+            return;
+        }
+        this.state = nextState;
+        this.renderColumnOrder();
+        this.updateOutputs();
+        this.onChange(this.state);
+    }
+
+    renderColumnOrder() {
+        if (!this.columnOrderContainer) {
+            return;
+        }
+        const order = Array.isArray(this.state.columnOrder) && this.state.columnOrder.length
+            ? this.state.columnOrder
+            : ALLOWED_COLUMNS;
+        const lastIndex = order.length - 1;
+        const items = order.map((column, index) => {
+            const label = this.getColumnLabel(column);
+            const upDisabled = index === 0 ? ' disabled' : '';
+            const downDisabled = index === lastIndex ? ' disabled' : '';
+            return `
+                <div class="performance-layout__column-item" data-column="${this.escapeHtml(column)}" role="listitem">
+                    <span class="performance-layout__column-label">${this.escapeHtml(label)}</span>
+                    <div class="performance-layout__column-actions" role="group" aria-label="Reorder ${this.escapeHtml(label)} column">
+                        <button type="button" class="performance-layout__column-button" data-action="move-column" data-direction="up"${upDisabled} aria-label="Move ${this.escapeHtml(label)} earlier">▲</button>
+                        <button type="button" class="performance-layout__column-button" data-action="move-column" data-direction="down"${downDisabled} aria-label="Move ${this.escapeHtml(label)} later">▼</button>
+                    </div>
+                </div>
+            `;
+        }).join('');
+        this.columnOrderContainer.innerHTML = items;
+    }
+
+    formatColumnOrderSummary(order = []) {
+        const sequence = (Array.isArray(order) && order.length ? order : ALLOWED_COLUMNS)
+            .map((column) => this.getColumnLabel(column));
+        return `Columns: ${sequence.join(' → ')}`;
+    }
+
+    getColumnLabel(column) {
+        return this.columnLabels[column] || column;
+    }
+
+    setProfiles(profiles = [], { selectedId = null } = {}) {
+        this.profiles = Array.isArray(profiles)
+            ? profiles.filter((profile) => profile && typeof profile === 'object' && profile.id && profile.name)
+            : [];
+        const select = this.profileElements?.select;
+        if (!select) {
+            return;
+        }
+
+        const currentSelection = selectedId || this.selectedProfileId;
+        let nextSelection = null;
+        const options = this.profiles.map((profile) => {
+            if (!nextSelection && (profile.id === currentSelection)) {
+                nextSelection = profile.id;
+            }
+            return `<option value="${this.escapeHtml(profile.id)}">${this.escapeHtml(profile.name)}</option>`;
+        });
+
+        select.innerHTML = options.join('');
+        if (!nextSelection && this.profiles.length) {
+            nextSelection = this.profiles[0].id;
+        }
+
+        if (nextSelection) {
+            select.removeAttribute('disabled');
+            select.value = nextSelection;
+            this.selectedProfileId = nextSelection;
+        } else {
+            select.value = '';
+            select.setAttribute('disabled', 'disabled');
+            this.selectedProfileId = null;
+        }
+
+        this.updateProfileDescription();
+        this.updateProfileButtonsState();
+        this.toggleProfileEmptyState();
+    }
+
+    toggleProfileEmptyState() {
+        const hasProfiles = this.profiles.length > 0;
+        const emptyMessage = this.profileElements?.empty;
+        if (emptyMessage) {
+            emptyMessage.style.display = hasProfiles ? 'none' : 'block';
+        }
+        const description = this.profileElements?.description;
+        if (description) {
+            description.style.display = hasProfiles ? 'block' : 'none';
+        }
+        const actions = [this.profileElements?.apply, this.profileElements?.update, this.profileElements?.delete];
+        actions.forEach((button) => {
+            if (button) {
+                button.style.display = hasProfiles ? '' : 'none';
+            }
+        });
+    }
+
+    updateProfileButtonsState() {
+        const hasSelection = Boolean(this.selectedProfileId);
+        const apply = this.profileElements?.apply;
+        const update = this.profileElements?.update;
+        const deleteButton = this.profileElements?.delete;
+        if (apply) {
+            apply.disabled = !hasSelection;
+        }
+        if (update) {
+            update.disabled = !hasSelection;
+        }
+        if (deleteButton) {
+            deleteButton.disabled = !hasSelection;
+        }
+    }
+
+    updateProfileDescription() {
+        const descriptionEl = this.profileElements?.description;
+        if (!descriptionEl) return;
+        const profile = this.getSelectedProfile();
+        if (!profile) {
+            descriptionEl.textContent = '';
+            return;
+        }
+        const summary = this.formatProfileSummary(profile);
+        descriptionEl.textContent = profile.description?.trim?.() ? profile.description.trim() : summary;
+    }
+
+    getSelectedProfile() {
+        if (!this.selectedProfileId) {
+            return null;
+        }
+        return this.profiles.find((profile) => profile.id === this.selectedProfileId) || null;
+    }
+
+    formatProfileSummary(profile) {
+        if (!profile || !profile.state) {
+            return '';
+        }
+        const { density = 0.45, surfaceScale = 1, fontScale = 1, profile: profileId, defaultPanel = 'pads', mobileBreakpoint = 1100, previewMode = 'auto' } = profile.state || {};
+        const densityLabel = `${Math.round(density * 100)}% density`;
+        const surfaceLabel = `${Math.round(surfaceScale * 100)}% pad surface`;
+        const fontLabel = `${Math.round(fontScale * 100)}% text`;
+        const profileLabel = getLayoutProfile(profileId)?.label || 'Balanced grid';
+        const panelLabel = defaultPanel === 'audio' ? 'Audio focus' : (defaultPanel === 'presets' ? 'Library focus' : 'Control focus');
+        const breakpointLabel = `${mobileBreakpoint}px breakpoint`;
+        const previewLabel = previewMode === 'auto' ? 'Live viewport' : `${previewMode.charAt(0).toUpperCase()}${previewMode.slice(1)} preview`;
+        const columnOrderLabel = this.formatColumnOrderSummary(profile.state?.columnOrder);
+        return `${profileLabel} · ${columnOrderLabel} · ${panelLabel} · ${densityLabel} · ${surfaceLabel} · ${fontLabel} · ${breakpointLabel} · ${previewLabel}`;
+    }
+
+    escapeHtml(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.replace(/[&<>"']/g, (match) => {
+            switch (match) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case '\'':
+                    return '&#39;';
+                default:
+                    return match;
+            }
+        });
+    }
+
+    clearProfileNameInput() {
+        const input = this.profileElements?.nameInput;
+        if (input) {
+            input.value = '';
+        }
+    }
+
+    readStateFromInputs() {
+        const densityValue = Number(this.inputs.density?.value ?? this.state.density * 100) / 100;
+        const surfaceValue = Number(this.inputs.surface?.value ?? this.state.surfaceScale * 100) / 100;
+        const fontValue = Number(this.inputs.font?.value ?? this.state.fontScale * 100) / 100;
+        const breakpointValue = Number(this.inputs.breakpoint?.value ?? this.state.mobileBreakpoint);
+        return {
+            density: densityValue,
+            surfaceScale: surfaceValue,
+            fontScale: fontValue,
+            profile: this.inputs.profile?.value || this.state.profile,
+            defaultPanel: this.inputs.defaultPanel?.value || this.state.defaultPanel,
+            mobileBreakpoint: breakpointValue,
+            columnOrder: Array.isArray(this.state.columnOrder) ? this.state.columnOrder.slice() : ALLOWED_COLUMNS.slice()
+        };
+    }
+
+    updateOutputs() {
+        if (!this.container) return;
+        const surfaceOutput = this.container.querySelector('[data-output="surface"]');
+        const fontOutput = this.container.querySelector('[data-output="font"]');
+        const breakpointOutput = this.container.querySelector('[data-output="breakpoint"]');
+        const profileDescription = this.container.querySelector('[data-role="profile-description"]');
+        const previewNote = this.container.querySelector('[data-preview-note]');
+
+        if (surfaceOutput) {
+            surfaceOutput.textContent = `${Math.round(this.state.surfaceScale * 100)}%`;
+        }
+        if (fontOutput) {
+            fontOutput.textContent = `${Math.round(this.state.fontScale * 100)}%`;
+        }
+        if (breakpointOutput) {
+            breakpointOutput.textContent = `${this.state.mobileBreakpoint}px`;
+        }
+        if (profileDescription) {
+            profileDescription.textContent = getLayoutProfile(this.state.profile)?.description || '';
+        }
+        if (previewNote) {
+            previewNote.textContent = this.getPreviewDescription(this.previewMode);
+        }
+        if (this.columnOrderSummary) {
+            this.columnOrderSummary.textContent = this.formatColumnOrderSummary(this.state.columnOrder);
+        }
+    }
+
+    applyState(state = {}) {
+        this.state = this.normalizeState(state);
+        if (this.inputs.density) {
+            this.inputs.density.value = Math.round(this.state.density * 100);
+        }
+        if (this.inputs.surface) {
+            this.inputs.surface.value = Math.round(this.state.surfaceScale * 100);
+        }
+        if (this.inputs.font) {
+            this.inputs.font.value = Math.round(this.state.fontScale * 100);
+        }
+        if (this.inputs.profile) {
+            this.inputs.profile.value = this.state.profile;
+        }
+        if (this.inputs.defaultPanel) {
+            this.inputs.defaultPanel.value = this.state.defaultPanel;
+        }
+        if (this.inputs.breakpoint) {
+            this.inputs.breakpoint.value = this.state.mobileBreakpoint;
+        }
+        this.renderColumnOrder();
+        this.updateOutputs();
+    }
+
+    setPreviewMode(mode, { emit = false } = {}) {
+        const allowed = ['auto', 'desktop', 'tablet', 'phone'];
+        const nextMode = allowed.includes(mode) ? mode : 'auto';
+        this.previewMode = nextMode;
+        if (Array.isArray(this.previewButtons) && this.previewButtons.length) {
+            this.previewButtons.forEach((button) => {
+                const buttonMode = button.getAttribute('data-preview-mode');
+                const isActive = buttonMode === nextMode;
+                button.classList.toggle('is-active', isActive);
+                button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+        }
+        this.updateOutputs();
+        if (emit) {
+            this.onPreview({ mode: nextMode });
+        }
+    }
+
+    getPreviewDescription(mode) {
+        switch (mode) {
+            case 'desktop':
+                return 'Simulating 1440px desktop viewport.';
+            case 'tablet':
+                return 'Simulating 1024px tablet viewport (mobile layout with wider canvas).';
+            case 'phone':
+                return 'Simulating 428px phone viewport (mobile layout).';
+            default:
+                return 'Follows current viewport.';
+        }
+    }
+
+    destroy() {
+        this.handlers.forEach(({ element, type, handler }) => {
+            if (element && element.removeEventListener) {
+                element.removeEventListener(type, handler);
+            }
+        });
+        this.handlers = [];
+        this.inputs = {};
+        this.previewButtons = [];
+        this.columnOrderContainer = null;
+        this.columnOrderSummary = null;
+    }
+}

--- a/src/ui/PerformanceMidiBridge.js
+++ b/src/ui/PerformanceMidiBridge.js
@@ -1,0 +1,637 @@
+const DEFAULT_OPTIONS = {
+    storageKey: 'vib34d-hardware-mappings',
+    autoConnect: false,
+    pickupThreshold: 0.04,
+    smoothing: 0.18,
+    channel: 'omni'
+};
+
+const SUPPORTED_MESSAGE_TYPES = {
+    cc: 0xB0
+};
+
+function createId(prefix = 'map') {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clamp01(value) {
+    if (value <= 0) return 0;
+    if (value >= 1) return 1;
+    return value;
+}
+
+export class PerformanceMidiBridge {
+    constructor({ container = null, hub = null, parameterManager = null, config = {}, onStatusChange = null } = {}) {
+        this.container = container || this.ensureContainer();
+        this.hub = hub;
+        this.parameterManager = parameterManager;
+        this.config = { ...DEFAULT_OPTIONS, ...(config || {}) };
+        this.onStatusChange = typeof onStatusChange === 'function' ? onStatusChange : () => {};
+
+        this.storageKey = this.config.storageKey || DEFAULT_OPTIONS.storageKey;
+        this.mappings = [];
+        this.mappingRefs = new Map();
+        this.inputs = new Map();
+        this.activeInputId = null;
+        this.pendingInputId = null;
+        this.midiAccess = null;
+        this.learnMappingId = null;
+        this.status = 'disabled';
+        this.parameterOptions = this.parameterManager?.listParameterMetadata?.() || [];
+
+        this.statusEl = null;
+        this.inputSelect = null;
+        this.enableButton = null;
+        this.refreshButton = null;
+        this.addButton = null;
+        this.mappingList = null;
+        this.webMidiUnsupportedMessage = null;
+
+        this.onMIDIMessageBound = this.onMIDIMessage.bind(this);
+        this.onMIDIAccessChangeBound = this.onMIDIAccessChange.bind(this);
+
+        const storedState = this.loadState();
+        if (storedState) {
+            this.mappings = Array.isArray(storedState.mappings)
+                ? storedState.mappings.map(mapping => ({ ...mapping, lastValue: 0, lastNormalized: 0 }))
+                : [];
+            this.pendingInputId = storedState.inputId || null;
+            this.pendingEnable = storedState.enabled === true;
+        } else {
+            this.mappings = [];
+            this.pendingInputId = null;
+            this.pendingEnable = false;
+        }
+
+        this.render();
+        this.refreshParameterOptions();
+
+        if (this.config.autoConnect || this.pendingEnable) {
+            this.requestAccess({ silent: true });
+        }
+    }
+
+    ensureContainer() {
+        if (typeof document === 'undefined') {
+            return null;
+        }
+        const section = document.createElement('section');
+        section.className = 'performance-block performance-hardware';
+        return section;
+    }
+
+    render() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-block', 'performance-hardware');
+        this.container.innerHTML = `
+            <header class="performance-block__header">
+                <div>
+                    <h3 class="performance-block__title">Hardware Bridge</h3>
+                    <p class="performance-block__subtitle">Map MIDI controllers to parameters for tactile playback.</p>
+                </div>
+            </header>
+            <div class="hardware-bridge__status" data-role="status">${this.statusLabel()}</div>
+            <div class="hardware-bridge__controls">
+                <button type="button" class="hardware-bridge__enable">Enable MIDI</button>
+                <select class="hardware-bridge__inputs" disabled></select>
+                <button type="button" class="hardware-bridge__refresh" disabled>Refresh</button>
+            </div>
+            <div class="hardware-bridge__warning" data-role="unsupported" hidden>
+                Web MIDI is not available in this browser. Connect through a companion bridge or
+                launch the viewer in Chrome / Edge with MIDI enabled.
+            </div>
+            <div class="hardware-bridge__mappings">
+                <div class="hardware-bridge__mappings-header">
+                    <h4>Mappings</h4>
+                    <button type="button" class="hardware-bridge__add" ${this.parameterOptions.length ? '' : 'disabled'}>Add mapping</button>
+                </div>
+                <ul class="hardware-bridge__list"></ul>
+                <p class="hardware-bridge__hint">Use “Learn” to capture CC messages, then move the selected control.
+                    Values are smoothed automatically to avoid jumps on stage.</p>
+            </div>
+        `;
+
+        this.statusEl = this.container.querySelector('[data-role="status"]');
+        this.inputSelect = this.container.querySelector('.hardware-bridge__inputs');
+        this.enableButton = this.container.querySelector('.hardware-bridge__enable');
+        this.refreshButton = this.container.querySelector('.hardware-bridge__refresh');
+        this.addButton = this.container.querySelector('.hardware-bridge__add');
+        this.mappingList = this.container.querySelector('.hardware-bridge__list');
+        this.webMidiUnsupportedMessage = this.container.querySelector('[data-role="unsupported"]');
+
+        this.enableButton.addEventListener('click', () => this.requestAccess());
+        this.refreshButton.addEventListener('click', () => this.refreshInputs());
+        this.inputSelect.addEventListener('change', () => this.handleInputSelection());
+        if (this.addButton) {
+            this.addButton.addEventListener('click', () => this.addMapping());
+        }
+
+        this.renderInputOptions();
+        this.renderMappings();
+    }
+
+    refreshParameterOptions() {
+        if (!this.parameterManager || typeof this.parameterManager.listParameterMetadata !== 'function') {
+            return;
+        }
+        const metadata = this.parameterManager.listParameterMetadata();
+        if (Array.isArray(metadata) && metadata.length) {
+            this.parameterOptions = metadata;
+            if (this.addButton) {
+                this.addButton.disabled = false;
+            }
+            this.mappings.forEach(mapping => {
+                if (!mapping.parameter) {
+                    mapping.parameter = metadata[0].id;
+                }
+            });
+            this.renderMappings();
+        } else if (this.addButton) {
+            this.addButton.disabled = true;
+        }
+    }
+
+    statusLabel() {
+        switch (this.status) {
+            case 'enabled':
+                return 'MIDI enabled';
+            case 'waiting':
+                return 'Waiting for permission…';
+            case 'learning':
+                return 'Learning control… move a knob or fader';
+            case 'no-inputs':
+                return 'No MIDI inputs detected';
+            default:
+                return 'MIDI disabled';
+        }
+    }
+
+    updateStatus(status, notify = true) {
+        this.status = status;
+        if (this.statusEl) {
+            this.statusEl.textContent = this.statusLabel();
+        }
+        if (notify) {
+            this.onStatusChange(this.statusLabel());
+        }
+    }
+
+    requestAccess({ silent = false } = {}) {
+        if (typeof navigator === 'undefined' || typeof navigator.requestMIDIAccess !== 'function') {
+            if (this.webMidiUnsupportedMessage) {
+                this.webMidiUnsupportedMessage.hidden = false;
+            }
+            this.updateStatus('disabled', !silent);
+            return;
+        }
+
+        if (!silent) {
+            this.updateStatus('waiting');
+        }
+
+        navigator.requestMIDIAccess({ sysex: false }).then(access => {
+            this.midiAccess = access;
+            this.midiAccess.onstatechange = this.onMIDIAccessChangeBound;
+            this.refreshInputs();
+            if (this.pendingInputId && this.inputs.has(this.pendingInputId)) {
+                this.setActiveInput(this.pendingInputId);
+            } else {
+                const firstInputId = this.inputs.size ? Array.from(this.inputs.keys())[0] : null;
+                if (firstInputId) {
+                    this.setActiveInput(firstInputId);
+                }
+            }
+            this.updateStatus(this.inputs.size ? 'enabled' : 'no-inputs');
+            this.persistState({ enabled: true });
+        }).catch(error => {
+            console.warn('PerformanceMidiBridge failed to obtain MIDI access', error);
+            this.updateStatus('disabled', !silent);
+        });
+    }
+
+    refreshInputs() {
+        if (!this.midiAccess) {
+            this.inputSelect.disabled = true;
+            if (this.refreshButton) {
+                this.refreshButton.disabled = true;
+            }
+            return;
+        }
+
+        this.inputs.forEach(input => {
+            if (input) {
+                input.onmidimessage = null;
+            }
+        });
+
+        this.inputs.clear();
+        this.midiAccess.inputs.forEach((input, key) => {
+            this.inputs.set(key, input);
+        });
+
+        this.renderInputOptions();
+
+        if (this.inputs.size === 0) {
+            this.updateStatus('no-inputs');
+        } else if (this.activeInputId && this.inputs.has(this.activeInputId)) {
+            this.setActiveInput(this.activeInputId);
+        }
+    }
+
+    renderInputOptions() {
+        if (!this.inputSelect) return;
+        const previousValue = this.inputSelect.value;
+        this.inputSelect.innerHTML = '';
+
+        if (this.inputs.size === 0) {
+            const option = document.createElement('option');
+            option.value = '';
+            option.textContent = 'No inputs detected';
+            this.inputSelect.appendChild(option);
+            this.inputSelect.disabled = true;
+            if (this.refreshButton) {
+                this.refreshButton.disabled = true;
+            }
+            return;
+        }
+
+        this.inputs.forEach((input, id) => {
+            const option = document.createElement('option');
+            option.value = id;
+            option.textContent = input.name || `Input ${id}`;
+            this.inputSelect.appendChild(option);
+        });
+
+        this.inputSelect.disabled = false;
+        if (this.refreshButton) {
+            this.refreshButton.disabled = false;
+        }
+
+        const targetValue = this.activeInputId || this.pendingInputId || previousValue;
+        if (targetValue && this.inputs.has(targetValue)) {
+            this.inputSelect.value = targetValue;
+        } else {
+            this.inputSelect.selectedIndex = 0;
+        }
+    }
+
+    handleInputSelection() {
+        if (!this.inputSelect) return;
+        const selected = this.inputSelect.value;
+        if (!selected || !this.inputs.has(selected)) {
+            return;
+        }
+        this.setActiveInput(selected);
+        this.persistState();
+    }
+
+    setActiveInput(id) {
+        if (!this.inputs.has(id)) {
+            return;
+        }
+
+        if (this.activeInputId && this.inputs.has(this.activeInputId)) {
+            const prev = this.inputs.get(this.activeInputId);
+            if (prev) {
+                prev.onmidimessage = null;
+            }
+        }
+
+        this.activeInputId = id;
+        const input = this.inputs.get(id);
+        if (input) {
+            input.onmidimessage = this.onMIDIMessageBound;
+        }
+        if (this.inputSelect) {
+            this.inputSelect.value = id;
+        }
+    }
+
+    onMIDIAccessChange() {
+        this.refreshInputs();
+    }
+
+    addMapping() {
+        const parameter = this.parameterOptions.length ? this.parameterOptions[0].id : null;
+        if (!parameter) {
+            return;
+        }
+        const mapping = {
+            id: createId('mapping'),
+            parameter,
+            channel: this.config.channel || 'omni',
+            control: null,
+            type: 'cc',
+            smoothing: typeof this.config.smoothing === 'number' ? this.config.smoothing : DEFAULT_OPTIONS.smoothing,
+            pickupThreshold: typeof this.config.pickupThreshold === 'number' ? this.config.pickupThreshold : DEFAULT_OPTIONS.pickupThreshold,
+            lastValue: 0,
+            lastNormalized: 0,
+            armed: false
+        };
+        this.mappings.push(mapping);
+        this.persistState();
+        this.renderMappings();
+    }
+
+    removeMapping(id) {
+        this.mappings = this.mappings.filter(mapping => mapping.id !== id);
+        this.mappingRefs.delete(id);
+        this.persistState();
+        this.renderMappings();
+    }
+
+    renderMappings() {
+        if (!this.mappingList) return;
+        this.mappingList.innerHTML = '';
+        this.mappingRefs.clear();
+
+        if (!this.mappings.length) {
+            const empty = document.createElement('li');
+            empty.className = 'hardware-bridge__empty';
+            empty.textContent = this.parameterOptions.length
+                ? 'No mappings yet. Add one to begin learning hardware controls.'
+                : 'Parameter metadata unavailable. Connect to an engine to load parameters.';
+            this.mappingList.appendChild(empty);
+            return;
+        }
+
+        this.mappings.forEach(mapping => {
+            const item = document.createElement('li');
+            item.className = 'hardware-bridge__mapping';
+            item.dataset.id = mapping.id;
+            item.innerHTML = `
+                <div class="hardware-bridge__mapping-target">
+                    <label>
+                        <span>Parameter</span>
+                        <select></select>
+                    </label>
+                </div>
+                <div class="hardware-bridge__mapping-binding" data-role="binding">${this.describeBinding(mapping)}</div>
+                <div class="hardware-bridge__mapping-value" data-role="value">--</div>
+                <div class="hardware-bridge__mapping-actions">
+                    <button type="button" data-action="learn">Learn</button>
+                    <button type="button" data-action="remove">Remove</button>
+                </div>
+            `;
+
+            const select = item.querySelector('select');
+            if (select) {
+                this.parameterOptions.forEach(option => {
+                    const opt = document.createElement('option');
+                    opt.value = option.id;
+                    opt.textContent = option.label;
+                    if (option.group) {
+                        opt.dataset.group = option.group;
+                    }
+                    select.appendChild(opt);
+                });
+                const hasExisting = this.parameterOptions.some(option => option.id === mapping.parameter);
+                if (!hasExisting && this.parameterOptions.length) {
+                    mapping.parameter = this.parameterOptions[0].id;
+                }
+                select.value = mapping.parameter || '';
+                select.addEventListener('change', () => {
+                    mapping.parameter = select.value;
+                    this.persistState();
+                });
+            }
+
+            const learnButton = item.querySelector('[data-action="learn"]');
+            learnButton.addEventListener('click', () => this.armMapping(mapping.id));
+            const removeButton = item.querySelector('[data-action="remove"]');
+            removeButton.addEventListener('click', () => this.removeMapping(mapping.id));
+
+            const bindingLabel = item.querySelector('[data-role="binding"]');
+            const valueLabel = item.querySelector('[data-role="value"]');
+
+            this.mappingRefs.set(mapping.id, { element: item, bindingLabel, valueLabel });
+
+            this.mappingList.appendChild(item);
+        });
+    }
+
+    describeBinding(mapping) {
+        if (!mapping.control && mapping.control !== 0) {
+            return 'Unassigned – click Learn';
+        }
+        const channel = typeof mapping.channel === 'number' ? mapping.channel + 1 : mapping.channel;
+        return `CC ${mapping.control}${channel ? ` · Ch ${channel}` : ''}`;
+    }
+
+    armMapping(id) {
+        if (!this.inputs.size) {
+            this.updateStatus('no-inputs');
+            return;
+        }
+
+        this.learnMappingId = id;
+        this.updateStatus('learning');
+        this.mappings.forEach(mapping => {
+            mapping.armed = mapping.id === id;
+            const ref = this.mappingRefs.get(mapping.id);
+            if (ref?.element) {
+                ref.element.classList.toggle('hardware-bridge__mapping--armed', mapping.armed);
+            }
+        });
+    }
+
+    onMIDIMessage(event) {
+        if (!event?.data || event.data.length < 3) return;
+        const [status, data1, data2] = event.data;
+        const messageType = status & 0xF0;
+        const channel = status & 0x0F;
+
+        if (messageType !== SUPPORTED_MESSAGE_TYPES.cc) {
+            return;
+        }
+
+        const control = data1;
+        const value = data2 / 127;
+
+        if (this.learnMappingId) {
+            this.assignLearnedControl(channel, control);
+            return;
+        }
+
+        this.mappings.forEach(mapping => {
+            if (!mapping.control && mapping.control !== 0) return;
+            if (typeof mapping.channel === 'number' && mapping.channel !== channel) return;
+            const smoothed = this.applySmoothing(mapping, value);
+            this.applyMappingValue(mapping, smoothed);
+        });
+    }
+
+    assignLearnedControl(channel, control) {
+        const mapping = this.mappings.find(entry => entry.id === this.learnMappingId);
+        if (!mapping) {
+            this.learnMappingId = null;
+            this.updateStatus('enabled');
+            return;
+        }
+
+        mapping.channel = this.config.channel === 'omni' ? 'omni' : channel;
+        mapping.control = control;
+        mapping.armed = false;
+        mapping.lastValue = 0;
+        mapping.lastNormalized = 0;
+        this.learnMappingId = null;
+        this.persistState();
+        this.updateStatus('enabled');
+
+        const ref = this.mappingRefs.get(mapping.id);
+        if (ref?.bindingLabel) {
+            ref.bindingLabel.textContent = this.describeBinding(mapping);
+        }
+    }
+
+    applySmoothing(mapping, incomingNormalized) {
+        const smoothing = clamp01(typeof mapping.smoothing === 'number' ? mapping.smoothing : this.config.smoothing);
+        const previous = typeof mapping.lastNormalized === 'number' ? mapping.lastNormalized : incomingNormalized;
+        const next = previous + (incomingNormalized - previous) * (1 - smoothing);
+        mapping.lastNormalized = next;
+        mapping.lastValue = incomingNormalized;
+        return next;
+    }
+
+    applyMappingValue(mapping, normalized) {
+        const parameterId = mapping.parameter;
+        if (!parameterId) return;
+
+        const def = this.parameterManager?.getParameterDefinition?.(parameterId);
+        let value = normalized;
+        if (def) {
+            value = def.min + (def.max - def.min) * clamp01(normalized);
+            if (def.type === 'int') {
+                value = Math.round(value);
+            }
+        }
+
+        this.parameterManager?.setParameter?.(parameterId, value, 'midi');
+        this.hub?.emit?.('hardware:midi-value', {
+            mappingId: mapping.id,
+            parameter: parameterId,
+            value,
+            normalized: clamp01(normalized),
+            control: mapping.control,
+            channel: mapping.channel,
+            inputId: this.activeInputId
+        });
+
+        const ref = this.mappingRefs.get(mapping.id);
+        if (ref?.valueLabel) {
+            const display = def?.type === 'int' ? value.toFixed(0) : value.toFixed(3);
+            ref.valueLabel.textContent = display;
+        }
+    }
+
+    persistState(partial = {}) {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        const enabledStatuses = new Set(['enabled', 'learning', 'no-inputs']);
+        const payload = {
+            mappings: this.mappings.map(mapping => ({
+                id: mapping.id,
+                parameter: mapping.parameter,
+                channel: mapping.channel,
+                control: mapping.control,
+                type: mapping.type,
+                smoothing: mapping.smoothing,
+                pickupThreshold: mapping.pickupThreshold
+            })),
+            inputId: this.activeInputId,
+            enabled: enabledStatuses.has(this.status),
+            ...partial
+        };
+        try {
+            window.localStorage.setItem(this.storageKey, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('PerformanceMidiBridge failed to persist state', error);
+        }
+    }
+
+    loadState() {
+        if (typeof window === 'undefined' || !window.localStorage) return null;
+        try {
+            const raw = window.localStorage.getItem(this.storageKey);
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object') {
+                return null;
+            }
+            if (Array.isArray(parsed.presets) && !parsed.mappings) {
+                return null;
+            }
+            return {
+                mappings: Array.isArray(parsed.mappings) ? parsed.mappings : [],
+                inputId: parsed.inputId || null,
+                enabled: parsed.enabled === true
+            };
+        } catch (error) {
+            console.warn('PerformanceMidiBridge failed to load state', error);
+            return null;
+        }
+    }
+
+    getState() {
+        const enabledStatuses = new Set(['enabled', 'learning', 'no-inputs']);
+        return {
+            mappings: this.mappings.map(mapping => ({
+                id: mapping.id,
+                parameter: mapping.parameter,
+                channel: mapping.channel,
+                control: mapping.control,
+                type: mapping.type,
+                smoothing: mapping.smoothing,
+                pickupThreshold: mapping.pickupThreshold
+            })),
+            inputId: this.activeInputId,
+            enabled: enabledStatuses.has(this.status)
+        };
+    }
+
+    applyState(state = {}) {
+        if (Array.isArray(state.mappings)) {
+            this.mappings = state.mappings.map(mapping => ({
+                id: mapping.id || createId('mapping'),
+                parameter: mapping.parameter,
+                channel: mapping.channel ?? (this.config.channel || 'omni'),
+                control: typeof mapping.control === 'number' ? mapping.control : null,
+                type: mapping.type || 'cc',
+                smoothing: typeof mapping.smoothing === 'number' ? mapping.smoothing : this.config.smoothing,
+                pickupThreshold: typeof mapping.pickupThreshold === 'number' ? mapping.pickupThreshold : this.config.pickupThreshold,
+                lastValue: 0,
+                lastNormalized: 0,
+                armed: false
+            }));
+        }
+        if (state.inputId) {
+            this.pendingInputId = state.inputId;
+            if (this.inputs.has(state.inputId)) {
+                this.setActiveInput(state.inputId);
+            }
+        }
+        if (state.enabled && !this.midiAccess) {
+            this.requestAccess({ silent: true });
+        }
+        this.refreshParameterOptions();
+        this.persistState();
+    }
+
+    destroy() {
+        if (this.inputs) {
+            this.inputs.forEach(input => {
+                if (input) {
+                    input.onmidimessage = null;
+                }
+            });
+            this.inputs.clear();
+        }
+        if (this.midiAccess) {
+            this.midiAccess.onstatechange = null;
+        }
+        this.mappingRefs.clear();
+        if (this.container) {
+            this.container.innerHTML = '';
+        }
+    }
+}

--- a/src/ui/PerformanceOscBridge.js
+++ b/src/ui/PerformanceOscBridge.js
@@ -1,0 +1,547 @@
+const DEFAULT_CONFIG = {
+    storageKey: 'vib34d-performance-osc',
+    defaults: {
+        enabled: false,
+        autoConnect: false,
+        endpoint: 'ws://localhost:3030',
+        namespace: '/performance',
+        forward: {
+            touchpad: true,
+            audio: true,
+            show: true,
+            presets: true,
+            hardware: true,
+            gestures: true,
+            theme: true
+        }
+    }
+};
+
+const EVENT_MAP = {
+    touchpad: ['touchpad:update', 'touchpad:mappings'],
+    audio: ['audio:settings', 'audio:flourish'],
+    show: ['show:start', 'show:stop', 'show:cue-trigger'],
+    presets: ['preset:saved', 'preset:loaded', 'preset:playlist-start', 'preset:list-changed'],
+    hardware: ['hardware:midi-value'],
+    gestures: [
+        'gestures:recording-start',
+        'gestures:recording-stop',
+        'gestures:playback-start',
+        'gestures:playback-event',
+        'gestures:playback-stop',
+        'gestures:playback-complete',
+        'gestures:list'
+    ],
+    theme: ['theme:updated', 'theme:applied']
+};
+
+const LOG_LIMIT = 12;
+
+function clone(value) {
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+        console.warn('PerformanceOscBridge failed to clone value', error);
+        return value;
+    }
+}
+
+function mergeForward(defaults = {}, overrides = {}) {
+    const result = { ...defaults };
+    Object.keys(defaults).forEach(key => {
+        if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+            result[key] = !!overrides[key];
+        }
+    });
+    Object.keys(overrides || {}).forEach(key => {
+        if (!Object.prototype.hasOwnProperty.call(result, key)) {
+            result[key] = !!overrides[key];
+        }
+    });
+    return result;
+}
+
+function normalizeState(state = {}, defaults = DEFAULT_CONFIG.defaults) {
+    const base = clone(defaults || DEFAULT_CONFIG.defaults);
+    const merged = { ...base, ...(state || {}) };
+    merged.forward = mergeForward(base.forward, state.forward || {});
+    Object.keys(EVENT_MAP).forEach(key => {
+        if (typeof merged.forward[key] === 'undefined') {
+            merged.forward[key] = false;
+        } else {
+            merged.forward[key] = !!merged.forward[key];
+        }
+    });
+    merged.enabled = !!merged.enabled;
+    merged.autoConnect = !!merged.autoConnect;
+    merged.endpoint = typeof merged.endpoint === 'string' && merged.endpoint.trim()
+        ? merged.endpoint.trim()
+        : base.endpoint;
+    merged.namespace = typeof merged.namespace === 'string' && merged.namespace.trim()
+        ? merged.namespace.trim()
+        : base.namespace;
+    return merged;
+}
+
+function safeParse(value, fallback = null) {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        return fallback;
+    }
+}
+
+function formatTime(date) {
+    if (!(date instanceof Date)) {
+        date = new Date(date);
+    }
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+export class PerformanceOscBridge {
+    constructor({ container = null, config = {}, hub = null, onStatusChange = null } = {}) {
+        this.container = container || this.ensureContainer();
+        this.config = { ...DEFAULT_CONFIG, ...(config || {}) };
+        this.defaults = clone(this.config.defaults || DEFAULT_CONFIG.defaults);
+        this.hub = hub;
+        this.onStatusChange = typeof onStatusChange === 'function' ? onStatusChange : () => {};
+
+        this.storageKey = this.config.storageKey || DEFAULT_CONFIG.storageKey;
+        this.state = normalizeState(this.loadState(), this.defaults);
+        this.socket = null;
+        this.isConnected = false;
+        this.subscriptions = [];
+        this.log = [];
+
+        this.statusEl = null;
+        this.endpointInput = null;
+        this.namespaceInput = null;
+        this.enableToggle = null;
+        this.autoConnectToggle = null;
+        this.connectButton = null;
+        this.testButton = null;
+        this.logList = null;
+        this.forwardToggles = new Map();
+
+        this.render();
+        this.bindEvents();
+        this.subscribeToHub();
+        this.refreshUI();
+
+        if (this.state.enabled && this.state.autoConnect) {
+            this.connect({ silent: true });
+        } else {
+            this.updateStatus(this.state.enabled ? 'Bridge idle' : 'Bridge disabled');
+        }
+    }
+
+    ensureContainer() {
+        if (typeof document === 'undefined') {
+            return null;
+        }
+        const section = document.createElement('section');
+        section.className = 'performance-block performance-osc';
+        return section;
+    }
+
+    render() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-block', 'performance-osc');
+        this.container.innerHTML = `
+            <header class="performance-block__header">
+                <div>
+                    <h3 class="performance-block__title">Network / OSC Bridge</h3>
+                    <p class="performance-block__subtitle">Mirror hub events to remote rigs over WebSocket.</p>
+                </div>
+            </header>
+            <div class="osc-bridge__status" data-role="status">Bridge disabled</div>
+            <div class="osc-bridge__controls">
+                <label class="osc-bridge__field">
+                    <span>Endpoint</span>
+                    <input type="text" data-role="endpoint" placeholder="ws://localhost:3030" />
+                </label>
+                <label class="osc-bridge__field">
+                    <span>Namespace</span>
+                    <input type="text" data-role="namespace" placeholder="/performance" />
+                </label>
+                <label class="osc-bridge__toggle">
+                    <input type="checkbox" data-role="enabled" /> Enable bridge
+                </label>
+                <label class="osc-bridge__toggle">
+                    <input type="checkbox" data-role="auto" /> Auto-connect
+                </label>
+                <button type="button" class="osc-bridge__connect" data-role="connect">Connect</button>
+                <button type="button" class="osc-bridge__test" data-role="test">Send heartbeat</button>
+            </div>
+            <div class="osc-bridge__forward">
+                <h4>Forward events</h4>
+                <div class="osc-bridge__forward-grid" data-role="forward-grid"></div>
+            </div>
+            <div class="osc-bridge__log">
+                <h4>Recent messages</h4>
+                <ul data-role="log"></ul>
+            </div>
+        `;
+
+        this.statusEl = this.container.querySelector('[data-role="status"]');
+        this.endpointInput = this.container.querySelector('[data-role="endpoint"]');
+        this.namespaceInput = this.container.querySelector('[data-role="namespace"]');
+        this.enableToggle = this.container.querySelector('[data-role="enabled"]');
+        this.autoConnectToggle = this.container.querySelector('[data-role="auto"]');
+        this.connectButton = this.container.querySelector('[data-role="connect"]');
+        this.testButton = this.container.querySelector('[data-role="test"]');
+        this.logList = this.container.querySelector('[data-role="log"]');
+
+        const forwardGrid = this.container.querySelector('[data-role="forward-grid"]');
+        forwardGrid.innerHTML = '';
+        Object.keys(EVENT_MAP).forEach(key => {
+            const label = key.charAt(0).toUpperCase() + key.slice(1);
+            const item = document.createElement('label');
+            item.className = 'osc-bridge__forward-item';
+            item.innerHTML = `
+                <input type="checkbox" data-role="forward" data-key="${key}" />
+                <span>${label}</span>
+            `;
+            forwardGrid.appendChild(item);
+            const checkbox = item.querySelector('input[data-role="forward"]');
+            this.forwardToggles.set(key, checkbox);
+        });
+    }
+
+    bindEvents() {
+        if (!this.container) return;
+
+        this.endpointInput?.addEventListener('change', () => {
+            this.state.endpoint = this.endpointInput.value.trim();
+            if (!this.state.endpoint) {
+                this.state.endpoint = this.defaults.endpoint;
+                this.refreshUI();
+            }
+            this.persistState();
+        });
+        this.namespaceInput?.addEventListener('change', () => {
+            this.state.namespace = this.namespaceInput.value.trim();
+            if (!this.state.namespace) {
+                this.state.namespace = this.defaults.namespace;
+                this.refreshUI();
+            }
+            this.persistState();
+        });
+        this.enableToggle?.addEventListener('change', () => {
+            this.setEnabled(this.enableToggle.checked);
+        });
+        this.autoConnectToggle?.addEventListener('change', () => {
+            this.state.autoConnect = this.autoConnectToggle.checked;
+            this.persistState();
+            if (this.state.enabled && this.state.autoConnect && !this.isConnected) {
+                this.connect();
+            }
+        });
+        this.connectButton?.addEventListener('click', () => {
+            if (this.isConnected) {
+                this.disconnect({ manual: true });
+            } else {
+                this.connect();
+            }
+        });
+        this.testButton?.addEventListener('click', () => {
+            this.sendTestHeartbeat();
+        });
+        this.forwardToggles.forEach((checkbox, key) => {
+            checkbox.addEventListener('change', () => {
+                this.state.forward[key] = checkbox.checked;
+                this.persistState();
+            });
+        });
+    }
+
+    subscribeToHub() {
+        if (!this.hub || typeof this.hub.on !== 'function') {
+            return;
+        }
+        Object.keys(EVENT_MAP).forEach(category => {
+            EVENT_MAP[category].forEach(eventName => {
+                const unsubscribe = this.hub.on(eventName, payload => {
+                    this.forwardEvent(eventName, payload, category);
+                });
+                this.subscriptions.push(unsubscribe);
+            });
+        });
+    }
+
+    refreshUI() {
+        if (this.endpointInput) {
+            this.endpointInput.value = this.state.endpoint;
+        }
+        if (this.namespaceInput) {
+            this.namespaceInput.value = this.state.namespace;
+        }
+        if (this.enableToggle) {
+            this.enableToggle.checked = this.state.enabled;
+        }
+        if (this.autoConnectToggle) {
+            this.autoConnectToggle.checked = this.state.autoConnect;
+        }
+        this.forwardToggles.forEach((checkbox, key) => {
+            checkbox.checked = !!this.state.forward[key];
+        });
+        this.updateConnectButton();
+        this.renderLog();
+    }
+
+    updateConnectButton() {
+        if (!this.connectButton) return;
+        if (this.isConnected) {
+            this.connectButton.textContent = 'Disconnect';
+            this.connectButton.classList.add('is-active');
+        } else {
+            this.connectButton.textContent = 'Connect';
+            this.connectButton.classList.remove('is-active');
+        }
+    }
+
+    loadState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return clone(this.defaults);
+        }
+        try {
+            const stored = window.localStorage.getItem(this.storageKey);
+            if (!stored) {
+                return clone(this.defaults);
+            }
+            const parsed = safeParse(stored, this.defaults);
+            return { ...this.defaults, ...(parsed || {}) };
+        } catch (error) {
+            console.warn('PerformanceOscBridge failed to load stored state', error);
+            return clone(this.defaults);
+        }
+    }
+
+    persistState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+        try {
+            window.localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+        } catch (error) {
+            console.warn('PerformanceOscBridge failed to persist state', error);
+        }
+    }
+
+    setEnabled(enabled) {
+        this.state.enabled = !!enabled;
+        this.persistState();
+        if (!this.state.enabled) {
+            this.disconnect({ silent: true });
+            this.updateStatus('Bridge disabled');
+        } else {
+            this.updateStatus('Bridge idle');
+            if (this.state.autoConnect && !this.isConnected) {
+                this.connect({ silent: true });
+            }
+        }
+    }
+
+    connect({ silent = false } = {}) {
+        if (!this.state.enabled) {
+            this.updateStatus('Enable bridge before connecting');
+            return;
+        }
+        if (typeof window === 'undefined' || typeof window.WebSocket === 'undefined') {
+            this.updateStatus('WebSocket unavailable in this environment');
+            return;
+        }
+        if (this.socket && (this.socket.readyState === WebSocket.CONNECTING || this.socket.readyState === WebSocket.OPEN)) {
+            this.socket.close();
+        }
+        try {
+            this.socket = new WebSocket(this.state.endpoint);
+        } catch (error) {
+            this.appendLog('error', 'connect', { message: error.message });
+            this.updateStatus('Connection failed');
+            return;
+        }
+
+        this.socket.addEventListener('open', () => {
+            this.isConnected = true;
+            this.updateConnectButton();
+            this.updateStatus('Bridge connected');
+            this.appendLog('info', 'connected', {});
+        });
+
+        this.socket.addEventListener('close', () => {
+            const wasConnected = this.isConnected;
+            this.isConnected = false;
+            this.updateConnectButton();
+            if (!silent) {
+                this.updateStatus(wasConnected ? 'Bridge disconnected' : 'Connection closed');
+            }
+            this.appendLog('info', 'disconnected', {});
+        });
+
+        this.socket.addEventListener('error', (event) => {
+            this.appendLog('error', 'socket-error', { message: event?.message || 'Socket error' });
+            this.updateStatus('Bridge error');
+        });
+    }
+
+    disconnect({ silent = false, manual = false } = {}) {
+        if (this.socket) {
+            try {
+                this.socket.close();
+            } catch (error) {
+                // ignore
+            }
+            this.socket = null;
+        }
+        const wasConnected = this.isConnected;
+        this.isConnected = false;
+        this.updateConnectButton();
+        if (!silent) {
+            this.updateStatus(manual ? 'Bridge disconnected' : 'Bridge idle');
+        } else if (!wasConnected) {
+            this.updateStatus('Bridge idle');
+        }
+    }
+
+    shouldForward(category) {
+        if (!this.state.enabled) return false;
+        if (!this.state.forward) return false;
+        return !!this.state.forward[category];
+    }
+
+    buildAddress(eventName) {
+        const base = this.state.namespace || '/performance';
+        const prefix = base.startsWith('/') ? base : `/${base}`;
+        const path = eventName.replace(/[:\s]+/g, '/');
+        return `${prefix}/${path}`;
+    }
+
+    forwardEvent(eventName, payload, category) {
+        if (!this.shouldForward(category)) {
+            return;
+        }
+        const message = {
+            type: 'event',
+            event: eventName,
+            category,
+            address: this.buildAddress(eventName),
+            timestamp: Date.now(),
+            payload: payload === undefined ? null : clone(payload)
+        };
+
+        if (!this.isConnected || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            this.appendLog('pending', eventName, { category, reason: 'not connected', payload: message.payload });
+            return;
+        }
+
+        try {
+            this.socket.send(JSON.stringify(message));
+            this.appendLog('outgoing', eventName, { category, payload: message.payload });
+        } catch (error) {
+            this.appendLog('error', eventName, { category, message: error.message });
+            this.updateStatus('Bridge send error');
+        }
+    }
+
+    sendTestHeartbeat() {
+        const message = {
+            type: 'heartbeat',
+            timestamp: Date.now(),
+            address: this.buildAddress('bridge:heartbeat'),
+            note: 'Manual heartbeat'
+        };
+        if (!this.isConnected || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            this.appendLog('pending', 'bridge:heartbeat', { category: 'system', reason: 'not connected' });
+            this.updateStatus('Heartbeat queued (connect to send)');
+            return;
+        }
+        try {
+            this.socket.send(JSON.stringify(message));
+            this.appendLog('outgoing', 'bridge:heartbeat', { category: 'system' });
+            this.updateStatus('Heartbeat sent');
+        } catch (error) {
+            this.appendLog('error', 'bridge:heartbeat', { category: 'system', message: error.message });
+            this.updateStatus('Heartbeat failed');
+        }
+    }
+
+    appendLog(direction, eventName, data = {}) {
+        const entry = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+            timestamp: new Date(),
+            direction,
+            event: eventName,
+            data
+        };
+        this.log.unshift(entry);
+        if (this.log.length > LOG_LIMIT) {
+            this.log.length = LOG_LIMIT;
+        }
+        this.renderLog();
+    }
+
+    renderLog() {
+        if (!this.logList) return;
+        if (!this.log.length) {
+            this.logList.innerHTML = '<li class="osc-bridge__log-empty">No messages yet.</li>';
+            return;
+        }
+        this.logList.innerHTML = this.log.map(entry => {
+            const { direction, event, data, timestamp } = entry;
+            const badgeClass = {
+                outgoing: 'is-outgoing',
+                pending: 'is-pending',
+                error: 'is-error',
+                info: 'is-info'
+            }[direction] || '';
+            const category = data?.category ? `<span class="osc-bridge__log-category">${data.category}</span>` : '';
+            return `
+                <li class="osc-bridge__log-item ${badgeClass}">
+                    <span class="osc-bridge__log-time">${formatTime(timestamp)}</span>
+                    <span class="osc-bridge__log-event">${event}</span>
+                    ${category}
+                </li>
+            `;
+        }).join('');
+    }
+
+    updateStatus(status) {
+        if (this.statusEl) {
+            this.statusEl.textContent = status;
+        }
+        this.onStatusChange(status);
+    }
+
+    getState() {
+        return clone(this.state);
+    }
+
+    applyState(nextState = {}) {
+        const normalized = normalizeState({ ...this.state, ...(nextState || {}) }, this.defaults);
+        this.state = normalized;
+        this.refreshUI();
+        if (!this.state.enabled) {
+            this.disconnect({ silent: true });
+        } else if (this.state.autoConnect) {
+            this.connect({ silent: true });
+        }
+    }
+
+    destroy() {
+        this.disconnect({ silent: true });
+        this.subscriptions.forEach(unsubscribe => unsubscribe?.());
+        this.subscriptions = [];
+        this.forwardToggles.clear();
+        this.container = null;
+        this.statusEl = null;
+        this.endpointInput = null;
+        this.namespaceInput = null;
+        this.enableToggle = null;
+        this.autoConnectToggle = null;
+        this.connectButton = null;
+        this.testButton = null;
+        this.logList = null;
+    }
+}

--- a/src/ui/PerformancePresetManager.js
+++ b/src/ui/PerformancePresetManager.js
@@ -1,0 +1,570 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+import {
+    mergeThemePalettes,
+    normalizeThemeState,
+    normalizeThemeTransition,
+    resolveThemeDetails,
+    areThemesEqual,
+    DEFAULT_THEME_TRANSITION
+} from './PerformanceThemeUtils.js';
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function createId(prefix = 'preset') {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizePresetRecord(preset, transitionDefaults = DEFAULT_THEME_TRANSITION) {
+    if (!preset || typeof preset !== 'object') {
+        return null;
+    }
+
+    const normalized = { ...preset };
+    normalized.id = normalized.id || createId('preset');
+    normalized.metadata = { ...(normalized.metadata || {}) };
+    normalized.theme = normalizeThemeState(normalized.theme, { transitionDefaults });
+
+    return normalized;
+}
+
+export class PerformancePresetManager {
+    constructor({
+        parameterManager = null,
+        touchPadController = null,
+        audioPanel = null,
+        container = null,
+        hub = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.presets,
+        themeOptions = {},
+        themeContext = {},
+        getThemeState = null,
+        applyThemeState = null,
+        hardwareBridge = null,
+        gestureRecorder = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.touchPadController = touchPadController;
+        this.audioPanel = audioPanel;
+        this.hub = hub;
+        this.hardwareBridge = hardwareBridge;
+        this.gestureRecorder = gestureRecorder;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.presets, ...(config || {}) };
+
+        this.themeOptions = themeOptions || {};
+        this.themeContext = themeContext || {};
+        this.themePalettes = mergeThemePalettes(this.themeOptions?.palettes || []);
+        this.transitionDefaults = normalizeThemeTransition(
+            this.themeOptions?.transitionDefaults,
+            DEFAULT_THEME_TRANSITION
+        );
+        this.getThemeState = typeof getThemeState === 'function' ? getThemeState : null;
+        this.applyThemeState = typeof applyThemeState === 'function' ? applyThemeState : null;
+        this.activeTheme = normalizeThemeState(this.themeContext?.themeState || null, {
+            transitionDefaults: this.transitionDefaults
+        });
+
+        this.container = container || this.ensureContainer();
+        this.storageKey = this.config.storageKey || 'vib34d-performance-presets';
+        this.playlistKey = this.config.playlistKey || 'vib34d-performance-playlist';
+
+        this.presets = this.loadPresets();
+        this.playlist = this.loadPlaylist();
+
+        this.render();
+        this.renderPresetList();
+        this.renderPlaylist();
+        this.emitPresetListChanged();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-presets');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-presets';
+        return section;
+    }
+
+    loadPresets() {
+        if (typeof window === 'undefined' || !window.localStorage) return [];
+        try {
+            const raw = window.localStorage.getItem(this.storageKey);
+            if (!raw) {
+                return [];
+            }
+
+            const parsed = JSON.parse(raw);
+            const list = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.presets)
+                    ? parsed.presets
+                    : [];
+
+            return list
+                .map(record => normalizePresetRecord(record, this.transitionDefaults))
+                .filter(Boolean);
+        } catch (error) {
+            console.warn('PresetManager failed to load presets', error);
+            return [];
+        }
+    }
+
+    loadPlaylist() {
+        if (typeof window === 'undefined' || !window.localStorage) return [];
+        try {
+            const raw = window.localStorage.getItem(this.playlistKey);
+            return raw ? JSON.parse(raw) : [];
+        } catch (error) {
+            console.warn('PresetManager failed to load playlist', error);
+            return [];
+        }
+    }
+
+    persistPresets() {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            window.localStorage.setItem(this.storageKey, JSON.stringify(this.presets));
+        } catch (error) {
+            console.warn('PresetManager failed to persist presets', error);
+        }
+    }
+
+    persistPlaylist() {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            window.localStorage.setItem(this.playlistKey, JSON.stringify(this.playlist));
+        } catch (error) {
+            console.warn('PresetManager failed to persist playlist', error);
+        }
+    }
+
+    render() {
+        if (!this.container) return;
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Presets &amp; Cues</h3>
+                <p class="performance-block__subtitle">Capture pad layouts, audio tuning, and create playlists for live runs.</p>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        const saveForm = document.createElement('form');
+        saveForm.className = 'preset-save';
+        saveForm.innerHTML = `
+            <label>
+                <span>Preset name</span>
+                <input type="text" name="name" required placeholder="Sunset build" />
+            </label>
+            <label>
+                <span>Notes</span>
+                <textarea name="notes" rows="2" placeholder="Describe choreography, cues, or lighting direction"></textarea>
+            </label>
+            <button type="submit">Save preset</button>
+        `;
+        saveForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const formData = new FormData(saveForm);
+            const name = (formData.get('name') || '').toString().trim();
+            if (!name) return;
+            const notes = (formData.get('notes') || '').toString();
+            this.createPreset({ name, notes });
+            saveForm.reset();
+        });
+        this.container.appendChild(saveForm);
+
+        const listsWrapper = document.createElement('div');
+        listsWrapper.className = 'preset-lists';
+
+        const presetList = document.createElement('section');
+        presetList.className = 'preset-list';
+        presetList.innerHTML = `
+            <header class="preset-list__header">
+                <h4>Library</h4>
+                <div class="preset-list__actions">
+                    <button type="button" class="preset-export">Export</button>
+                    <label class="preset-import">
+                        <span>Import</span>
+                        <input type="file" accept="application/json" />
+                    </label>
+                </div>
+            </header>
+            <ul class="preset-list__items"></ul>
+        `;
+        listsWrapper.appendChild(presetList);
+        this.container.appendChild(listsWrapper);
+
+        const playlistSection = document.createElement('section');
+        playlistSection.className = 'preset-playlist';
+        playlistSection.innerHTML = `
+            <header class="preset-playlist__header">
+                <h4>Playlist</h4>
+                <div class="preset-playlist__actions">
+                    <button type="button" class="playlist-start">Start</button>
+                    <button type="button" class="playlist-clear">Clear</button>
+                </div>
+            </header>
+            <ol class="preset-playlist__items"></ol>
+        `;
+        listsWrapper.appendChild(playlistSection);
+
+        presetList.querySelector('.preset-export').addEventListener('click', () => this.exportPresets());
+        presetList.querySelector('.preset-import input').addEventListener('change', (event) => this.importPresets(event));
+
+        playlistSection.querySelector('.playlist-start').addEventListener('click', () => this.startPlaylist());
+        playlistSection.querySelector('.playlist-clear').addEventListener('click', () => this.clearPlaylist());
+
+        this.listEl = presetList.querySelector('.preset-list__items');
+        this.playlistEl = playlistSection.querySelector('.preset-playlist__items');
+    }
+
+    createPreset({ name, notes }) {
+        const preset = {
+            id: createId('preset'),
+            name,
+            notes,
+            createdAt: Date.now(),
+            touchPads: this.touchPadController?.getState?.() || {},
+            audio: this.audioPanel?.getSettings?.() || {},
+            hardware: this.hardwareBridge?.getState?.() || {},
+            gestures: this.gestureRecorder?.getState?.() || { recordings: [] },
+            theme: this.captureThemeSnapshot(),
+            metadata: {
+                lastEdited: Date.now()
+            }
+        };
+        const normalized = normalizePresetRecord(preset, this.transitionDefaults);
+        this.presets.unshift(normalized);
+        this.persistPresets();
+        this.renderPresetList();
+        this.hub?.emit?.('preset:saved', clone(normalized));
+        this.emitPresetListChanged();
+    }
+
+    captureThemeSnapshot() {
+        let snapshot = null;
+
+        if (this.getThemeState) {
+            try {
+                snapshot = this.getThemeState();
+            } catch (error) {
+                console.warn('PresetManager failed to capture theme state', error);
+            }
+        }
+
+        if (!snapshot && this.themeContext?.themeState) {
+            snapshot = this.themeContext.themeState;
+        }
+
+        return normalizeThemeState(snapshot, { transitionDefaults: this.transitionDefaults });
+    }
+
+    describePresetTheme(preset) {
+        if (!preset) {
+            return null;
+        }
+
+        const details = resolveThemeDetails(preset.theme, {
+            palettes: this.themePalettes,
+            baseTheme: this.themeContext?.baseTheme,
+            transitionDefaults: this.transitionDefaults
+        });
+
+        return {
+            label: details.paletteLabel,
+            accent: details.accent,
+            paletteId: details.paletteId,
+            description: details.description,
+            state: details.state,
+            highlightAlpha: details.highlightAlpha,
+            glowStrength: details.glowStrength
+        };
+    }
+
+    setActiveThemeState(themeState) {
+        const normalized = normalizeThemeState(themeState, { transitionDefaults: this.transitionDefaults });
+        if (areThemesEqual(this.activeTheme, normalized)) {
+            return;
+        }
+        this.activeTheme = normalized;
+        this.renderPresetList();
+        this.renderPlaylist();
+    }
+
+    renderPresetList() {
+        if (!this.listEl) return;
+        this.listEl.innerHTML = '';
+        if (!this.presets.length) {
+            const empty = document.createElement('li');
+            empty.className = 'preset-list__empty';
+            empty.textContent = 'No presets saved yet.';
+            this.listEl.appendChild(empty);
+            return;
+        }
+
+        this.presets.forEach(preset => {
+            const item = document.createElement('li');
+            item.className = 'preset-list__item';
+            const themeDetails = this.describePresetTheme(preset);
+            const themeMeta = themeDetails ? '<div class="preset-list__meta"><span class="preset-list__theme"></span></div>' : '';
+            item.innerHTML = `
+                <div class="preset-list__details">
+                    <strong>${preset.name}</strong>
+                    ${preset.notes ? `<p>${preset.notes}</p>` : ''}
+                    ${themeMeta}
+                </div>
+                <div class="preset-list__buttons">
+                    <button type="button" data-action="load">Load</button>
+                    <button type="button" data-action="queue">Queue</button>
+                    <button type="button" data-action="delete">Delete</button>
+                </div>
+            `;
+
+            item.querySelector('[data-action="load"]').addEventListener('click', () => this.applyPreset(preset));
+            item.querySelector('[data-action="queue"]').addEventListener('click', () => this.queuePreset(preset.id));
+            item.querySelector('[data-action="delete"]').addEventListener('click', () => this.deletePreset(preset.id));
+
+            if (themeDetails) {
+                item.style.setProperty('--preset-theme-accent', themeDetails.accent);
+                const themeBadge = item.querySelector('.preset-list__theme');
+                if (themeBadge) {
+                    themeBadge.textContent = themeDetails.label;
+                    if (themeDetails.description) {
+                        themeBadge.title = themeDetails.description;
+                    }
+                    if (this.activeTheme && areThemesEqual(themeDetails.state, this.activeTheme)) {
+                        item.classList.add('preset-list__item--active-theme');
+                        themeBadge.classList.add('preset-list__theme--active');
+                    }
+                }
+            }
+
+            this.listEl.appendChild(item);
+        });
+    }
+
+    renderPlaylist() {
+        if (!this.playlistEl) return;
+        this.playlistEl.innerHTML = '';
+        if (!this.playlist.length) {
+            const empty = document.createElement('li');
+            empty.className = 'preset-playlist__empty';
+            empty.textContent = 'Queue presets to build a run order.';
+            this.playlistEl.appendChild(empty);
+            return;
+        }
+
+        this.playlist.forEach((entry, index) => {
+            const preset = this.presets.find(p => p.id === entry.presetId);
+            const item = document.createElement('li');
+            item.className = 'preset-playlist__item';
+            const themeDetails = preset ? this.describePresetTheme(preset) : null;
+            const themeMeta = themeDetails ? '<div class="preset-playlist__meta"><span class="preset-playlist__theme"></span></div>' : '';
+            item.innerHTML = `
+                <div>
+                    <strong>${preset ? preset.name : 'Unknown preset'}</strong>
+                    ${entry.notes ? `<p>${entry.notes}</p>` : ''}
+                    ${themeMeta}
+                </div>
+                <div class="preset-playlist__buttons">
+                    <button type="button" data-action="load">Load now</button>
+                    <button type="button" data-action="remove">Remove</button>
+                </div>
+            `;
+
+            item.querySelector('[data-action="load"]').addEventListener('click', () => {
+                if (preset) this.applyPreset(preset);
+            });
+            item.querySelector('[data-action="remove"]').addEventListener('click', () => this.removeFromPlaylist(index));
+
+            if (themeDetails) {
+                item.style.setProperty('--preset-theme-accent', themeDetails.accent);
+                const badge = item.querySelector('.preset-playlist__theme');
+                if (badge) {
+                    badge.textContent = themeDetails.label;
+                    if (themeDetails.description) {
+                        badge.title = themeDetails.description;
+                    }
+                    if (this.activeTheme && areThemesEqual(themeDetails.state, this.activeTheme)) {
+                        item.classList.add('preset-playlist__item--active-theme');
+                        badge.classList.add('preset-playlist__theme--active');
+                    }
+                }
+            }
+
+            this.playlistEl.appendChild(item);
+        });
+    }
+
+    applyPreset(preset, { applyTheme = true } = {}) {
+        if (!preset) return;
+        const themeState = normalizeThemeState(preset.theme, { transitionDefaults: this.transitionDefaults });
+        preset.theme = themeState;
+        if (preset.touchPads && this.touchPadController?.applyState) {
+            this.touchPadController.applyState(preset.touchPads);
+        }
+        if (preset.audio && this.audioPanel?.applySettings) {
+            this.audioPanel.applySettings(preset.audio);
+        }
+        if (preset.hardware && this.hardwareBridge?.applyState) {
+            this.hardwareBridge.applyState(preset.hardware);
+        }
+        if (preset.gestures && this.gestureRecorder?.applyState) {
+            this.gestureRecorder.applyState(preset.gestures);
+        }
+        if (applyTheme) {
+            if (this.applyThemeState) {
+                this.applyThemeState(themeState);
+            } else {
+                this.setActiveThemeState(themeState);
+            }
+        }
+
+        const payload = clone(preset);
+        this.hub?.emit?.('preset:loaded', payload);
+        if (applyTheme) {
+            this.hub?.emit?.('theme:applied', {
+                source: 'preset',
+                presetId: preset.id,
+                theme: clone(themeState)
+            });
+        }
+    }
+
+    deletePreset(id) {
+        this.presets = this.presets.filter(p => p.id !== id);
+        this.persistPresets();
+        this.renderPresetList();
+        this.playlist = this.playlist.filter(entry => entry.presetId !== id);
+        this.persistPlaylist();
+        this.renderPlaylist();
+        this.emitPresetListChanged();
+    }
+
+    queuePreset(id) {
+        if (!id) return;
+        this.playlist.push({ presetId: id, notes: '' });
+        this.persistPlaylist();
+        this.renderPlaylist();
+    }
+
+    removeFromPlaylist(index) {
+        this.playlist.splice(index, 1);
+        this.persistPlaylist();
+        this.renderPlaylist();
+    }
+
+    startPlaylist() {
+        if (!this.playlist.length) return;
+        const [first] = this.playlist;
+        const preset = this.presets.find(p => p.id === first.presetId);
+        if (preset) {
+            this.applyPreset(preset);
+            this.hub?.emit?.('preset:playlist-start', clone({ playlist: this.playlist, current: first }));
+        }
+    }
+
+    clearPlaylist() {
+        this.playlist = [];
+        this.persistPlaylist();
+        this.renderPlaylist();
+    }
+
+    exportPresets() {
+        if (!this.presets.length) return;
+        if (typeof window === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined') return;
+        const blob = new Blob([JSON.stringify({ presets: this.presets }, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'vib34d-performance-presets.json';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    importPresets(event) {
+        if (typeof FileReader === 'undefined') {
+            return;
+        }
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const parsed = JSON.parse(reader.result);
+                if (Array.isArray(parsed?.presets)) {
+                    this.presets = parsed.presets
+                        .map(record => normalizePresetRecord(record, this.transitionDefaults))
+                        .filter(Boolean);
+                    this.persistPresets();
+                    this.renderPresetList();
+                    this.renderPlaylist();
+                    this.emitPresetListChanged();
+                }
+            } catch (error) {
+                console.warn('Failed to import presets', error);
+            }
+        };
+        reader.readAsText(file);
+        event.target.value = '';
+    }
+
+    getState() {
+        return {
+            presets: clone(this.presets),
+            playlist: clone(this.playlist)
+        };
+    }
+
+    applyState(state = {}) {
+        if (Array.isArray(state.presets)) {
+            this.presets = clone(state.presets)
+                .map(record => normalizePresetRecord(record, this.transitionDefaults))
+                .filter(Boolean);
+            this.persistPresets();
+        }
+        if (Array.isArray(state.playlist)) {
+            this.playlist = clone(state.playlist);
+            this.persistPlaylist();
+        }
+        this.renderPresetList();
+        this.renderPlaylist();
+        this.emitPresetListChanged();
+    }
+
+    getPresetSummaries() {
+        return this.presets.map(preset => ({
+            id: preset.id,
+            name: preset.name,
+            notes: preset.notes,
+            theme: this.describePresetTheme(preset)
+        }));
+    }
+
+    getPresetById(id) {
+        const preset = this.presets.find(p => p.id === id);
+        return preset ? clone(preset) : null;
+    }
+
+    loadPresetById(id, options = {}) {
+        const preset = this.presets.find(p => p.id === id);
+        if (!preset) return false;
+        this.applyPreset(preset, options);
+        return true;
+    }
+
+    emitPresetListChanged() {
+        const summaries = this.getPresetSummaries();
+        this.hub?.emit?.('preset:list-changed', summaries);
+    }
+}

--- a/src/ui/PerformanceShowPlanner.js
+++ b/src/ui/PerformanceShowPlanner.js
@@ -1,0 +1,1328 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+import {
+    mergeThemePalettes,
+    normalizeThemeState,
+    normalizeThemeTransition,
+    resolveThemeDetails,
+    areThemesEqual,
+    DEFAULT_THEME_TRANSITION,
+    THEME_EASING_PRESETS
+} from './PerformanceThemeUtils.js';
+
+function createId(prefix = 'cue') {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function parseNumber(value, fallback = 0) {
+    const number = parseFloat(value);
+    return Number.isFinite(number) ? number : fallback;
+}
+
+function formatTimecode(seconds) {
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+        return '0:00';
+    }
+    const totalSeconds = Math.max(0, Math.round(seconds));
+    const minutes = Math.floor(totalSeconds / 60);
+    const remaining = totalSeconds - minutes * 60;
+    const padded = remaining < 10 ? `0${remaining}` : `${remaining}`;
+    return `${minutes}:${padded}`;
+}
+
+function formatRuntimeLabel(seconds) {
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+        return 'Manual';
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remaining = Math.round(seconds - minutes * 60);
+    if (minutes <= 0) {
+        return `${remaining}s`;
+    }
+    const secondsPart = remaining > 0 ? `${remaining}s` : '';
+    return `${minutes}m${secondsPart ? ` ${secondsPart}` : ''}`;
+}
+
+function formatBarsLabel(beats, beatsPerBar) {
+    if (!Number.isFinite(beats) || beats <= 0 || !Number.isFinite(beatsPerBar) || beatsPerBar <= 0) {
+        return null;
+    }
+    const bars = beats / beatsPerBar;
+    if (!Number.isFinite(bars) || bars <= 0) {
+        return null;
+    }
+    const precision = bars < 3 ? 2 : 1;
+    const value = Number.isInteger(bars) ? bars : parseFloat(bars.toFixed(precision));
+    return `${value} bar${value === 1 ? '' : 's'}`;
+}
+
+export class PerformanceShowPlanner {
+    constructor({
+        container = null,
+        hub = null,
+        presetManager = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.showPlanner,
+        themeOptions = {},
+        themeContext = {},
+        applyThemeState = null,
+        gestureOptions = []
+    } = {}) {
+        this.container = container || this.ensureContainer();
+        this.hub = hub;
+        this.presetManager = presetManager;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.showPlanner, ...(config || {}) };
+
+        this.themeOptions = themeOptions || {};
+        this.themeContext = themeContext || {};
+        this.themePalettes = mergeThemePalettes(this.themeOptions?.palettes || []);
+        this.transitionDefaults = normalizeThemeTransition(
+            this.themeOptions?.transitionDefaults,
+            DEFAULT_THEME_TRANSITION
+        );
+        this.easingOptions = Array.isArray(this.themeOptions?.easingPresets) && this.themeOptions.easingPresets.length
+            ? this.themeOptions.easingPresets.map(option => ({
+                id: option.id || option.value || option.label,
+                label: option.label || option.id || option.value,
+                value: option.value || option.id
+            }))
+            : THEME_EASING_PRESETS;
+        this.activeTheme = normalizeThemeState(this.themeContext?.themeState || null, {
+            transitionDefaults: this.transitionDefaults
+        });
+        this.activeThemeDetails = resolveThemeDetails(this.activeTheme, {
+            palettes: this.themePalettes,
+            baseTheme: this.themeContext?.baseTheme,
+            transitionDefaults: this.transitionDefaults
+        });
+        this.activeThemeAccent = this.activeThemeDetails.accent;
+
+        this.applyThemeState = typeof applyThemeState === 'function' ? applyThemeState : null;
+
+        this.storageKey = this.config.storageKey || 'vib34d-show-planner';
+        this.defaults = {
+            tempo: 120,
+            beatsPerBar: 4,
+            autoAdvance: false,
+            loop: false,
+            ...(this.config.defaults || {})
+        };
+
+        this.state = this.loadState();
+        this.isRunning = false;
+        this.activeIndex = -1;
+        this.nextCueTimeout = null;
+        this.subscriptions = [];
+        this.gestures = Array.isArray(gestureOptions) ? gestureOptions.slice() : [];
+        this.gestureMap = new Map(this.gestures.map(item => [item.id, item]));
+
+        this.render();
+        this.populateThemeSelect();
+        this.updateTempoInputs();
+        this.renderCueList();
+        this.syncPresetOptions();
+        this.populateGestureSelect();
+        this.registerHubListeners();
+        this.updateRunControls();
+        this.updateStatus();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-show-planner');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-show-planner';
+        return section;
+    }
+
+    loadState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return clone(this.defaultsWithCues());
+        }
+        try {
+            const raw = window.localStorage.getItem(this.storageKey);
+            if (!raw) return clone(this.defaultsWithCues());
+            const parsed = JSON.parse(raw);
+            return {
+                tempo: parsed?.tempo ?? this.defaults.tempo,
+                beatsPerBar: parsed?.beatsPerBar ?? this.defaults.beatsPerBar,
+                autoAdvance: parsed?.autoAdvance ?? this.defaults.autoAdvance,
+                loop: parsed?.loop ?? this.defaults.loop,
+                cues: Array.isArray(parsed?.cues) ? this.normalizeCues(parsed.cues) : []
+            };
+        } catch (error) {
+            console.warn('ShowPlanner failed to load state', error);
+            return clone(this.defaultsWithCues());
+        }
+    }
+
+    defaultsWithCues() {
+        return {
+            tempo: this.defaults.tempo,
+            beatsPerBar: this.defaults.beatsPerBar,
+            autoAdvance: this.defaults.autoAdvance,
+            loop: this.defaults.loop,
+            cues: []
+        };
+    }
+
+    persistState() {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            window.localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+        } catch (error) {
+            console.warn('ShowPlanner failed to persist state', error);
+        }
+    }
+
+    render() {
+        if (!this.container) return;
+
+        this.container.classList.add('performance-block', 'show-planner');
+        this.container.innerHTML = `
+            <header class="performance-block__header">
+                <div>
+                    <h3 class="performance-block__title">Show Planner</h3>
+                    <p class="performance-block__subtitle">Sequence presets, notes, and cue timings for live sets.</p>
+                </div>
+                <div class="show-planner__status" data-role="planner-status">Idle</div>
+            </header>
+            <div class="show-planner__run">
+                <div class="show-planner__controls">
+                    <button type="button" data-action="start">Start</button>
+                    <button type="button" data-action="stop" disabled>Stop</button>
+                    <button type="button" data-action="prev" disabled>Prev</button>
+                    <button type="button" data-action="next" disabled>Next</button>
+                </div>
+                <div class="show-planner__tempo">
+                    <label>
+                        <span>Tempo (BPM)</span>
+                        <input type="number" name="tempo" min="40" max="240" step="1" />
+                    </label>
+                    <label>
+                        <span>Beats / bar</span>
+                        <input type="number" name="beats" min="1" max="16" step="1" />
+                    </label>
+                    <label class="show-planner__toggle">
+                        <input type="checkbox" name="autoAdvance" />
+                        <span>Auto advance cues</span>
+                    </label>
+                    <label class="show-planner__toggle">
+                        <input type="checkbox" name="loop" />
+                        <span>Loop show</span>
+                    </label>
+                </div>
+            </div>
+            <form class="show-planner__form">
+                <label>
+                    <span>Cue label</span>
+                    <input type="text" name="label" placeholder="Verse build" />
+                </label>
+                <label>
+                    <span>Preset</span>
+                    <select name="presetId"></select>
+                </label>
+                <label>
+                    <span>Gesture</span>
+                    <select name="gestureId"></select>
+                </label>
+                <label>
+                    <span>Theme</span>
+                    <select name="themeMode" data-role="theme-mode"></select>
+                </label>
+                <div class="show-planner__theme-controls" data-role="theme-controls">
+                    <label>
+                        <span>Transition (ms)</span>
+                        <input type="number" name="themeTransitionDuration" min="0" max="8000" step="50" />
+                    </label>
+                    <label>
+                        <span>Transition Curve</span>
+                        <select name="themeTransitionEasing"></select>
+                    </label>
+                </div>
+                <label>
+                    <span>Duration (beats)</span>
+                    <input type="number" name="duration" min="0" step="1" placeholder="8" />
+                </label>
+                <label class="show-planner__toggle">
+                    <input type="checkbox" name="cueAutoAdvance" />
+                    <span>Auto advance after cue</span>
+                </label>
+                <label class="show-planner__notes">
+                    <span>Notes</span>
+                    <textarea name="notes" rows="2" placeholder="Lighting callouts or band cues"></textarea>
+                </label>
+                <button type="submit">Add cue</button>
+            </form>
+            <section class="show-planner__timeline" data-role="timeline">
+                <header class="show-planner__timeline-header">
+                    <h4>Timeline Overview</h4>
+                    <div class="show-planner__timeline-summary">
+                        <span data-role="timeline-total-beats">0 beats</span>
+                        <span data-role="timeline-total-runtime">Manual</span>
+                    </div>
+                </header>
+                <ol class="show-planner__timeline-cues" data-role="timeline-list"></ol>
+            </section>
+            <ol class="show-planner__cues" data-role="cue-list"></ol>
+        `;
+
+        this.statusEl = this.container.querySelector('[data-role="planner-status"]');
+        this.startBtn = this.container.querySelector('[data-action="start"]');
+        this.stopBtn = this.container.querySelector('[data-action="stop"]');
+        this.prevBtn = this.container.querySelector('[data-action="prev"]');
+        this.nextBtn = this.container.querySelector('[data-action="next"]');
+        this.tempoInput = this.container.querySelector('input[name="tempo"]');
+        this.beatsInput = this.container.querySelector('input[name="beats"]');
+        this.autoAdvanceToggle = this.container.querySelector('input[name="autoAdvance"]');
+        this.loopToggle = this.container.querySelector('input[name="loop"]');
+        this.form = this.container.querySelector('.show-planner__form');
+        this.presetSelect = this.form.querySelector('select[name="presetId"]');
+        this.gestureSelect = this.form.querySelector('select[name="gestureId"]');
+        this.themeSelect = this.form.querySelector('select[name="themeMode"]');
+        this.themeControls = this.form.querySelector('[data-role="theme-controls"]');
+        this.transitionDurationInput = this.form.querySelector('input[name="themeTransitionDuration"]');
+        this.transitionEasingSelect = this.form.querySelector('select[name="themeTransitionEasing"]');
+        this.cueListEl = this.container.querySelector('[data-role="cue-list"]');
+        this.timelineEl = this.container.querySelector('[data-role="timeline"]');
+        this.timelineListEl = this.container.querySelector('[data-role="timeline-list"]');
+        this.timelineTotalBeatsEl = this.container.querySelector('[data-role="timeline-total-beats"]');
+        this.timelineRuntimeEl = this.container.querySelector('[data-role="timeline-total-runtime"]');
+
+        this.startBtn.addEventListener('click', () => this.startRun());
+        this.stopBtn.addEventListener('click', () => this.stopRun());
+        this.prevBtn.addEventListener('click', () => this.previousCue());
+        this.nextBtn.addEventListener('click', () => this.nextCue());
+        this.tempoInput.addEventListener('change', () => this.updateTempo());
+        this.beatsInput.addEventListener('change', () => this.updateBeatsPerBar());
+        this.autoAdvanceToggle.addEventListener('change', () => this.toggleAutoAdvance());
+        this.loopToggle.addEventListener('change', () => this.toggleLoop());
+        if (this.presetSelect) {
+            this.presetSelect.addEventListener('change', () => this.updateThemeSelectAvailability());
+        }
+        if (this.gestureSelect) {
+            this.gestureSelect.addEventListener('change', () => {
+                this.gestureSelect.dataset.userSelected = 'true';
+            });
+        }
+        if (this.themeSelect) {
+            this.themeSelect.addEventListener('change', () => {
+                this.themeSelect.dataset.userSelected = 'true';
+                this.updateThemeControlAvailability();
+            });
+        }
+        if (this.transitionDurationInput) {
+            this.transitionDurationInput.addEventListener('input', () => {
+                this.markThemeControlsTouched();
+            });
+        }
+        if (this.transitionEasingSelect) {
+            this.transitionEasingSelect.addEventListener('change', () => {
+                this.markThemeControlsTouched();
+            });
+        }
+        this.form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            this.addCue(new FormData(this.form));
+        });
+    }
+
+    registerHubListeners() {
+        if (!this.hub || typeof this.hub.on !== 'function') return;
+        this.subscriptions.push(this.hub.on('preset:list-changed', () => this.syncPresetOptions()));
+        this.subscriptions.push(this.hub.on('preset:saved', () => this.syncPresetOptions()));
+        this.subscriptions.push(this.hub.on('preset:loaded', () => this.updateStatus()));
+        this.subscriptions.push(this.hub.on('gestures:list', ({ gestures } = {}) => {
+            this.setGestureOptions(Array.isArray(gestures) ? gestures : []);
+        }));
+    }
+
+    updateActiveThemeDetails() {
+        this.activeThemeDetails = resolveThemeDetails(this.activeTheme, {
+            palettes: this.themePalettes,
+            baseTheme: this.themeContext?.baseTheme,
+            transitionDefaults: this.transitionDefaults
+        });
+        this.activeThemeAccent = this.activeThemeDetails.accent;
+    }
+
+    setActiveThemeState(themeState) {
+        const normalized = normalizeThemeState(themeState, { transitionDefaults: this.transitionDefaults });
+        if (areThemesEqual(this.activeTheme, normalized)) {
+            return;
+        }
+        this.activeTheme = normalized;
+        this.updateActiveThemeDetails();
+        this.renderCueList();
+    }
+
+    updateTempoInputs() {
+        if (!this.tempoInput || !this.beatsInput || !this.autoAdvanceToggle || !this.loopToggle) return;
+        this.tempoInput.value = this.state.tempo;
+        this.beatsInput.value = this.state.beatsPerBar;
+        this.autoAdvanceToggle.checked = Boolean(this.state.autoAdvance);
+        this.loopToggle.checked = Boolean(this.state.loop);
+    }
+
+    normalizeCues(cues = []) {
+        return cues
+            .map(cue => this.normalizeCue(cue))
+            .filter(Boolean);
+    }
+
+    normalizeCueTheme(theme) {
+        if (!theme) {
+            return null;
+        }
+
+        if (typeof theme === 'string') {
+            if (theme === 'none' || theme === 'hold') {
+                return { mode: 'none', transition: null };
+            }
+            const state = normalizeThemeState({ paletteId: theme }, { transitionDefaults: this.transitionDefaults });
+            return { mode: 'palette', state, transition: state.transition };
+        }
+
+        const mode = typeof theme.mode === 'string' ? theme.mode : null;
+        let transition = null;
+        if (theme.transition) {
+            transition = normalizeThemeTransition(theme.transition, this.transitionDefaults);
+        } else if (theme.state?.transition) {
+            transition = normalizeThemeTransition(theme.state.transition, this.transitionDefaults);
+        }
+
+        if (mode === 'none') {
+            return transition ? { mode: 'none', transition } : { mode: 'none', transition: null };
+        }
+
+        if (mode === 'palette') {
+            const baseState = theme.state || (theme.paletteId ? { paletteId: theme.paletteId } : null);
+            if (!baseState) {
+                return null;
+            }
+            let state = normalizeThemeState(baseState, { transitionDefaults: this.transitionDefaults });
+            if (transition) {
+                state = { ...state, transition };
+            }
+            return { mode: 'palette', state, transition: state.transition };
+        }
+
+        if (mode === 'preset') {
+            return transition ? { mode: 'preset', transition } : { mode: 'preset', transition: null };
+        }
+
+        if (theme.paletteId) {
+            let state = normalizeThemeState({
+                paletteId: theme.paletteId,
+                overrides: theme.overrides
+            }, { transitionDefaults: this.transitionDefaults });
+            if (transition) {
+                state = { ...state, transition };
+            }
+            return { mode: 'palette', state, transition: state.transition };
+        }
+
+        return null;
+    }
+
+    normalizeCueTransition(transition) {
+        if (!transition || typeof transition !== 'object') {
+            return null;
+        }
+
+        const normalized = normalizeThemeTransition(transition, this.transitionDefaults);
+        if (
+            normalized.duration === this.transitionDefaults.duration
+            && normalized.easing === this.transitionDefaults.easing
+        ) {
+            return null;
+        }
+
+        return normalized;
+    }
+
+    normalizeCue(record = {}) {
+        if (!record || typeof record !== 'object') {
+            return null;
+        }
+
+        const id = typeof record.id === 'string' && record.id.trim() ? record.id : createId('cue');
+        const label = typeof record.label === 'string' && record.label.trim() ? record.label.trim() : 'Cue';
+        const presetId = typeof record.presetId === 'string' && record.presetId.trim() ? record.presetId : null;
+        const gestureId = typeof record.gestureId === 'string' && record.gestureId.trim() ? record.gestureId : null;
+        const duration = parseNumber(record.duration, 0);
+        const normalizedDuration = duration > 0 ? Math.round(duration) : 0;
+        const notes = typeof record.notes === 'string' ? record.notes : '';
+        const autoAdvance = Boolean(record.autoAdvance);
+        const theme = this.normalizeCueTheme(record.theme);
+
+        return {
+            id,
+            label,
+            presetId,
+            gestureId,
+            duration: normalizedDuration,
+            notes,
+            autoAdvance,
+            theme
+        };
+    }
+
+    buildCueTheme({ themeMode, transition }) {
+        const normalizedTransition = this.normalizeCueTransition(transition);
+
+        if (!themeMode || themeMode === 'preset') {
+            return normalizedTransition ? { mode: 'preset', transition: normalizedTransition } : null;
+        }
+
+        if (themeMode === 'none') {
+            return normalizedTransition ? { mode: 'none', transition: normalizedTransition } : { mode: 'none' };
+        }
+
+        if (themeMode.startsWith('palette:')) {
+            const paletteId = themeMode.slice('palette:'.length);
+            if (!paletteId) {
+                return null;
+            }
+            const state = normalizeThemeState({ paletteId }, { transitionDefaults: this.transitionDefaults });
+            const stateWithTransition = normalizedTransition
+                ? { ...state, transition: normalizedTransition }
+                : state;
+            return { mode: 'palette', state: stateWithTransition, transition: stateWithTransition.transition };
+        }
+
+        return null;
+    }
+
+    describeCueTheme(cue, presetSummary) {
+        const baseTheme = this.themeContext?.baseTheme;
+        const theme = cue?.theme ? this.normalizeCueTheme(cue.theme) : null;
+
+        if (theme && theme.mode === 'none') {
+            const accent = this.activeThemeAccent || baseTheme?.accent || '#53d7ff';
+            return {
+                mode: 'none',
+                label: 'Hold current theme',
+                accent,
+                description: 'Cue keeps the active glow palette.',
+                matchesActive: false,
+                state: null,
+                transition: theme.transition || null,
+                transitionLabel: theme.transition ? this.describeTransition(theme.transition) : ''
+            };
+        }
+
+        if (theme && theme.mode === 'palette') {
+            const details = resolveThemeDetails(theme.state, {
+                palettes: this.themePalettes,
+                baseTheme,
+                transitionDefaults: this.transitionDefaults
+            });
+            const transition = theme.transition || details.transition || null;
+            return {
+                mode: 'palette',
+                label: details.paletteLabel,
+                accent: details.accent,
+                description: details.description || 'Cue applies a palette override.',
+                matchesActive: this.activeTheme ? areThemesEqual(details.state, this.activeTheme) : false,
+                state: details.state,
+                transition,
+                transitionLabel: transition ? this.describeTransition(transition) : ''
+            };
+        }
+
+        const presetTheme = presetSummary?.theme || null;
+        if (!presetTheme) {
+            return null;
+        }
+
+        const state = presetTheme.state
+            ? normalizeThemeState(presetTheme.state, { transitionDefaults: this.transitionDefaults })
+            : normalizeThemeState(presetTheme, { transitionDefaults: this.transitionDefaults });
+        const details = resolveThemeDetails(state, {
+            palettes: this.themePalettes,
+            baseTheme,
+            transitionDefaults: this.transitionDefaults
+        });
+        const transition = (theme && theme.mode === 'preset' && theme.transition)
+            ? theme.transition
+            : details.transition;
+
+        return {
+            mode: 'preset',
+            label: presetTheme.label || details.paletteLabel,
+            accent: presetTheme.accent || details.accent,
+            description: presetTheme.description || details.description,
+            matchesActive: this.activeTheme ? areThemesEqual(state, this.activeTheme) : false,
+            state,
+            transition,
+            transitionLabel: transition ? this.describeTransition(transition) : ''
+        };
+    }
+
+    resolveCueThemeStrategy(cue, presetSummary) {
+        const normalizedTheme = cue?.theme ? this.normalizeCueTheme(cue.theme) : null;
+        if (normalizedTheme && normalizedTheme.mode === 'none') {
+            return {
+                mode: 'none',
+                applyPresetTheme: false,
+                state: null,
+                transition: normalizedTheme.transition || null
+            };
+        }
+
+        if (normalizedTheme && normalizedTheme.mode === 'palette') {
+            let state = normalizeThemeState(normalizedTheme.state, { transitionDefaults: this.transitionDefaults });
+            if (normalizedTheme.transition) {
+                state = { ...state, transition: normalizedTheme.transition };
+            }
+            return {
+                mode: 'palette',
+                applyPresetTheme: false,
+                state,
+                transition: state.transition
+            };
+        }
+
+        const presetTheme = presetSummary?.theme?.state || presetSummary?.theme || null;
+        if (normalizedTheme && normalizedTheme.mode === 'preset') {
+            if (presetTheme) {
+                let state = normalizeThemeState(presetTheme, { transitionDefaults: this.transitionDefaults });
+                if (normalizedTheme.transition) {
+                    state = { ...state, transition: normalizedTheme.transition };
+                    return {
+                        mode: 'preset',
+                        applyPresetTheme: false,
+                        state,
+                        transition: state.transition
+                    };
+                }
+                return {
+                    mode: 'preset',
+                    applyPresetTheme: true,
+                    state,
+                    transition: state.transition
+                };
+            }
+            return { mode: 'none', applyPresetTheme: false, state: null, transition: normalizedTheme.transition || null };
+        }
+
+        if (presetTheme) {
+            const state = normalizeThemeState(presetTheme, { transitionDefaults: this.transitionDefaults });
+            return { mode: 'preset', applyPresetTheme: true, state, transition: state.transition };
+        }
+
+        return { mode: 'none', applyPresetTheme: false, state: null, transition: null };
+    }
+
+    populateThemeSelect() {
+        if (!this.themeSelect) return;
+        this.themeSelect.innerHTML = '';
+        delete this.themeSelect.dataset.userSelected;
+
+        const presetOption = document.createElement('option');
+        presetOption.value = 'preset';
+        presetOption.textContent = 'Adopt preset theme';
+        this.themeSelect.appendChild(presetOption);
+
+        const holdOption = document.createElement('option');
+        holdOption.value = 'none';
+        holdOption.textContent = 'Hold current glow';
+        this.themeSelect.appendChild(holdOption);
+
+        if (this.themePalettes.length) {
+            const paletteGroup = document.createElement('optgroup');
+            paletteGroup.label = 'Cue palettes';
+            this.themePalettes.forEach(palette => {
+                if (!palette?.id) return;
+                const option = document.createElement('option');
+                option.value = `palette:${palette.id}`;
+                option.textContent = palette.label || palette.id;
+                paletteGroup.appendChild(option);
+            });
+            this.themeSelect.appendChild(paletteGroup);
+        }
+
+        this.themeSelect.value = this.presetSelect?.value ? 'preset' : 'none';
+        this.updateThemeSelectAvailability();
+        this.populateTransitionEasingSelect();
+        this.resetThemeControlsToDefaults({ force: true });
+    }
+
+    updateThemeSelectAvailability() {
+        if (!this.themeSelect) return;
+        const presetSelected = Boolean(this.presetSelect?.value);
+        const presetOption = this.themeSelect.querySelector('option[value="preset"]');
+        if (presetOption) {
+            presetOption.disabled = !presetSelected;
+        }
+        const userSelected = this.themeSelect.dataset.userSelected === 'true';
+        if (!userSelected) {
+            this.themeSelect.value = presetSelected ? 'preset' : 'none';
+        }
+        if (!presetSelected && this.themeSelect.value === 'preset') {
+            this.themeSelect.value = 'none';
+        }
+        this.updateThemeControlAvailability();
+    }
+
+    populateTransitionEasingSelect() {
+        if (!this.transitionEasingSelect) {
+            return;
+        }
+
+        const currentValue = this.transitionEasingSelect.value || this.transitionDefaults.easing;
+        this.transitionEasingSelect.innerHTML = '';
+
+        this.easingOptions.forEach(option => {
+            if (!option || !option.value) return;
+            const opt = document.createElement('option');
+            opt.value = option.value;
+            opt.textContent = option.label || option.value;
+            this.transitionEasingSelect.appendChild(opt);
+        });
+
+        this.ensureTransitionOption(currentValue);
+        this.transitionEasingSelect.value = currentValue;
+    }
+
+    ensureTransitionOption(value) {
+        if (!this.transitionEasingSelect || !value) {
+            return;
+        }
+
+        const hasOption = Array.from(this.transitionEasingSelect.options).some(option => option.value === value);
+        if (!hasOption) {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = `Custom (${value})`;
+            option.dataset.dynamic = 'true';
+            this.transitionEasingSelect.appendChild(option);
+        }
+    }
+
+    resetThemeControlsToDefaults({ force = false } = {}) {
+        const userSelected = this.themeControls?.dataset?.userSelected === 'true';
+        if (!force && userSelected) {
+            return;
+        }
+        if (this.transitionDurationInput) {
+            this.transitionDurationInput.value = this.transitionDefaults.duration;
+        }
+        if (this.transitionEasingSelect) {
+            this.ensureTransitionOption(this.transitionDefaults.easing);
+            this.transitionEasingSelect.value = this.transitionDefaults.easing;
+        }
+        if (this.themeControls && this.themeControls.dataset) {
+            delete this.themeControls.dataset.userSelected;
+        }
+        this.updateThemeControlAvailability();
+    }
+
+    markThemeControlsTouched() {
+        if (this.themeControls) {
+            this.themeControls.dataset.userSelected = 'true';
+        }
+    }
+
+    updateThemeControlAvailability() {
+        const mode = this.themeSelect?.value || 'none';
+        const disabled = mode === 'none';
+
+        if (this.transitionDurationInput) {
+            this.transitionDurationInput.disabled = disabled;
+        }
+        if (this.transitionEasingSelect) {
+            this.transitionEasingSelect.disabled = disabled;
+        }
+        if (this.themeControls) {
+            this.themeControls.classList.toggle('show-planner__theme-controls--disabled', disabled);
+        }
+    }
+
+    getEasingLabel(value) {
+        if (!value) {
+            return '';
+        }
+        const preset = this.easingOptions.find(option => option.value === value || option.id === value);
+        return preset?.label || '';
+    }
+
+    describeTransition(transition) {
+        if (!transition) {
+            return '';
+        }
+        const normalized = normalizeThemeTransition(transition, this.transitionDefaults);
+        if (normalized.duration <= 0) {
+            return 'Instant';
+        }
+        const durationMs = normalized.duration;
+        const durationLabel = durationMs < 1000
+            ? `${Math.round(durationMs)} ms`
+            : `${(durationMs / 1000) % 1 === 0 ? (durationMs / 1000).toFixed(0) : (durationMs / 1000).toFixed(1)} s`;
+        const easingLabel = this.getEasingLabel(normalized.easing);
+        return easingLabel ? `${durationLabel} ${easingLabel}` : durationLabel;
+    }
+
+    syncPresetOptions() {
+        if (!this.presetSelect) return;
+        const presets = this.presetManager?.getPresetSummaries?.() || [];
+        this.presetSelect.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = presets.length ? 'Select preset' : 'Save a preset first';
+        this.presetSelect.appendChild(placeholder);
+
+        presets.forEach(preset => {
+            const option = document.createElement('option');
+            option.value = preset.id;
+            option.textContent = preset.name;
+            this.presetSelect.appendChild(option);
+        });
+
+        this.updateThemeSelectAvailability();
+    }
+
+    populateGestureSelect() {
+        if (!this.gestureSelect) return;
+        const previous = this.gestureSelect.value;
+        this.gestureSelect.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = this.gestures.length ? 'None' : 'Record a gesture first';
+        this.gestureSelect.appendChild(placeholder);
+
+        this.gestures.forEach(gesture => {
+            const option = document.createElement('option');
+            option.value = gesture.id;
+            option.textContent = gesture.name || 'Untitled gesture';
+            this.gestureSelect.appendChild(option);
+        });
+
+        if (previous && this.gestures.some(gesture => gesture.id === previous)) {
+            this.gestureSelect.value = previous;
+        }
+    }
+
+    setGestureOptions(list = []) {
+        this.gestures = Array.isArray(list) ? list.slice() : [];
+        this.gestureMap = new Map(this.gestures.map(item => [item.id, item]));
+        this.populateGestureSelect();
+        this.renderCueList();
+    }
+
+    addCue(formData) {
+        const rawLabel = (formData.get('label') || '').toString().trim();
+        const presetId = (formData.get('presetId') || '').toString();
+        const gestureId = (formData.get('gestureId') || '').toString();
+        const duration = parseNumber(formData.get('duration'), 0);
+        const notes = (formData.get('notes') || '').toString();
+        const cueAutoAdvance = formData.get('cueAutoAdvance') === 'on';
+        const themeMode = (formData.get('themeMode') || '').toString();
+        const transitionDuration = parseNumber(formData.get('themeTransitionDuration'), this.transitionDefaults.duration);
+        const transitionEasing = (formData.get('themeTransitionEasing') || '').toString();
+
+        if (!presetId && !rawLabel && !notes) {
+            return;
+        }
+
+        const preset = presetId ? this.presetManager?.getPresetById?.(presetId) : null;
+        const label = rawLabel || preset?.name || `Cue ${this.state.cues.length + 1}`;
+
+        const cueTheme = this.buildCueTheme({
+            themeMode,
+            transition: { duration: transitionDuration, easing: transitionEasing }
+        });
+
+        const cue = this.normalizeCue({
+            id: createId('cue'),
+            label,
+            presetId: presetId || null,
+            gestureId: gestureId || null,
+            duration: duration > 0 ? Math.round(duration) : 0,
+            notes,
+            autoAdvance: cueAutoAdvance,
+            theme: cueTheme
+        });
+
+        this.state.cues.push(cue);
+        this.persistState();
+        this.renderCueList();
+        this.form.reset();
+        this.resetThemeControlsToDefaults({ force: false });
+        this.syncPresetOptions();
+        this.populateThemeSelect();
+        this.updateStatus();
+        this.updateRunControls();
+    }
+
+    renderCueList() {
+        if (!this.cueListEl) return;
+        this.cueListEl.innerHTML = '';
+
+        if (!this.state.cues.length) {
+            const empty = document.createElement('li');
+            empty.className = 'show-planner__empty';
+            empty.textContent = 'No cues yet. Add presets with notes and durations to build your run.';
+            this.cueListEl.appendChild(empty);
+            this.renderTimeline();
+            return;
+        }
+
+        const summaries = (this.presetManager?.getPresetSummaries?.() || []).reduce((map, summary) => {
+            map[summary.id] = summary;
+            return map;
+        }, {});
+
+        const activeAccent = this.activeThemeAccent || this.themeContext?.baseTheme?.accent;
+
+        this.state.cues.forEach((cue, index) => {
+            const item = document.createElement('li');
+            item.className = 'show-planner__cue';
+            if (index === this.activeIndex) {
+                item.classList.add('show-planner__cue--active');
+            }
+
+            const preset = cue.presetId ? summaries[cue.presetId] : null;
+            const presetName = preset?.name || (cue.presetId ? 'Missing preset' : 'Manual cue');
+            const themeInfo = this.describeCueTheme(cue, preset);
+            const themeBadge = themeInfo
+                ? `<span class="show-planner__cue-theme${themeInfo.matchesActive ? ' show-planner__cue-theme--active' : ''}"></span>`
+                : '';
+            const metaParts = [];
+            if (cue.duration) {
+                metaParts.push(`${cue.duration} beat${cue.duration === 1 ? '' : 's'}`);
+            } else {
+                metaParts.push('Manual');
+            }
+            if (cue.autoAdvance) {
+                metaParts.push('Auto');
+            }
+            if (themeInfo?.transitionLabel) {
+                metaParts.push(themeInfo.transitionLabel);
+            }
+            if (cue.gestureId) {
+                const gesture = this.gestureMap.get(cue.gestureId);
+                metaParts.push(`Gesture: ${gesture?.name || 'Pending'}`);
+            }
+
+            item.innerHTML = `
+                <div class="show-planner__cue-details">
+                    <div class="show-planner__cue-title">
+                        <strong>${cue.label}</strong>
+                        <span>${presetName}</span>
+                        ${themeBadge}
+                    </div>
+                    ${cue.notes ? `<p>${cue.notes}</p>` : ''}
+                    <footer>
+                        ${metaParts.map(part => `<span>${part}</span>`).join('')}
+                    </footer>
+                </div>
+                <div class="show-planner__cue-actions">
+                    <button type="button" data-action="trigger">Trigger</button>
+                    <button type="button" data-action="up">Up</button>
+                    <button type="button" data-action="down">Down</button>
+                    <button type="button" data-action="delete">Delete</button>
+                </div>
+            `;
+
+            item.querySelector('[data-action="trigger"]').addEventListener('click', () => this.triggerCue(index, { manual: true }));
+            item.querySelector('[data-action="up"]').addEventListener('click', () => this.moveCue(index, index - 1));
+            item.querySelector('[data-action="down"]').addEventListener('click', () => this.moveCue(index, index + 1));
+            item.querySelector('[data-action="delete"]').addEventListener('click', () => this.deleteCue(index));
+
+            if (activeAccent) {
+                item.style.setProperty('--active-theme-accent', activeAccent);
+            }
+
+            if (themeInfo) {
+                if (themeInfo.accent) {
+                    item.style.setProperty('--cue-theme-accent', themeInfo.accent);
+                }
+                if (themeInfo.matchesActive) {
+                    item.classList.add('show-planner__cue--theme-match');
+                }
+                const badge = item.querySelector('.show-planner__cue-theme');
+                if (badge) {
+                    badge.textContent = themeInfo.label;
+                    if (themeInfo.description) {
+                        badge.title = themeInfo.description;
+                    }
+                    if (themeInfo.mode === 'none') {
+                        badge.classList.add('show-planner__cue-theme--hold');
+                    }
+                }
+            }
+
+            this.cueListEl.appendChild(item);
+        });
+
+        this.renderTimeline();
+    }
+
+    calculateTimeline() {
+        const tempo = parseNumber(this.state.tempo, this.defaults.tempo);
+        const beatsPerBar = parseNumber(this.state.beatsPerBar, this.defaults.beatsPerBar);
+        const secondsPerBeat = tempo > 0 ? 60 / tempo : 0;
+
+        let cursorBeats = 0;
+        const items = this.state.cues.map((cue, index) => {
+            const beats = Math.max(0, parseNumber(cue.duration, 0));
+            const startBeat = cursorBeats;
+            const startSeconds = secondsPerBeat > 0 ? startBeat * secondsPerBeat : 0;
+            const durationSeconds = secondsPerBeat > 0 ? beats * secondsPerBeat : 0;
+            const endBeat = startBeat + beats;
+            const endSeconds = startSeconds + durationSeconds;
+            if (beats > 0) {
+                cursorBeats = endBeat;
+            }
+            return {
+                cue,
+                index,
+                beats,
+                startBeat,
+                endBeat,
+                startSeconds,
+                endSeconds,
+                durationSeconds
+            };
+        });
+
+        const totalBeats = cursorBeats;
+        const totalSeconds = secondsPerBeat > 0 ? totalBeats * secondsPerBeat : 0;
+        const manualCount = this.state.cues.filter(cue => !parseNumber(cue.duration, 0)).length;
+
+        return {
+            items,
+            totalBeats,
+            totalSeconds,
+            tempo,
+            beatsPerBar,
+            manualCount
+        };
+    }
+
+    renderTimeline() {
+        if (!this.timelineListEl) return;
+
+        const { items, totalBeats, totalSeconds, beatsPerBar, manualCount } = this.calculateTimeline();
+        const activeAccent = this.activeThemeAccent || this.themeContext?.baseTheme?.accent || null;
+
+        if (this.timelineEl && activeAccent) {
+            this.timelineEl.style.setProperty('--timeline-accent', activeAccent);
+        }
+
+        if (this.timelineTotalBeatsEl) {
+            const beatsLabel = totalBeats > 0 ? `${totalBeats} beat${totalBeats === 1 ? '' : 's'}` : '0 beats';
+            const barsLabel = formatBarsLabel(totalBeats, beatsPerBar);
+            this.timelineTotalBeatsEl.textContent = barsLabel ? `${beatsLabel} (${barsLabel})` : beatsLabel;
+        }
+
+        if (this.timelineRuntimeEl) {
+            const runtimeLabel = formatRuntimeLabel(totalSeconds);
+            if (manualCount > 0 && totalSeconds > 0) {
+                const plural = manualCount === 1 ? 'manual cue' : 'manual cues';
+                this.timelineRuntimeEl.textContent = `${runtimeLabel} + ${manualCount} ${plural}`;
+            } else if (manualCount > 0 && totalSeconds <= 0) {
+                const plural = manualCount === 1 ? 'cue' : 'cues';
+                this.timelineRuntimeEl.textContent = `Manual (${manualCount} ${plural})`;
+            } else {
+                this.timelineRuntimeEl.textContent = runtimeLabel;
+            }
+        }
+
+        this.timelineListEl.innerHTML = '';
+
+        if (!items.length) {
+            const empty = document.createElement('li');
+            empty.className = 'show-planner__timeline-empty';
+            empty.textContent = 'Timeline populates as you add cues.';
+            this.timelineListEl.appendChild(empty);
+            return;
+        }
+
+        const summaries = (this.presetManager?.getPresetSummaries?.() || []).reduce((map, summary) => {
+            map[summary.id] = summary;
+            return map;
+        }, {});
+
+        const widthBase = totalBeats > 0 ? totalBeats : items.length || 1;
+
+        items.forEach(entry => {
+            const li = document.createElement('li');
+            li.className = 'show-planner__timeline-cue';
+            if (entry.index === this.activeIndex) {
+                li.classList.add('show-planner__timeline-cue--active');
+            }
+
+            const cue = entry.cue;
+            const preset = cue.presetId ? summaries[cue.presetId] : null;
+            const presetName = preset?.name || (cue.presetId ? 'Missing preset' : 'Manual cue');
+            const beatsLabel = entry.beats > 0 ? `${entry.beats} beat${entry.beats === 1 ? '' : 's'}` : 'Manual';
+            const barsLabel = formatBarsLabel(entry.beats, beatsPerBar);
+            const timeLabel = entry.beats > 0 && entry.durationSeconds > 0
+                ? `${formatTimecode(entry.startSeconds)} → ${formatTimecode(entry.endSeconds)}`
+                : `${formatTimecode(entry.startSeconds)} • Manual`;
+            const widthPercent = entry.beats > 0 && totalBeats > 0
+                ? Math.max(4, (entry.beats / totalBeats) * 100)
+                : Math.max(6, 100 / widthBase);
+
+            li.innerHTML = `
+                <div class="show-planner__timeline-bar">
+                    <span class="show-planner__timeline-progress" style="width: ${widthPercent}%"></span>
+                </div>
+                <div class="show-planner__timeline-details">
+                    <div class="show-planner__timeline-title">
+                        <strong>${entry.index + 1}. ${cue.label}</strong>
+                        <span>${timeLabel}</span>
+                    </div>
+                    <footer>
+                        <span>${presetName}</span>
+                        <span>${beatsLabel}${barsLabel ? ` • ${barsLabel}` : ''}</span>
+                    </footer>
+                </div>
+            `;
+
+            if (preset?.accent) {
+                li.style.setProperty('--timeline-preset-accent', preset.accent);
+            } else if (activeAccent) {
+                li.style.setProperty('--timeline-preset-accent', activeAccent);
+            }
+
+            this.timelineListEl.appendChild(li);
+        });
+    }
+
+    moveCue(fromIndex, toIndex) {
+        if (toIndex < 0 || toIndex >= this.state.cues.length || fromIndex === toIndex) return;
+        const activeId = this.activeIndex >= 0 ? this.state.cues[this.activeIndex]?.id : null;
+        const [cue] = this.state.cues.splice(fromIndex, 1);
+        this.state.cues.splice(toIndex, 0, cue);
+        if (activeId) {
+            this.activeIndex = this.state.cues.findIndex(item => item.id === activeId);
+        }
+        this.persistState();
+        this.renderCueList();
+        this.updateStatus();
+        this.updateRunControls();
+    }
+
+    deleteCue(index) {
+        if (index < 0 || index >= this.state.cues.length) return;
+        const [removed] = this.state.cues.splice(index, 1);
+        if (removed && this.activeIndex >= 0) {
+            const activeId = this.state.cues[this.activeIndex]?.id;
+            if (!activeId || removed.id === activeId) {
+                this.stopRun();
+            } else {
+                this.activeIndex = this.state.cues.findIndex(item => item.id === activeId);
+            }
+        }
+        if (!this.state.cues.length) {
+            this.activeIndex = -1;
+        }
+        this.persistState();
+        this.renderCueList();
+        this.updateStatus();
+        this.updateRunControls();
+    }
+
+    updateTempo() {
+        this.state.tempo = Math.min(240, Math.max(40, parseNumber(this.tempoInput.value, this.defaults.tempo)));
+        this.tempoInput.value = this.state.tempo;
+        this.persistState();
+        this.updateStatus();
+        this.renderTimeline();
+    }
+
+    updateBeatsPerBar() {
+        this.state.beatsPerBar = Math.min(16, Math.max(1, parseNumber(this.beatsInput.value, this.defaults.beatsPerBar)));
+        this.beatsInput.value = this.state.beatsPerBar;
+        this.persistState();
+        this.updateStatus();
+        this.renderTimeline();
+    }
+
+    toggleAutoAdvance() {
+        this.state.autoAdvance = Boolean(this.autoAdvanceToggle.checked);
+        this.persistState();
+        this.updateStatus();
+    }
+
+    toggleLoop() {
+        this.state.loop = Boolean(this.loopToggle.checked);
+        this.persistState();
+        this.updateStatus();
+    }
+
+    startRun() {
+        if (!this.state.cues.length) return;
+        this.isRunning = true;
+        this.activeIndex = 0;
+        this.updateRunControls();
+        this.triggerCue(0, { manual: false });
+        this.hub?.emit?.('show:start', {
+            cues: clone(this.state.cues),
+            tempo: this.state.tempo,
+            beatsPerBar: this.state.beatsPerBar,
+            autoAdvance: this.state.autoAdvance,
+            loop: this.state.loop
+        });
+    }
+
+    stopRun() {
+        const wasRunning = this.isRunning;
+        if (this.isRunning) {
+            this.isRunning = false;
+            this.clearNextCueTimer();
+        }
+        this.activeIndex = -1;
+        this.updateRunControls();
+        this.updateStatus();
+        this.renderCueList();
+        if (wasRunning) {
+            this.hub?.emit?.('show:stop');
+        }
+    }
+
+    previousCue() {
+        if (!this.isRunning) {
+            this.startRun();
+            return;
+        }
+        const nextIndex = Math.max(0, this.activeIndex - 1);
+        this.triggerCue(nextIndex, { manual: false });
+    }
+
+    nextCue() {
+        if (!this.state.cues.length) return;
+        if (!this.isRunning) {
+            this.startRun();
+            return;
+        }
+        const nextIndex = this.activeIndex + 1;
+        if (nextIndex >= this.state.cues.length) {
+            if (this.state.loop) {
+                this.triggerCue(0, { manual: false });
+            } else {
+                this.stopRun();
+            }
+        } else {
+            this.triggerCue(nextIndex, { manual: false });
+        }
+    }
+
+    triggerCue(index, { manual = false } = {}) {
+        if (index < 0 || index >= this.state.cues.length) return;
+        const cue = this.state.cues[index];
+        this.clearNextCueTimer();
+        this.activeIndex = index;
+        this.updateRunControls();
+        this.renderCueList();
+
+        let presetSummary = null;
+        if (cue.presetId && this.presetManager?.getPresetSummaries) {
+            const summaries = this.presetManager.getPresetSummaries();
+            if (Array.isArray(summaries)) {
+                presetSummary = summaries.find(p => p.id === cue.presetId) || null;
+            }
+        }
+        const themeStrategy = this.resolveCueThemeStrategy(cue, presetSummary);
+
+        if (cue.presetId) {
+            const loaded = this.presetManager?.loadPresetById?.(cue.presetId, { applyTheme: themeStrategy.applyPresetTheme });
+            if (!loaded) {
+                console.warn('ShowPlanner cue preset missing', cue.presetId);
+            }
+        }
+
+        const transitionMeta = themeStrategy.transition || themeStrategy.state?.transition || null;
+
+        if (themeStrategy.mode === 'palette' && themeStrategy.state) {
+            this.applyThemeState?.(themeStrategy.state, { cueLabel: cue.label, mode: 'palette', transition: transitionMeta });
+        } else if (themeStrategy.mode === 'preset' && themeStrategy.state && !themeStrategy.applyPresetTheme) {
+            this.applyThemeState?.(themeStrategy.state, { cueLabel: cue.label, mode: 'preset', transition: transitionMeta });
+        }
+
+        this.hub?.emit?.('show:cue-trigger', {
+            cue: clone(cue),
+            index,
+            manual,
+            running: this.isRunning,
+            themeMode: themeStrategy.mode,
+            themeState: themeStrategy.state ? clone(themeStrategy.state) : null,
+            themeTransition: transitionMeta ? clone(transitionMeta) : null
+        });
+        this.updateStatus();
+
+        const shouldAutoAdvance = (this.state.autoAdvance || cue.autoAdvance) && cue.duration > 0 && this.state.tempo > 0;
+        if (this.isRunning && shouldAutoAdvance) {
+            const milliseconds = (60 / this.state.tempo) * cue.duration * 1000;
+            this.nextCueTimeout = setTimeout(() => this.nextCue(), milliseconds);
+        }
+    }
+
+    clearNextCueTimer() {
+        if (this.nextCueTimeout) {
+            clearTimeout(this.nextCueTimeout);
+            this.nextCueTimeout = null;
+        }
+    }
+
+    updateRunControls() {
+        const hasCues = this.state.cues.length > 0;
+        this.startBtn.disabled = this.isRunning || !hasCues;
+        this.stopBtn.disabled = !this.isRunning;
+        this.prevBtn.disabled = !this.isRunning || this.activeIndex <= 0;
+        this.nextBtn.disabled = !this.isRunning || (this.activeIndex >= this.state.cues.length - 1 && !this.state.loop);
+    }
+
+    updateStatus() {
+        if (!this.statusEl) return;
+        if (this.isRunning && this.activeIndex >= 0 && this.state.cues[this.activeIndex]) {
+            const cue = this.state.cues[this.activeIndex];
+            this.statusEl.textContent = `Running: ${cue.label} (${this.activeIndex + 1}/${this.state.cues.length})`;
+            this.statusEl.dataset.state = 'running';
+        } else if (this.state.cues.length) {
+            this.statusEl.textContent = `Ready with ${this.state.cues.length} cue${this.state.cues.length === 1 ? '' : 's'}`;
+            this.statusEl.dataset.state = 'ready';
+        } else {
+            this.statusEl.textContent = 'Idle';
+            this.statusEl.dataset.state = 'idle';
+        }
+    }
+
+    getState() {
+        return clone(this.state);
+    }
+
+    applyState(state = {}) {
+        this.state = {
+            tempo: state.tempo ?? this.defaults.tempo,
+            beatsPerBar: state.beatsPerBar ?? this.defaults.beatsPerBar,
+            autoAdvance: state.autoAdvance ?? this.defaults.autoAdvance,
+            loop: state.loop ?? this.defaults.loop,
+            cues: Array.isArray(state.cues) ? this.normalizeCues(state.cues) : []
+        };
+        this.persistState();
+        this.updateTempoInputs();
+        this.renderCueList();
+        this.populateThemeSelect();
+        this.updateRunControls();
+        this.updateStatus();
+    }
+
+    destroy() {
+        this.clearNextCueTimer();
+        this.subscriptions.forEach(unsubscribe => unsubscribe?.());
+        this.subscriptions = [];
+        this.container = null;
+    }
+}

--- a/src/ui/PerformanceSuite.js
+++ b/src/ui/PerformanceSuite.js
@@ -1,0 +1,1310 @@
+import { TouchPadController } from './TouchPadController.js';
+import { AudioReactivityPanel } from './AudioReactivityPanel.js';
+import { PerformancePresetManager } from './PerformancePresetManager.js';
+import { PerformanceHub } from './PerformanceHub.js';
+import { mergePerformanceConfig, DEFAULT_LAYOUT_CONFIG } from './PerformanceConfig.js';
+import { PerformanceShowPlanner } from './PerformanceShowPlanner.js';
+import { PerformanceThemePanel } from './PerformanceThemePanel.js';
+import { normalizeThemeState, normalizeThemeTransition, DEFAULT_THEME_TRANSITION } from './PerformanceThemeUtils.js';
+import { PerformanceMidiBridge } from './PerformanceMidiBridge.js';
+import { PerformanceGestureRecorder } from './PerformanceGestureRecorder.js';
+import { PerformanceTelemetryPanel } from './PerformanceTelemetryPanel.js';
+import { PerformanceOscBridge } from './PerformanceOscBridge.js';
+import { PerformanceLayoutPanel, getLayoutProfile } from './PerformanceLayoutPanel.js';
+
+function clampBetween(value, min, max) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return min;
+    }
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+}
+
+const PREVIEW_WIDTHS = {
+    desktop: 1440,
+    tablet: 1024,
+    phone: 428
+};
+
+const PREVIEW_LABELS = {
+    auto: 'Live viewport',
+    desktop: 'Desktop preview · 1440px',
+    tablet: 'Tablet preview · 1024px',
+    phone: 'Phone preview · 428px'
+};
+
+export class PerformanceSuite {
+    constructor({ engine = null, parameterManager = null, config = {}, themeContext = {} } = {}) {
+        this.engine = engine;
+        this.parameterManager = parameterManager;
+        this.config = mergePerformanceConfig(config);
+        this.themeContext = themeContext || {};
+        this.layoutDefaults = this.sanitizeLayoutState(DEFAULT_LAYOUT_CONFIG);
+        this.layoutConfig = this.normalizeLayoutConfig(this.config?.layout);
+        this.columnLabels = {
+            pads: 'Control Deck',
+            audio: 'Audio & Atmosphere',
+            presets: 'Library & Planner'
+        };
+        this.stackLabels = {
+            touchpads: 'Touch Pads & Layout',
+            telemetry: 'Telemetry & Diagnostics',
+            gestures: 'Gesture Recorder',
+            theme: 'Color Atmosphere',
+            audio: 'Audio Reactivity',
+            hardware: 'Hardware Bridge',
+            network: 'Network Bridge',
+            presets: 'Preset Library',
+            planner: 'Show Planner'
+        };
+        this.transitionDefaults = normalizeThemeTransition(
+            this.config?.theme?.transitionDefaults,
+            DEFAULT_THEME_TRANSITION
+        );
+
+        this.hub = new PerformanceHub({ engine: this.engine, parameterManager: this.parameterManager });
+        this.root = null;
+        this.columnsContainer = null;
+        this.columnElements = {};
+        this.layoutPanel = null;
+        this.touchPadController = null;
+        this.audioPanel = null;
+        this.presetManager = null;
+        this.subscriptions = [];
+        this.showPlanner = null;
+        this.themePanel = null;
+        this.hardwareBridge = null;
+        this.gestureRecorder = null;
+        this.telemetryPanel = null;
+        this.oscBridge = null;
+        this.mobileTabs = null;
+        this.mobileTabButtons = [];
+        this.onMobileTabClick = null;
+        this.onResize = null;
+        this.collapsibleStacks = [];
+        this.responsive = {
+            mode: 'desktop',
+            activePanel: this.layoutConfig.defaultPanel,
+            breakpoint: this.layoutConfig.mobileBreakpoint
+        };
+        this.previewState = {
+            mode: this.layoutConfig?.previewMode || 'auto',
+            width: null
+        };
+
+        this.layoutProfiles = [];
+        this.lastAppliedLayoutProfileId = null;
+        this.initializeLayoutProfiles();
+
+        this.mountLayout();
+        this.applyLayoutState(this.layoutConfig, { persist: false, silentStatus: true, updatePanel: false });
+        this.syncPreviewWidth();
+        this.setupResponsiveBehavior();
+        this.setupCollapsibleStacks();
+        this.initModules();
+    }
+
+    normalizeLayoutConfig(layout = {}) {
+        const defaults = this.sanitizeLayoutState(
+            { ...this.layoutDefaults, ...(DEFAULT_LAYOUT_CONFIG || {}) },
+            this.layoutDefaults,
+            { skipProfiles: true }
+        );
+        const merged = this.sanitizeLayoutState({ ...defaults, ...(layout || {}) }, defaults, { skipProfiles: true });
+        const stored = this.loadStoredLayoutState(merged.storageKey, merged);
+        if (stored) {
+            return this.sanitizeLayoutState({ ...merged, ...stored }, merged);
+        }
+        return merged;
+    }
+
+    resolveLayoutProfile(profileId) {
+        return getLayoutProfile(profileId);
+    }
+
+    sanitizeLayoutState(state = {}, fallback = {}, options = {}) {
+        const base = { ...(fallback || {}) };
+        const allowedPanels = ['pads', 'audio', 'presets'];
+        const storageKeyCandidate = state.storageKey ?? base.storageKey ?? DEFAULT_LAYOUT_CONFIG?.storageKey;
+        const storageKey = typeof storageKeyCandidate === 'string' && storageKeyCandidate.trim().length
+            ? storageKeyCandidate
+            : 'vib34d-performance-layout';
+        const profileStorageCandidate = state.profileStorageKey ?? base.profileStorageKey ?? DEFAULT_LAYOUT_CONFIG?.profileStorageKey;
+        const profileStorageKey = typeof profileStorageCandidate === 'string' && profileStorageCandidate.trim().length
+            ? profileStorageCandidate.trim()
+            : 'vib34d-performance-layout-profiles';
+        const { skipProfiles = false } = options || {};
+
+        const profile = this.resolveLayoutProfile(state.profile)?.id
+            || this.resolveLayoutProfile(base.profile)?.id
+            || getLayoutProfile().id;
+
+        const normalizeNumber = (value, defaultValue, min, max) => {
+            const source = typeof value === 'number' && !Number.isNaN(value)
+                ? value
+                : (typeof defaultValue === 'number' && !Number.isNaN(defaultValue) ? defaultValue : undefined);
+            if (typeof source !== 'number' || Number.isNaN(source)) {
+                return clampBetween((min + max) / 2, min, max);
+            }
+            return clampBetween(source, min, max);
+        };
+
+        const density = normalizeNumber(state.density, base.density ?? 0.45, 0, 1);
+        const fontScale = normalizeNumber(state.fontScale, base.fontScale ?? 1, 0.85, 1.25);
+        const surfaceScale = normalizeNumber(state.surfaceScale, base.surfaceScale ?? 1, 0.7, 1.4);
+        const mobileBreakpoint = Math.round(normalizeNumber(state.mobileBreakpoint, base.mobileBreakpoint ?? 1100, 720, 1600));
+
+        const collapsedStacks = Array.isArray(state.collapsedStacks)
+            ? state.collapsedStacks.filter(Boolean)
+            : (Array.isArray(base.collapsedStacks) ? base.collapsedStacks.slice() : []);
+
+        const defaultPanel = allowedPanels.includes(state.defaultPanel)
+            ? state.defaultPanel
+            : (allowedPanels.includes(base.defaultPanel) ? base.defaultPanel : 'pads');
+
+        const baseOrder = Array.isArray(base.columnOrder) && base.columnOrder.length
+            ? base.columnOrder.filter((panel) => allowedPanels.includes(panel))
+            : allowedPanels.slice();
+        const requestedOrder = Array.isArray(state.columnOrder) && state.columnOrder.length
+            ? state.columnOrder
+            : baseOrder;
+        const columnOrder = [];
+        requestedOrder.forEach((panel) => {
+            if (allowedPanels.includes(panel) && !columnOrder.includes(panel)) {
+                columnOrder.push(panel);
+            }
+        });
+        allowedPanels.forEach((panel) => {
+            if (!columnOrder.includes(panel)) {
+                columnOrder.push(panel);
+            }
+        });
+
+        const allowedPreviewModes = ['auto', 'desktop', 'tablet', 'phone'];
+        const previewMode = allowedPreviewModes.includes(state.previewMode)
+            ? state.previewMode
+            : (allowedPreviewModes.includes(base.previewMode) ? base.previewMode : 'auto');
+
+        let profiles = undefined;
+        if (!skipProfiles && Array.isArray(state.profiles)) {
+            profiles = state.profiles
+                .map((profileEntry) => this.sanitizeLayoutProfile(profileEntry))
+                .filter(Boolean);
+        }
+
+        const normalized = {
+            storageKey,
+            profileStorageKey,
+            profile,
+            density,
+            fontScale,
+            surfaceScale,
+            mobileBreakpoint,
+            collapsedStacks,
+            defaultPanel,
+            previewMode,
+            columnOrder
+        };
+
+        if (!skipProfiles && Array.isArray(profiles)) {
+            normalized.profiles = profiles;
+        }
+
+        return normalized;
+    }
+
+    generateLayoutProfileId() {
+        try {
+            if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+                return crypto.randomUUID();
+            }
+        } catch (error) {
+            // ignore
+        }
+        return `layout-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    sanitizeLayoutProfile(profile = {}, fallbackProfile = null) {
+        if (!profile || typeof profile !== 'object') {
+            return null;
+        }
+        const fallbackState = fallbackProfile?.state || this.layoutDefaults || DEFAULT_LAYOUT_CONFIG || {};
+        const idCandidate = typeof profile.id === 'string' && profile.id.trim().length
+            ? profile.id.trim()
+            : (fallbackProfile?.id || this.generateLayoutProfileId());
+        const nameCandidate = typeof profile.name === 'string' && profile.name.trim().length
+            ? profile.name.trim()
+            : (fallbackProfile?.name || 'Custom Layout');
+        const descriptionCandidate = typeof profile.description === 'string'
+            ? profile.description.trim()
+            : (fallbackProfile?.description || '');
+
+        const mergedState = {
+            ...(fallbackState || {}),
+            ...(profile.state && typeof profile.state === 'object' ? profile.state : {})
+        };
+        const sanitizedState = this.sanitizeLayoutState(mergedState, this.layoutDefaults, { skipProfiles: true });
+        if (!sanitizedState.previewMode) {
+            sanitizedState.previewMode = this.previewState?.mode || 'auto';
+        }
+
+        const createdAtCandidate = Number.isFinite(profile.createdAt)
+            ? Number(profile.createdAt)
+            : Number(fallbackProfile?.createdAt);
+        const updatedAtCandidate = Number.isFinite(profile.updatedAt)
+            ? Number(profile.updatedAt)
+            : Date.now();
+
+        const createdAt = Number.isFinite(createdAtCandidate) ? createdAtCandidate : Date.now();
+        const updatedAt = Number.isFinite(updatedAtCandidate) ? updatedAtCandidate : Date.now();
+
+        return {
+            id: idCandidate.slice(0, 120),
+            name: nameCandidate.slice(0, 60),
+            description: descriptionCandidate.slice(0, 200),
+            state: sanitizedState,
+            createdAt,
+            updatedAt
+        };
+    }
+
+    initializeLayoutProfiles() {
+        this.layoutProfiles = [];
+        const storageKey = this.layoutConfig?.profileStorageKey || DEFAULT_LAYOUT_CONFIG?.profileStorageKey;
+        const storedProfiles = this.loadStoredLayoutProfiles(storageKey);
+        if (storedProfiles.length) {
+            this.layoutProfiles = storedProfiles;
+            return;
+        }
+        const configProfiles = Array.isArray(this.config?.layout?.profiles) ? this.config.layout.profiles : [];
+        if (configProfiles.length) {
+            this.layoutProfiles = configProfiles
+                .map((profile) => this.sanitizeLayoutProfile(profile))
+                .filter(Boolean);
+            if (this.layoutProfiles.length) {
+                this.persistLayoutProfiles(this.layoutProfiles, storageKey);
+            }
+        }
+    }
+
+    loadStoredLayoutProfiles(storageKey = this.layoutConfig?.profileStorageKey) {
+        if (typeof window === 'undefined' || !window.localStorage || !storageKey) {
+            return [];
+        }
+        try {
+            const raw = window.localStorage.getItem(storageKey);
+            if (!raw) {
+                return [];
+            }
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) {
+                return [];
+            }
+            return parsed
+                .map((profile) => this.sanitizeLayoutProfile(profile))
+                .filter(Boolean);
+        } catch (error) {
+            console.warn('PerformanceSuite failed to load layout profiles', error);
+            return [];
+        }
+    }
+
+    persistLayoutProfiles(profiles = [], storageKey = this.layoutConfig?.profileStorageKey) {
+        if (typeof window === 'undefined' || !window.localStorage || !storageKey) {
+            return;
+        }
+        try {
+            const payload = JSON.stringify(profiles);
+            window.localStorage.setItem(storageKey, payload);
+        } catch (error) {
+            console.warn('PerformanceSuite failed to persist layout profiles', error);
+        }
+    }
+
+    setLayoutProfiles(profiles = [], { persist = true, silentStatus = false, selectedId = null } = {}) {
+        this.layoutProfiles = Array.isArray(profiles)
+            ? profiles.map((profile) => this.sanitizeLayoutProfile(profile)).filter(Boolean)
+            : [];
+        if (!selectedId && this.lastAppliedLayoutProfileId && !this.layoutProfiles.some((profile) => profile.id === this.lastAppliedLayoutProfileId)) {
+            this.lastAppliedLayoutProfileId = this.layoutProfiles[0]?.id || null;
+        }
+        if (persist) {
+            this.persistLayoutProfiles(this.layoutProfiles);
+        }
+        if (this.layoutPanel?.setProfiles) {
+            this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: selectedId || this.lastAppliedLayoutProfileId });
+        }
+        if (!silentStatus) {
+            if (this.layoutProfiles.length) {
+                this.updateStatus('Layout profiles updated');
+            } else {
+                this.updateStatus('Layout profiles cleared');
+            }
+        }
+        return this.layoutProfiles;
+    }
+
+    generateLayoutProfileName() {
+        const baseName = 'Layout Snapshot';
+        const existingNames = new Set((this.layoutProfiles || []).map((profile) => profile.name));
+        let index = this.layoutProfiles.length + 1;
+        let candidate = `${baseName} ${index}`;
+        while (existingNames.has(candidate)) {
+            index += 1;
+            candidate = `${baseName} ${index}`;
+        }
+        return candidate;
+    }
+
+    saveLayoutProfile({ name = null, state = null } = {}) {
+        const layoutState = state && typeof state === 'object'
+            ? state
+            : { ...this.getLayoutState(), profiles: undefined };
+        const sanitizedState = this.sanitizeLayoutState(layoutState, this.layoutDefaults, { skipProfiles: true });
+        sanitizedState.previewMode = sanitizedState.previewMode || this.previewState.mode || 'auto';
+        const profile = this.sanitizeLayoutProfile({
+            id: this.generateLayoutProfileId(),
+            name: (typeof name === 'string' && name.trim().length) ? name.trim() : this.generateLayoutProfileName(),
+            state: sanitizedState,
+            createdAt: Date.now(),
+            updatedAt: Date.now()
+        });
+        this.layoutProfiles = [...(this.layoutProfiles || []), profile];
+        this.lastAppliedLayoutProfileId = profile.id;
+        this.persistLayoutProfiles(this.layoutProfiles);
+        if (this.layoutPanel?.setProfiles) {
+            this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: profile.id });
+        }
+        this.updateStatus(`Layout profile saved: ${profile.name}`);
+    }
+
+    updateLayoutProfile({ id = null, name = null, state = null } = {}) {
+        if (!id) {
+            return;
+        }
+        const index = (this.layoutProfiles || []).findIndex((profile) => profile.id === id);
+        if (index === -1) {
+            return;
+        }
+        const current = this.layoutProfiles[index];
+        const layoutState = state && typeof state === 'object'
+            ? state
+            : { ...this.getLayoutState(), profiles: undefined };
+        const sanitizedState = this.sanitizeLayoutState(layoutState, current.state || this.layoutDefaults, { skipProfiles: true });
+        sanitizedState.previewMode = sanitizedState.previewMode || this.previewState.mode || 'auto';
+        const updated = this.sanitizeLayoutProfile({
+            ...current,
+            name: (typeof name === 'string' && name.trim().length) ? name.trim() : current.name,
+            state: sanitizedState,
+            updatedAt: Date.now()
+        }, current);
+        this.layoutProfiles.splice(index, 1, updated);
+        this.lastAppliedLayoutProfileId = updated.id;
+        this.persistLayoutProfiles(this.layoutProfiles);
+        if (this.layoutPanel?.setProfiles) {
+            this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: updated.id });
+        }
+        this.updateStatus(`Layout profile updated: ${updated.name}`);
+    }
+
+    deleteLayoutProfile({ id = null } = {}) {
+        if (!id) {
+            return;
+        }
+        const existingProfiles = this.layoutProfiles || [];
+        const removedProfile = existingProfiles.find((profile) => profile.id === id) || null;
+        const beforeLength = existingProfiles.length;
+        this.layoutProfiles = existingProfiles.filter((profile) => profile.id !== id);
+        if (beforeLength === this.layoutProfiles.length) {
+            return;
+        }
+        if (this.lastAppliedLayoutProfileId === id) {
+            this.lastAppliedLayoutProfileId = this.layoutProfiles[0]?.id || null;
+        }
+        this.persistLayoutProfiles(this.layoutProfiles);
+        if (this.layoutPanel?.setProfiles) {
+            this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: this.lastAppliedLayoutProfileId });
+        }
+        const suffix = removedProfile?.name ? `: ${removedProfile.name}` : '';
+        this.updateStatus(`Layout profile deleted${suffix}`);
+    }
+
+    getLayoutProfileById(profileId) {
+        if (!profileId) {
+            return null;
+        }
+        return (this.layoutProfiles || []).find((profile) => profile.id === profileId) || null;
+    }
+
+    applySavedLayoutProfile(profileId, { silentStatus = false } = {}) {
+        const profile = typeof profileId === 'string'
+            ? this.getLayoutProfileById(profileId)
+            : this.getLayoutProfileById(profileId?.id);
+        if (!profile) {
+            return;
+        }
+        this.applyLayoutState(profile.state, { persist: true });
+        this.applyPreviewMode(profile.state?.previewMode || 'auto', { silent: true });
+        this.lastAppliedLayoutProfileId = profile.id;
+        if (!silentStatus) {
+            this.updateStatus(`Layout profile applied: ${profile.name}`);
+        }
+    }
+
+    loadStoredLayoutState(storageKey, fallback = {}) {
+        if (typeof window === 'undefined' || !window.localStorage || !storageKey) {
+            return null;
+        }
+        try {
+            const raw = window.localStorage.getItem(storageKey);
+            if (!raw) {
+                return null;
+            }
+            const parsed = JSON.parse(raw);
+            return this.sanitizeLayoutState(parsed, fallback);
+        } catch (error) {
+            console.warn('PerformanceSuite failed to load layout state', error);
+            return null;
+        }
+    }
+
+    persistLayoutState(state = null) {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+        const storageKey = (state && state.storageKey) || this.layoutConfig?.storageKey;
+        if (!storageKey) {
+            return;
+        }
+        try {
+            const payload = JSON.stringify(this.getLayoutState(state || this.layoutConfig));
+            window.localStorage.setItem(storageKey, payload);
+        } catch (error) {
+            console.warn('PerformanceSuite failed to persist layout state', error);
+        }
+    }
+
+    getLayoutState(source = this.layoutConfig) {
+        const base = source || this.layoutDefaults || {};
+        const normalized = this.sanitizeLayoutState(base, this.layoutDefaults, { skipProfiles: true });
+        if (Array.isArray(this.layoutProfiles) && this.layoutProfiles.length) {
+            normalized.profiles = this.layoutProfiles.map((profile) => ({
+                ...profile,
+                state: this.sanitizeLayoutState(profile.state || {}, this.layoutDefaults, { skipProfiles: true })
+            }));
+        }
+        return normalized;
+    }
+
+    applyLayoutState(state = {}, { persist = true, silentStatus = false, updatePanel = true } = {}) {
+        const previousDefaultPanel = this.layoutConfig?.defaultPanel;
+        const normalized = this.sanitizeLayoutState(
+            { ...(this.layoutConfig || this.layoutDefaults), ...(state || {}) },
+            this.layoutDefaults
+        );
+        const { profiles: incomingProfiles, ...layoutConfig } = normalized;
+        this.layoutConfig = layoutConfig;
+        this.responsive.breakpoint = layoutConfig.mobileBreakpoint;
+        this.previewState.mode = layoutConfig.previewMode || 'auto';
+
+        if (Array.isArray(incomingProfiles)) {
+            this.setLayoutProfiles(incomingProfiles, { persist, silentStatus: true });
+        }
+
+        if (this.root) {
+            this.root.dataset.layoutProfile = layoutConfig.profile;
+            const profile = this.resolveLayoutProfile(layoutConfig.profile);
+            if (profile?.template) {
+                this.root.style.setProperty('--performance-column-template', profile.template);
+            }
+            this.applyColumnOrder(layoutConfig.columnOrder);
+
+            const airy = 1 - layoutConfig.density;
+            const columnGap = Math.round(18 + airy * 14);
+            const stackGap = Math.round(18 + airy * 10);
+            const stackBodyGap = Math.round(16 + airy * 8);
+            const blockPadding = Math.round(18 + airy * 6);
+            const blockGap = Math.round(14 + airy * 6);
+            const padGridGap = Math.round(16 + airy * 6);
+            const shellPadding = Math.round(22 + airy * 8);
+            const padMinWidth = Math.round(220 * layoutConfig.surfaceScale);
+            const padSurfaceHeight = Math.round(180 * layoutConfig.surfaceScale);
+
+            this.root.style.setProperty('--performance-column-gap', `${columnGap}px`);
+            this.root.style.setProperty('--performance-stack-gap', `${stackGap}px`);
+            this.root.style.setProperty('--performance-stack-body-gap', `${stackBodyGap}px`);
+            this.root.style.setProperty('--performance-block-padding', `${blockPadding}px`);
+            this.root.style.setProperty('--performance-block-gap', `${blockGap}px`);
+            this.root.style.setProperty('--performance-pad-grid-gap', `${padGridGap}px`);
+            this.root.style.setProperty('--performance-shell-padding', `${shellPadding}px`);
+            this.root.style.setProperty('--performance-font-scale', layoutConfig.fontScale.toFixed(3));
+            this.root.style.setProperty('--performance-pad-min-width', `${padMinWidth}px`);
+            this.root.style.setProperty('--performance-pad-surface-height', `${padSurfaceHeight}px`);
+
+            const collapsedSet = new Set(layoutConfig.collapsedStacks || []);
+            const stacks = Array.from(this.root.querySelectorAll('.performance-suite__stack'));
+            stacks.forEach((stack) => {
+                const target = stack.getAttribute('data-stack');
+                if (!target) return;
+                const button = stack.querySelector('[data-action="toggle-stack"]');
+                const body = stack.querySelector('.performance-suite__stack-body');
+                const shouldCollapse = collapsedSet.has(target);
+                this.setStackCollapsed(stack, button, body, shouldCollapse);
+            });
+        }
+
+        if (this.layoutPanel && updatePanel) {
+            this.layoutPanel.applyState(layoutConfig);
+            this.layoutPanel.setPreviewMode(layoutConfig.previewMode, { emit: false });
+            if (Array.isArray(this.layoutProfiles)) {
+                this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: this.lastAppliedLayoutProfileId });
+            }
+        }
+
+        if (persist) {
+            this.persistLayoutState(layoutConfig);
+        }
+
+        this.syncPreviewWidth();
+
+        if (!silentStatus) {
+            const profile = this.resolveLayoutProfile(layoutConfig.profile);
+            this.updateStatus(`${profile?.label || 'Layout'} updated`);
+        }
+
+        if (this.onResize) {
+            this.onResize();
+        }
+
+        if (this.responsive.mode === 'mobile') {
+            const shouldUpdateActivePanel = !this.responsive.activePanel
+                || this.responsive.activePanel === previousDefaultPanel;
+            if (shouldUpdateActivePanel) {
+                this.setActivePanel(layoutConfig.defaultPanel, { silent: true });
+            }
+        }
+    }
+
+    applyColumnOrder(order = []) {
+        if (!this.columnsContainer || !this.root) {
+            return;
+        }
+        const allowed = ['pads', 'audio', 'presets'];
+        const normalized = [];
+        if (Array.isArray(order)) {
+            order.forEach((panel) => {
+                if (allowed.includes(panel) && !normalized.includes(panel)) {
+                    normalized.push(panel);
+                }
+            });
+        }
+        allowed.forEach((panel) => {
+            if (!normalized.includes(panel)) {
+                normalized.push(panel);
+            }
+        });
+
+        normalized.forEach((panel, index) => {
+            const column = this.columnElements?.[panel];
+            if (column && column.parentNode === this.columnsContainer) {
+                column.style.order = index;
+                this.columnsContainer.appendChild(column);
+            }
+        });
+
+        if (this.mobileTabs && Array.isArray(this.mobileTabButtons) && this.mobileTabButtons.length) {
+            normalized.forEach((panel, index) => {
+                const button = this.mobileTabs.querySelector(`button[data-panel="${panel}"]`);
+                if (button) {
+                    button.style.order = index;
+                    this.mobileTabs.appendChild(button);
+                }
+            });
+            this.mobileTabButtons = normalized
+                .map((panel) => this.mobileTabs.querySelector(`button[data-panel="${panel}"]`))
+                .filter(Boolean);
+        }
+
+        this.root.dataset.columnOrder = normalized.join(',');
+        this.layoutConfig.columnOrder = normalized.slice();
+    }
+
+    syncCollapsedStack(target, collapsed, { persist = true } = {}) {
+        if (!target) {
+            return;
+        }
+        const set = new Set(this.layoutConfig?.collapsedStacks || []);
+        if (collapsed) {
+            set.add(target);
+        } else {
+            set.delete(target);
+        }
+        this.layoutConfig.collapsedStacks = Array.from(set);
+        if (persist) {
+            this.persistLayoutState();
+        }
+    }
+
+    mountLayout() {
+        if (typeof document === 'undefined') return;
+        const host = document.getElementById('controlPanel') || document.body;
+        this.root = document.createElement('section');
+        this.root.className = 'performance-suite';
+        this.root.innerHTML = `
+            <header class="performance-suite__header">
+                <div>
+                    <h2>Live Performance Suite</h2>
+                    <p>Designed for DJs, bands, and visual operators performing in sync.</p>
+                </div>
+                <div class="performance-suite__status" data-role="status">Ready</div>
+            </header>
+            <nav class="performance-suite__mobile-tabs" data-role="mobile-tabs" aria-label="Performance suite navigation">
+                <button type="button" data-panel="pads" class="is-active" aria-pressed="true">Control Deck</button>
+                <button type="button" data-panel="audio" aria-pressed="false">Audio &amp; Atmosphere</button>
+                <button type="button" data-panel="presets" aria-pressed="false">Library &amp; Planner</button>
+            </nav>
+            <div class="performance-suite__columns">
+                <section class="performance-suite__column performance-suite__column--pads" data-panel="pads">
+                    <article class="performance-suite__stack" data-stack="touchpads">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="touchpads" aria-expanded="true" aria-controls="performance-stack-body-touchpads" type="button">
+                            <span class="performance-suite__stack-title">Touch Pads &amp; Layout</span>
+                            <span class="performance-suite__stack-meta">Multi-touch surfaces, templates, and axis response</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-touchpads" data-role="touchpads-stack">
+                            <div data-role="layout"></div>
+                            <div data-role="pads"></div>
+                        </div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="telemetry">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="telemetry" aria-expanded="true" aria-controls="performance-stack-body-telemetry" type="button">
+                            <span class="performance-suite__stack-title">Telemetry &amp; Diagnostics</span>
+                            <span class="performance-suite__stack-meta">Rotation energy, control pulses, and history traces</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-telemetry" data-role="telemetry"></div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="gestures">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="gestures" aria-expanded="true" aria-controls="performance-stack-body-gestures" type="button">
+                            <span class="performance-suite__stack-title">Gesture Recorder</span>
+                            <span class="performance-suite__stack-meta">Capture, replay, and export curated flourishes</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-gestures" data-role="gestures"></div>
+                    </article>
+                </section>
+                <section class="performance-suite__column performance-suite__column--audio" data-panel="audio">
+                    <article class="performance-suite__stack" data-stack="theme">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="theme" aria-expanded="true" aria-controls="performance-stack-body-theme" type="button">
+                            <span class="performance-suite__stack-title">Color Atmosphere</span>
+                            <span class="performance-suite__stack-meta">Palettes, glow strength, and transition timing</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-theme" data-role="theme"></div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="audio">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="audio" aria-expanded="true" aria-controls="performance-stack-body-audio" type="button">
+                            <span class="performance-suite__stack-title">Audio Reactivity</span>
+                            <span class="performance-suite__stack-meta">Band weighting, smoothing, and flourish triggers</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-audio" data-role="audio"></div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="hardware">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="hardware" aria-expanded="true" aria-controls="performance-stack-body-hardware" type="button">
+                            <span class="performance-suite__stack-title">Hardware Bridge</span>
+                            <span class="performance-suite__stack-meta">MIDI device discovery, smoothing, and mappings</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-hardware" data-role="hardware"></div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="network">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="network" aria-expanded="true" aria-controls="performance-stack-body-network" type="button">
+                            <span class="performance-suite__stack-title">Network Bridge</span>
+                            <span class="performance-suite__stack-meta">OSC/WebSocket relays and remote diagnostics</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-network" data-role="network"></div>
+                    </article>
+                </section>
+                <section class="performance-suite__column performance-suite__column--presets" data-panel="presets">
+                    <article class="performance-suite__stack" data-stack="presets">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="presets" aria-expanded="true" aria-controls="performance-stack-body-presets" type="button">
+                            <span class="performance-suite__stack-title">Preset Library</span>
+                            <span class="performance-suite__stack-meta">Snapshots, playlists, and theme-aware summaries</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-presets" data-role="presets"></div>
+                    </article>
+                    <article class="performance-suite__stack" data-stack="planner">
+                        <button class="performance-suite__stack-toggle" data-action="toggle-stack" data-target="planner" aria-expanded="true" aria-controls="performance-stack-body-planner" type="button">
+                            <span class="performance-suite__stack-title">Show Planner</span>
+                            <span class="performance-suite__stack-meta">Cue stacks, tempo, timeline, and playback controls</span>
+                            <span class="performance-suite__stack-icon" aria-hidden="true"></span>
+                        </button>
+                        <div class="performance-suite__stack-body" id="performance-stack-body-planner" data-role="planner"></div>
+                    </article>
+                </section>
+            </div>
+        `;
+        host.appendChild(this.root);
+
+        this.columnsContainer = this.root.querySelector('.performance-suite__columns');
+        this.columnElements = {
+            pads: this.root.querySelector('.performance-suite__column--pads'),
+            audio: this.root.querySelector('.performance-suite__column--audio'),
+            presets: this.root.querySelector('.performance-suite__column--presets')
+        };
+        this.statusEl = this.root.querySelector('[data-role="status"]');
+        this.layoutContainer = this.root.querySelector('[data-role="layout"]');
+        this.touchpadContainer = this.root.querySelector('[data-role="pads"]')
+            || this.root.querySelector('.performance-suite__column--pads');
+        this.telemetryContainer = this.root.querySelector('[data-role="telemetry"]')
+            || this.root.querySelector('.performance-suite__column--pads');
+        this.gestureContainer = this.root.querySelector('[data-role="gestures"]')
+            || this.root.querySelector('.performance-suite__column--pads');
+        this.audioColumn = this.root.querySelector('.performance-suite__column--audio');
+        this.themeContainer = this.root.querySelector('[data-role="theme"]');
+        this.audioContainer = this.root.querySelector('[data-role="audio"]');
+        this.hardwareContainer = this.root.querySelector('[data-role="hardware"]');
+        this.networkContainer = this.root.querySelector('[data-role="network"]');
+        this.presetsContainer = this.root.querySelector('[data-role="presets"]');
+        this.showPlannerContainer = this.root.querySelector('[data-role="planner"]');
+    }
+
+    setupResponsiveBehavior() {
+        if (!this.root) return;
+
+        this.mobileTabs = this.root.querySelector('[data-role="mobile-tabs"]');
+        this.mobileTabButtons = this.mobileTabs
+            ? Array.from(this.mobileTabs.querySelectorAll('button[data-panel]'))
+            : [];
+
+        this.setActivePanel(this.responsive.activePanel || this.layoutConfig.defaultPanel, { silent: true });
+
+        if (this.mobileTabs) {
+            this.onMobileTabClick = (event) => {
+                const button = event.target.closest('button[data-panel]');
+                if (!button) return;
+                const target = button.getAttribute('data-panel');
+                if (!target) return;
+                this.setActivePanel(target);
+            };
+            this.mobileTabs.addEventListener('click', this.onMobileTabClick);
+        }
+
+        if (typeof window !== 'undefined') {
+            this.onResize = () => {
+                const viewportWidth = this.getViewportWidth();
+                if (this.previewState.mode === 'auto') {
+                    this.previewState.width = viewportWidth;
+                    this.syncPreviewWidth();
+                }
+                const mode = this.determineResponsiveMode(viewportWidth);
+                this.applyResponsiveMode(mode);
+            };
+            window.addEventListener('resize', this.onResize);
+            this.onResize();
+        } else {
+            this.applyResponsiveMode('desktop');
+        }
+    }
+
+    setActivePanel(panel, { silent = false } = {}) {
+        if (!panel) {
+            return;
+        }
+        this.responsive.activePanel = panel;
+        if (this.root) {
+            this.root.dataset.activePanel = panel;
+        }
+        if (Array.isArray(this.mobileTabButtons) && this.mobileTabButtons.length) {
+            this.mobileTabButtons.forEach((button) => {
+                const isActive = button.getAttribute('data-panel') === panel;
+                button.classList.toggle('is-active', isActive);
+                button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+        }
+        if (!silent && this.responsive.mode === 'mobile') {
+            const label = this.columnLabels[panel] || 'panel';
+            this.updateStatus(`Viewing ${label}`);
+        }
+    }
+
+    applyResponsiveMode(mode) {
+        const nextMode = mode === 'mobile' ? 'mobile' : 'desktop';
+        if (this.root) {
+            this.root.dataset.layoutMode = nextMode;
+        }
+        this.responsive.mode = nextMode;
+        if (this.mobileTabs) {
+            this.mobileTabs.hidden = nextMode !== 'mobile';
+        }
+        if (nextMode === 'mobile') {
+            this.setActivePanel(this.responsive.activePanel || this.layoutConfig.defaultPanel, { silent: true });
+            if (this.mobileTabs) {
+                this.mobileTabs.setAttribute('aria-hidden', 'false');
+            }
+        } else if (this.mobileTabs) {
+            this.mobileTabs.setAttribute('aria-hidden', 'true');
+        }
+    }
+
+    getViewportWidth() {
+        if (typeof window === 'undefined') {
+            return this.previewState.width || 0;
+        }
+        return window.innerWidth || document.documentElement?.clientWidth || 0;
+    }
+
+    getPreviewWidth(mode) {
+        const width = PREVIEW_WIDTHS[mode];
+        return typeof width === 'number' && !Number.isNaN(width) ? width : null;
+    }
+
+    determineResponsiveMode(viewportWidth) {
+        if (this.previewState.mode && this.previewState.mode !== 'auto') {
+            return this.previewState.mode === 'desktop' ? 'desktop' : 'mobile';
+        }
+        const breakpoint = this.responsive.breakpoint || this.layoutConfig.mobileBreakpoint;
+        return viewportWidth <= breakpoint ? 'mobile' : 'desktop';
+    }
+
+    getPreviewLabel(mode) {
+        return PREVIEW_LABELS[mode] || PREVIEW_LABELS.auto;
+    }
+
+    syncPreviewWidth() {
+        if (!this.root) {
+            return;
+        }
+        const mode = this.previewState.mode || 'auto';
+        let width = null;
+        if (mode === 'auto') {
+            width = this.getViewportWidth();
+            this.root.classList.remove('performance-suite--preview-active');
+            this.root.style.removeProperty('--performance-suite-preview-width');
+            this.root.dataset.previewLabel = '';
+        } else {
+            width = this.getPreviewWidth(mode);
+            if (typeof width === 'number') {
+                this.root.style.setProperty('--performance-suite-preview-width', `${width}px`);
+            }
+            this.root.classList.add('performance-suite--preview-active');
+            this.root.dataset.previewLabel = this.getPreviewLabel(mode).toUpperCase();
+        }
+        this.root.dataset.previewMode = mode;
+        this.previewState.width = width;
+    }
+
+    applyPreviewMode(mode, { silent = false, fromPanel = false } = {}) {
+        const allowed = ['auto', 'desktop', 'tablet', 'phone'];
+        const nextMode = allowed.includes(mode) ? mode : 'auto';
+        const previousMode = this.previewState.mode;
+        this.previewState.mode = nextMode;
+        if (!fromPanel && this.layoutPanel?.setPreviewMode) {
+            this.layoutPanel.setPreviewMode(nextMode, { emit: false });
+        }
+        this.syncPreviewWidth();
+        const viewportWidth = this.getViewportWidth();
+        const layoutMode = this.determineResponsiveMode(viewportWidth);
+        this.applyResponsiveMode(layoutMode);
+        if (this.layoutConfig) {
+            this.layoutConfig.previewMode = nextMode;
+            if (nextMode !== previousMode) {
+                this.persistLayoutState(this.layoutConfig);
+            }
+        }
+        if (!silent && nextMode !== previousMode) {
+            const label = this.getPreviewLabel(nextMode);
+            this.updateStatus(`Viewport preview: ${label}`);
+        }
+    }
+
+    setupCollapsibleStacks() {
+        if (!this.root) return;
+        const defaults = new Set(this.layoutConfig.collapsedStacks || []);
+        const stacks = Array.from(this.root.querySelectorAll('.performance-suite__stack'));
+        stacks.forEach((stack) => {
+            const target = stack.getAttribute('data-stack');
+            const button = stack.querySelector('[data-action="toggle-stack"]');
+            const body = stack.querySelector('.performance-suite__stack-body');
+            if (!button || !body) {
+                return;
+            }
+            const initialCollapsed = defaults.has(target);
+            this.setStackCollapsed(stack, button, body, initialCollapsed);
+            this.syncCollapsedStack(target, initialCollapsed, { persist: false });
+            const handler = () => {
+                const wasCollapsed = stack.classList.contains('is-collapsed');
+                const nextCollapsed = !wasCollapsed;
+                this.setStackCollapsed(stack, button, body, nextCollapsed);
+                this.syncCollapsedStack(target, nextCollapsed);
+                const label = this.stackLabels[target] || 'section';
+                this.updateStatus(`${label} ${nextCollapsed ? 'collapsed' : 'expanded'}`);
+            };
+            button.addEventListener('click', handler);
+            this.collapsibleStacks.push({ button, handler });
+        });
+    }
+
+    setStackCollapsed(stack, button, body, collapsed) {
+        const isCollapsed = Boolean(collapsed);
+        stack.classList.toggle('is-collapsed', isCollapsed);
+        if (button) {
+            button.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
+        }
+        if (body) {
+            body.setAttribute('aria-hidden', isCollapsed ? 'true' : 'false');
+        }
+    }
+
+    initModules() {
+        if (!this.touchpadContainer || !this.audioContainer || !this.presetsContainer || !this.showPlannerContainer) {
+            return;
+        }
+
+        if (this.themeContainer || this.audioColumn) {
+            this.themePanel = new PerformanceThemePanel({
+                container: this.themeContainer || this.audioColumn,
+                config: this.config.theme,
+                context: this.themeContext,
+                onThemeChange: (state) => this.applyThemeState(state, { notifyHost: true })
+            });
+
+            let initialTheme = this.themeContext?.themeState;
+            if ((!initialTheme || (initialTheme.paletteId === 'system' && !initialTheme.overrides)) && this.config?.theme?.storageKey) {
+                const storedTheme = this.loadStoredThemeState();
+                if (storedTheme) {
+                    initialTheme = storedTheme;
+                }
+            }
+
+            if (!initialTheme) {
+                initialTheme = { paletteId: 'system' };
+            }
+            this.applyThemeState(initialTheme, { notifyHost: true, silentStatus: true });
+        }
+
+        if (this.layoutContainer) {
+            this.layoutPanel = new PerformanceLayoutPanel({
+                container: this.layoutContainer,
+                config: { ...this.layoutConfig, profiles: this.layoutProfiles },
+                onChange: (layoutState) => {
+                    this.applyLayoutState(layoutState, { persist: true, updatePanel: false });
+                },
+                onReset: () => {
+                    this.applyLayoutState(this.layoutDefaults, { persist: true, silentStatus: true });
+                    this.applyPreviewMode('auto', { silent: true });
+                    this.updateStatus('Layout reset');
+                },
+                onPreview: ({ mode }) => this.applyPreviewMode(mode, { fromPanel: true }),
+                onSaveProfile: ({ name, state }) => this.saveLayoutProfile({ name, state }),
+                onUpdateProfile: ({ id, name, state }) => this.updateLayoutProfile({ id, name, state }),
+                onDeleteProfile: ({ id }) => this.deleteLayoutProfile({ id }),
+                onApplyProfile: ({ id }) => this.applySavedLayoutProfile(id)
+            });
+            this.layoutPanel.setPreviewMode(this.previewState.mode, { emit: false });
+            this.layoutPanel.setProfiles(this.layoutProfiles, { selectedId: this.lastAppliedLayoutProfileId });
+        }
+
+        this.touchPadController = new TouchPadController({
+            parameterManager: this.parameterManager,
+            container: this.touchpadContainer,
+            config: this.config.touchPads,
+            hub: this.hub,
+            onMappingChange: () => this.updateStatus('Touch pads ready')
+        });
+
+        if (this.telemetryContainer) {
+            this.telemetryPanel = new PerformanceTelemetryPanel({
+                parameterManager: this.parameterManager,
+                container: this.telemetryContainer,
+                config: this.config.telemetry,
+                hub: this.hub
+            });
+        }
+
+        if (this.gestureContainer) {
+            this.gestureRecorder = new PerformanceGestureRecorder({
+                parameterManager: this.parameterManager,
+                container: this.gestureContainer,
+                config: this.config.gestures,
+                hub: this.hub,
+                onStatusChange: (status) => this.updateStatus(status)
+            });
+        }
+
+        this.audioPanel = new AudioReactivityPanel({
+            parameterManager: this.parameterManager,
+            container: this.audioContainer,
+            config: this.config.audio,
+            hub: this.hub,
+            onSettingsChange: (settings) => this.applyAudioSettings(settings)
+        });
+
+        this.hardwareBridge = new PerformanceMidiBridge({
+            parameterManager: this.parameterManager,
+            container: this.hardwareContainer || this.audioColumn,
+            config: this.config.hardware,
+            hub: this.hub,
+            onStatusChange: (status) => this.updateStatus(status)
+        });
+
+        if (this.networkContainer || this.audioColumn) {
+            this.oscBridge = new PerformanceOscBridge({
+                container: this.networkContainer || this.audioColumn,
+                config: this.config.network,
+                hub: this.hub,
+                onStatusChange: (status) => this.updateStatus(status)
+            });
+        }
+
+        this.presetManager = new PerformancePresetManager({
+            parameterManager: this.parameterManager,
+            touchPadController: this.touchPadController,
+            audioPanel: this.audioPanel,
+            hardwareBridge: this.hardwareBridge,
+            gestureRecorder: this.gestureRecorder,
+            container: this.presetsContainer,
+            hub: this.hub,
+            config: this.config.presets,
+            themeOptions: this.config.theme,
+            themeContext: this.themeContext,
+            getThemeState: () => this.themePanel?.getState?.() || this.themeContext?.themeState || { paletteId: 'system' },
+            applyThemeState: (state) => this.applyThemeState(state, { notifyHost: true, silentStatus: true })
+        });
+
+        this.showPlanner = new PerformanceShowPlanner({
+            container: this.showPlannerContainer,
+            hub: this.hub,
+            presetManager: this.presetManager,
+            config: this.config.showPlanner,
+            themeOptions: this.config.theme,
+            themeContext: this.themeContext,
+            applyThemeState: (themeState, meta) => this.applyCueThemeState(themeState, meta),
+            gestureOptions: this.gestureRecorder?.getSummaries?.() || []
+        });
+
+        const activeTheme = this.themePanel?.getState?.() || this.themeContext?.themeState || { paletteId: 'system' };
+        this.presetManager?.setActiveThemeState?.(activeTheme);
+        this.showPlanner?.setActiveThemeState?.(activeTheme);
+        if (this.gestureRecorder && this.showPlanner?.setGestureOptions) {
+            this.showPlanner.setGestureOptions(this.gestureRecorder.getSummaries());
+        }
+
+        this.subscriptions.push(this.hub.on('preset:loaded', () => this.updateStatus('Preset loaded')));
+        this.subscriptions.push(this.hub.on('preset:playlist-start', () => this.updateStatus('Playlist launched')));
+        this.subscriptions.push(this.hub.on('audio:flourish', () => this.updateStatus('Flourish triggered')));
+        this.subscriptions.push(this.hub.on('show:cue-trigger', ({ cue } = {}) => {
+            if (cue?.label) {
+                this.updateStatus(`Cue triggered: ${cue.label}`);
+            }
+        }));
+    }
+
+    applyAudioSettings(settings) {
+        if (this.engine && typeof this.engine.setLiveAudioSettings === 'function') {
+            this.engine.setLiveAudioSettings(settings);
+        }
+        this.updateStatus('Audio reactivity updated');
+    }
+
+    updateStatus(message) {
+        if (!this.statusEl) return;
+        this.statusEl.textContent = message;
+        clearTimeout(this.statusTimeout);
+        this.statusTimeout = setTimeout(() => {
+            this.statusEl.textContent = 'Ready';
+        }, 2500);
+    }
+
+    getState() {
+        return {
+            layout: this.getLayoutState(),
+            touchPads: this.touchPadController?.getState?.() || {},
+            audio: this.audioPanel?.getSettings?.() || {},
+            hardware: this.hardwareBridge?.getState?.() || {},
+            network: this.oscBridge?.getState?.() || {},
+            gestures: this.gestureRecorder?.getState?.() || { recordings: [] },
+            presets: this.presetManager?.getState?.() || { presets: [], playlist: [] },
+            showPlanner: this.showPlanner?.getState?.() || { cues: [] },
+            theme: this.themePanel?.getState?.() || this.themeContext?.themeState || { paletteId: 'system' }
+        };
+    }
+
+    applyState(state = {}) {
+        if (state.layout) {
+            this.applyLayoutState(state.layout, { persist: false, silentStatus: true });
+        }
+        if (state.theme) {
+            this.applyThemeState(state.theme, { notifyHost: true, silentStatus: true });
+        }
+        if (state.touchPads && this.touchPadController?.applyState) {
+            this.touchPadController.applyState(state.touchPads);
+        }
+        if (state.audio && this.audioPanel?.applySettings) {
+            this.audioPanel.applySettings(state.audio);
+        }
+        if (state.hardware && this.hardwareBridge?.applyState) {
+            this.hardwareBridge.applyState(state.hardware);
+        }
+        if (state.network && this.oscBridge?.applyState) {
+            this.oscBridge.applyState(state.network);
+        }
+        if (state.gestures && this.gestureRecorder?.applyState) {
+            this.gestureRecorder.applyState(state.gestures);
+        }
+        if (state.presets && this.presetManager?.applyState) {
+            this.presetManager.applyState(state.presets);
+        }
+        if (state.showPlanner && this.showPlanner?.applyState) {
+            this.showPlanner.applyState(state.showPlanner);
+        }
+    }
+
+    applyThemeState(themeState, { notifyHost = false, silentStatus = false, transition = null } = {}) {
+        const baseState = themeState ? { ...themeState } : { paletteId: 'system' };
+        if (transition) {
+            baseState.transition = transition;
+        }
+
+        const normalizedTarget = normalizeThemeState(baseState, { transitionDefaults: this.transitionDefaults });
+
+        if (this.themePanel) {
+            this.themePanel.applyState(normalizedTarget, { notify: false });
+        }
+
+        this.themeContext = this.themeContext || {};
+        const normalizedState = this.themePanel?.getState?.()
+            || normalizeThemeState(normalizedTarget, { transitionDefaults: this.transitionDefaults });
+        this.themeContext.themeState = normalizedState;
+
+        this.persistThemeState(normalizedState);
+
+        this.presetManager?.setActiveThemeState?.(normalizedState);
+        this.showPlanner?.setActiveThemeState?.(normalizedState);
+
+        this.hub?.emit?.('theme:updated', { state: normalizedState });
+
+        if (notifyHost && typeof this.themeContext?.onThemeChange === 'function') {
+            this.themeContext.onThemeChange(normalizedState);
+        }
+
+        if (!silentStatus) {
+            this.updateStatus('Theme updated');
+        }
+    }
+
+    applyCueThemeState(themeState, { cueLabel = '', mode = '', transition = null } = {}) {
+        if (!themeState && !transition) {
+            return;
+        }
+        const state = themeState ? { ...themeState } : { paletteId: 'system' };
+        if (transition) {
+            state.transition = transition;
+        }
+        this.applyThemeState(state, { notifyHost: true, silentStatus: true });
+        if (cueLabel) {
+            const descriptor = mode === 'palette' ? 'palette' : 'theme';
+            this.updateStatus(`Cue ${descriptor} applied: ${cueLabel}`);
+        } else {
+            this.updateStatus('Cue theme applied');
+        }
+    }
+
+    loadStoredThemeState() {
+        const storageKey = this.config?.theme?.storageKey;
+        if (!storageKey || typeof window === 'undefined') {
+            return null;
+        }
+
+        try {
+            const raw = window.localStorage.getItem(storageKey);
+            return raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            console.warn('PerformanceSuite failed to load stored theme state', error);
+            return null;
+        }
+    }
+
+    persistThemeState(state) {
+        const storageKey = this.config?.theme?.storageKey;
+        if (!storageKey || typeof window === 'undefined') {
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(storageKey, JSON.stringify(state));
+        } catch (error) {
+            console.warn('PerformanceSuite failed to persist theme state', error);
+        }
+    }
+
+    destroy() {
+        if (typeof window !== 'undefined' && this.onResize) {
+            window.removeEventListener('resize', this.onResize);
+            this.onResize = null;
+        }
+        if (this.mobileTabs && this.onMobileTabClick) {
+            this.mobileTabs.removeEventListener('click', this.onMobileTabClick);
+            this.onMobileTabClick = null;
+        }
+        if (this.collapsibleStacks.length) {
+            this.collapsibleStacks.forEach(({ button, handler }) => {
+                button.removeEventListener('click', handler);
+            });
+            this.collapsibleStacks = [];
+        }
+        this.mobileTabButtons = [];
+        this.mobileTabs = null;
+        if (this.layoutPanel) {
+            this.layoutPanel.destroy();
+            this.layoutPanel = null;
+        }
+        if (this.touchPadController) {
+            this.touchPadController.destroy();
+            this.touchPadController = null;
+        }
+        if (this.telemetryPanel) {
+            this.telemetryPanel.destroy();
+            this.telemetryPanel = null;
+        }
+        if (this.audioPanel) {
+            this.audioPanel = null;
+        }
+        if (this.hardwareBridge) {
+            this.hardwareBridge.destroy();
+            this.hardwareBridge = null;
+        }
+        if (this.oscBridge) {
+            this.oscBridge.destroy();
+            this.oscBridge = null;
+        }
+        if (this.gestureRecorder) {
+            this.gestureRecorder.destroy();
+            this.gestureRecorder = null;
+        }
+        if (this.presetManager) {
+            this.presetManager = null;
+        }
+        if (this.showPlanner) {
+            this.showPlanner.destroy();
+            this.showPlanner = null;
+        }
+        if (this.themePanel) {
+            this.themePanel.destroy();
+            this.themePanel = null;
+        }
+        this.subscriptions.forEach(unsubscribe => unsubscribe?.());
+        this.subscriptions = [];
+        if (this.statusTimeout) {
+            clearTimeout(this.statusTimeout);
+            this.statusTimeout = null;
+        }
+        if (this.root && this.root.parentNode) {
+            this.root.parentNode.removeChild(this.root);
+        }
+    }
+}

--- a/src/ui/PerformanceSuiteHost.js
+++ b/src/ui/PerformanceSuiteHost.js
@@ -1,0 +1,264 @@
+import { PerformanceSuite } from './PerformanceSuite.js';
+import { normalizeThemeState, normalizeThemeTransition, DEFAULT_THEME_TRANSITION } from './PerformanceThemeUtils.js';
+
+const SYSTEM_THEMES = {
+    faceted: {
+        accent: '#53d7ff',
+        surface: 'rgba(17, 20, 35, 0.94)',
+        background: '#050a16',
+        highlightAlpha: 0.22,
+        glowStrength: 0.65
+    },
+    quantum: {
+        accent: '#ff6dff',
+        surface: 'rgba(33, 12, 40, 0.94)',
+        background: '#090212',
+        highlightAlpha: 0.26,
+        glowStrength: 0.7
+    },
+    holographic: {
+        accent: '#ffc853',
+        surface: 'rgba(36, 24, 8, 0.94)',
+        background: '#0d0802',
+        highlightAlpha: 0.24,
+        glowStrength: 0.6
+    },
+    polychora: {
+        accent: '#9bff85',
+        surface: 'rgba(10, 26, 24, 0.94)',
+        background: '#02140f',
+        highlightAlpha: 0.22,
+        glowStrength: 0.68
+    }
+};
+
+function hexToRgba(hex, alpha) {
+    if (!hex) {
+        return `rgba(255, 255, 255, ${alpha ?? 1})`;
+    }
+
+    const normalized = hex.replace('#', '');
+    const values = normalized.length === 3
+        ? normalized.split('').map(ch => parseInt(ch + ch, 16))
+        : [
+            parseInt(normalized.slice(0, 2), 16),
+            parseInt(normalized.slice(2, 4), 16),
+            parseInt(normalized.slice(4, 6), 16)
+        ];
+
+    const [r = 255, g = 255, b = 255] = values;
+    const resolvedAlpha = typeof alpha === 'number' ? alpha : 1;
+    return `rgba(${r}, ${g}, ${b}, ${resolvedAlpha})`;
+}
+
+function buildTheme(systemName, themeState = null) {
+    const normalized = normalizeThemeState(themeState);
+    const base = SYSTEM_THEMES[systemName] || SYSTEM_THEMES.faceted;
+    const overrides = normalized?.overrides || {};
+
+    const accent = overrides.accent || base.accent;
+    const highlightAlpha = typeof overrides.highlightAlpha === 'number'
+        ? overrides.highlightAlpha
+        : base.highlightAlpha;
+    const glowStrength = typeof overrides.glowStrength === 'number'
+        ? overrides.glowStrength
+        : base.glowStrength;
+
+    const transition = normalizeThemeTransition(normalized?.transition, DEFAULT_THEME_TRANSITION);
+
+    return {
+        accent,
+        surface: base.surface,
+        background: base.background,
+        highlight: hexToRgba(accent, highlightAlpha),
+        glowStrength,
+        transition
+    };
+}
+
+function applyThemeVariables(systemName, themeState = null) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const normalizedState = normalizeThemeState(themeState);
+    const theme = buildTheme(systemName, normalizedState);
+    const root = document.documentElement;
+
+    root.style.setProperty('--performance-accent', theme.accent);
+    root.style.setProperty('--performance-highlight', theme.highlight);
+    root.style.setProperty('--performance-surface', theme.surface);
+    root.style.setProperty('--performance-bg', theme.background);
+    root.style.setProperty('--performance-glow-strength', String(theme.glowStrength));
+    const transition = theme.transition || normalizeThemeTransition(null, DEFAULT_THEME_TRANSITION);
+    root.style.setProperty('--performance-theme-transition-ms', String(transition.duration));
+    root.style.setProperty('--performance-theme-transition-easing', transition.easing);
+    root.style.setProperty('--performance-theme-transition', `calc(${transition.duration} * 1ms) ${transition.easing}`);
+}
+
+function getBaseTheme(systemName) {
+    const base = SYSTEM_THEMES[systemName] || SYSTEM_THEMES.faceted;
+    return {
+        accent: base.accent,
+        highlightAlpha: base.highlightAlpha,
+        glowStrength: base.glowStrength
+    };
+}
+
+function resolveParameterManager(engine, explicitManager) {
+    if (explicitManager) return explicitManager;
+    if (!engine) return null;
+
+    if (engine.parameterManager) return engine.parameterManager;
+    if (engine.parameters) return engine.parameters;
+    if (typeof engine.getParameterManager === 'function') {
+        try {
+            return engine.getParameterManager();
+        } catch (error) {
+            console.warn('PerformanceSuiteHost failed to resolve parameter manager via getter', error);
+        }
+    }
+    return null;
+}
+
+class PerformanceSuiteHost {
+    constructor() {
+        this.suite = null;
+        this.cachedState = null;
+        this.activeEngine = null;
+        this.activeSystem = 'faceted';
+        this.themeState = { paletteId: 'system', overrides: null };
+    }
+
+    prepareForEngineSwitch(engine) {
+        if (!engine || this.activeEngine !== engine || !this.suite) {
+            return;
+        }
+
+        try {
+            this.cachedState = this.suite.getState();
+        } catch (error) {
+            console.warn('PerformanceSuiteHost failed to capture state before switch', error);
+        }
+
+        this.suite.destroy();
+        this.suite = null;
+        this.activeEngine = null;
+    }
+
+    activateEngine(engine, { systemName = 'faceted', parameterManager } = {}) {
+        if (!engine) {
+            return null;
+        }
+
+        if (this.activeEngine === engine && this.suite) {
+            this.activeSystem = systemName;
+            applyThemeVariables(systemName, this.themeState);
+            return this.suite;
+        }
+
+        const resolvedManager = resolveParameterManager(engine, parameterManager);
+        const cachedThemeState = normalizeThemeState(this.cachedState?.theme);
+        const activeThemeState = cachedThemeState || this.themeState || { paletteId: 'system', overrides: null };
+        this.themeState = normalizeThemeState(activeThemeState);
+        applyThemeVariables(systemName, this.themeState);
+
+        if (!this.cachedState && this.suite) {
+            try {
+                this.cachedState = this.suite.getState();
+            } catch (error) {
+                console.warn('PerformanceSuiteHost failed to snapshot existing state', error);
+            }
+        }
+
+        if (this.suite) {
+            this.suite.destroy();
+        }
+
+        try {
+            this.suite = new PerformanceSuite({
+                engine,
+                parameterManager: resolvedManager || undefined,
+                themeContext: {
+                    systemName,
+                    baseTheme: getBaseTheme(systemName),
+                    themeState: this.themeState,
+                    onThemeChange: (state) => this.setThemeState(state, systemName)
+                }
+            });
+        } catch (error) {
+            console.warn('PerformanceSuiteHost failed to initialize suite', error);
+            this.suite = null;
+            return null;
+        }
+
+        if (this.suite?.applyThemeState) {
+            try {
+                this.suite.applyThemeState(this.themeState, { notify: true, silentStatus: true });
+            } catch (error) {
+                console.warn('PerformanceSuiteHost failed to apply theme state to suite', error);
+            }
+        }
+
+        if (this.cachedState && this.suite?.applyState) {
+            try {
+                this.suite.applyState(this.cachedState);
+            } catch (error) {
+                console.warn('PerformanceSuiteHost failed to restore cached state', error);
+            }
+        }
+
+        this.activeEngine = engine;
+        this.activeSystem = systemName;
+
+        return this.suite;
+    }
+
+    detachEngine(engine) {
+        if (!engine || this.activeEngine !== engine) {
+            return;
+        }
+
+        if (this.suite) {
+            try {
+                this.cachedState = this.suite.getState();
+            } catch (error) {
+                console.warn('PerformanceSuiteHost failed to snapshot state on detach', error);
+            }
+
+            this.suite.destroy();
+            this.suite = null;
+        }
+
+        this.activeEngine = null;
+    }
+
+    setThemeState(themeState, systemName = this.activeSystem) {
+        this.themeState = normalizeThemeState(themeState);
+        applyThemeVariables(systemName, this.themeState);
+
+        if (this.cachedState) {
+            this.cachedState.theme = this.themeState;
+        }
+    }
+}
+
+let singleton = null;
+
+export function getPerformanceSuiteHost() {
+    if (singleton) {
+        return singleton;
+    }
+
+    singleton = new PerformanceSuiteHost();
+
+    if (typeof window !== 'undefined') {
+        window.performanceSuiteHost = singleton;
+    }
+
+    return singleton;
+}
+
+export function getPerformanceTheme(systemName, themeState = null) {
+    return buildTheme(systemName, normalizeThemeState(themeState));
+}

--- a/src/ui/PerformanceTelemetryPanel.js
+++ b/src/ui/PerformanceTelemetryPanel.js
@@ -1,0 +1,279 @@
+const DEFAULT_ROTATION_PARAMS = ['rot4dXW', 'rot4dYW', 'rot4dZW'];
+const DEFAULT_DYNAMICS_PARAMS = ['dimension', 'speed', 'chaos', 'intensity'];
+
+function clamp01(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+    return Math.max(0, Math.min(1, value));
+}
+
+function formatNumber(value, precision = 2) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return '0.00';
+    }
+    return value.toFixed(precision);
+}
+
+export class PerformanceTelemetryPanel {
+    constructor({ parameterManager = null, container = null, hub = null, config = {} } = {}) {
+        this.parameterManager = parameterManager;
+        this.hub = hub;
+        this.config = {
+            rotationParameters: DEFAULT_ROTATION_PARAMS,
+            dynamicsParameters: DEFAULT_DYNAMICS_PARAMS,
+            historySize: 180,
+            pulseFadeMs: 2600,
+            ...config
+        };
+
+        this.container = container;
+        this.root = null;
+        this.rotationRefs = new Map();
+        this.dynamicsRefs = new Map();
+        this.energyEl = null;
+        this.pulseEl = null;
+        this.historyEl = null;
+        this.activityEl = null;
+        this.currentValues = {};
+        this.history = [];
+        this.subscriptions = [];
+        this.unsubscribeParams = null;
+        this.pulseTimeout = null;
+
+        this.mount();
+        this.bindListeners();
+        this.refreshAll();
+    }
+
+    mount() {
+        if (!this.container || typeof document === 'undefined') {
+            return;
+        }
+        this.container.classList.add('performance-block', 'performance-telemetry');
+        this.container.innerHTML = `
+            <header class="performance-block__header performance-telemetry__header">
+                <div>
+                    <h3 class="performance-block__title">Live Telemetry</h3>
+                    <p class="performance-block__subtitle">Monitor 4D rotation vectors, dynamics, and incoming control pulses.</p>
+                </div>
+                <span class="performance-telemetry__energy-badge" data-role="rotation-energy">0%</span>
+            </header>
+            <div class="performance-telemetry__body">
+                <section class="performance-telemetry__section" data-section="rotation">
+                    <h4>4D Rotation Field</h4>
+                    <div class="performance-telemetry__metrics" data-role="rotation-metrics"></div>
+                </section>
+                <section class="performance-telemetry__section" data-section="dynamics">
+                    <h4>Dynamics &amp; Atmosphere</h4>
+                    <div class="performance-telemetry__metrics" data-role="dynamics-metrics"></div>
+                    <div class="performance-telemetry__activity" data-role="activity">Activity index <strong>0.00</strong></div>
+                </section>
+                <section class="performance-telemetry__section" data-section="inputs">
+                    <h4>Input Pulses</h4>
+                    <div class="performance-telemetry__pulse" data-role="pulse">Awaiting input...</div>
+                    <ul class="performance-telemetry__history" data-role="history"></ul>
+                </section>
+            </div>
+        `;
+        this.root = this.container;
+
+        const rotationContainer = this.root.querySelector('[data-role="rotation-metrics"]');
+        const dynamicsContainer = this.root.querySelector('[data-role="dynamics-metrics"]');
+        this.energyEl = this.root.querySelector('[data-role="rotation-energy"]');
+        this.pulseEl = this.root.querySelector('[data-role="pulse"]');
+        this.historyEl = this.root.querySelector('[data-role="history"]');
+        this.activityEl = this.root.querySelector('[data-role="activity"] strong');
+
+        this.renderMetrics(rotationContainer, this.config.rotationParameters, this.rotationRefs);
+        this.renderMetrics(dynamicsContainer, this.config.dynamicsParameters, this.dynamicsRefs);
+    }
+
+    renderMetrics(container, parameters, refMap) {
+        if (!container) return;
+        container.innerHTML = '';
+        parameters
+            .map(param => (typeof param === 'string' ? param : null))
+            .filter(Boolean)
+            .forEach(param => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'performance-telemetry__metric';
+                wrapper.dataset.parameter = param;
+                wrapper.innerHTML = `
+                    <span class="performance-telemetry__metric-label">${this.getParameterLabel(param)}</span>
+                    <div class="performance-telemetry__metric-bar">
+                        <span class="performance-telemetry__metric-fill" style="width:0%"></span>
+                    </div>
+                    <span class="performance-telemetry__metric-value">0.00</span>
+                `;
+                container.appendChild(wrapper);
+                refMap.set(param, {
+                    bar: wrapper.querySelector('.performance-telemetry__metric-fill'),
+                    value: wrapper.querySelector('.performance-telemetry__metric-value')
+                });
+            });
+    }
+
+    bindListeners() {
+        if (this.parameterManager?.addChangeListener) {
+            this.unsubscribeParams = this.parameterManager.addChangeListener(change => this.handleParameterChange(change));
+        }
+
+        if (this.hub?.on) {
+            this.subscriptions.push(this.hub.on('touchpad:update', payload => this.registerPulse('Touch pad', payload?.padId, payload?.parameter)));
+            this.subscriptions.push(this.hub.on('hardware:midi-value', payload => this.registerPulse('MIDI', payload?.inputId || 'device', payload?.parameter)));
+            this.subscriptions.push(this.hub.on('gestures:playback-event', payload => this.registerPulse('Gesture', payload?.recordingId, payload?.event?.parameter)));
+            this.subscriptions.push(this.hub.on('show:cue-trigger', payload => this.registerPulse('Cue', payload?.cue?.label || 'Unnamed cue', payload?.cue?.presetId)));
+        }
+    }
+
+    refreshAll() {
+        const rotationValues = this.config.rotationParameters.map(param => this.getParameterValue(param));
+        this.config.rotationParameters.forEach((param, index) => {
+            this.updateMetric(param, rotationValues[index], this.rotationRefs);
+        });
+        this.updateRotationEnergy(rotationValues);
+
+        const dynamicsValues = this.config.dynamicsParameters.map(param => this.getParameterValue(param));
+        this.config.dynamicsParameters.forEach((param, index) => {
+            this.updateMetric(param, dynamicsValues[index], this.dynamicsRefs);
+        });
+        this.updateActivityIndex(dynamicsValues);
+    }
+
+    handleParameterChange({ name, value } = {}) {
+        if (!name) return;
+        this.currentValues[name] = value;
+
+        if (this.rotationRefs.has(name)) {
+            this.updateMetric(name, value, this.rotationRefs);
+            const rotationValues = this.config.rotationParameters.map(param => this.currentValues[param] ?? this.getParameterValue(param));
+            this.updateRotationEnergy(rotationValues);
+        }
+
+        if (this.dynamicsRefs.has(name)) {
+            this.updateMetric(name, value, this.dynamicsRefs);
+            const dynamicsValues = this.config.dynamicsParameters.map(param => this.currentValues[param] ?? this.getParameterValue(param));
+            this.updateActivityIndex(dynamicsValues);
+        }
+    }
+
+    updateMetric(parameterId, value, refMap) {
+        const refs = refMap.get(parameterId);
+        if (!refs) return;
+
+        const def = this.parameterManager?.getParameterDefinition?.(parameterId) || null;
+        let normalized = 0;
+        if (def) {
+            const range = def.max - def.min;
+            const safeRange = range === 0 ? 1 : range;
+            normalized = clamp01((value - def.min) / safeRange);
+        }
+        const displayValue = def?.type === 'int' ? formatNumber(value, 0) : formatNumber(value, 2);
+        refs.value.textContent = displayValue;
+        refs.bar.style.width = `${(normalized * 100).toFixed(1)}%`;
+    }
+
+    updateRotationEnergy(values = []) {
+        if (!this.energyEl) return;
+        if (!Array.isArray(values) || values.length === 0) {
+            this.energyEl.textContent = '0%';
+            return;
+        }
+        const normalizedSquares = values.map((value, index) => {
+            const param = this.config.rotationParameters[index];
+            const def = this.parameterManager?.getParameterDefinition?.(param);
+            if (!def) return 0;
+            const range = def.max - def.min || 1;
+            const normalized = clamp01((value - def.min) / range);
+            const centered = normalized * 2 - 1;
+            return centered * centered;
+        });
+        const energy = Math.sqrt(normalizedSquares.reduce((sum, sq) => sum + sq, 0) / normalizedSquares.length);
+        const percentage = clamp01(energy) * 100;
+        this.energyEl.textContent = `${percentage.toFixed(0)}%`;
+        this.pushHistorySample({ rotationEnergy: energy });
+    }
+
+    updateActivityIndex(values = []) {
+        if (!this.activityEl) return;
+        if (!Array.isArray(values) || values.length === 0) {
+            this.activityEl.textContent = '0.00';
+            return;
+        }
+        const normalizedValues = values.map((value, index) => {
+            const param = this.config.dynamicsParameters[index];
+            const def = this.parameterManager?.getParameterDefinition?.(param);
+            if (!def) return 0;
+            const range = def.max - def.min || 1;
+            return clamp01((value - def.min) / range);
+        });
+        const average = normalizedValues.reduce((sum, v) => sum + v, 0) / normalizedValues.length;
+        this.activityEl.textContent = average.toFixed(2);
+        this.pushHistorySample({ activity: average });
+    }
+
+    pushHistorySample(sample = {}) {
+        if (!this.historyEl) return;
+        const timestamp = Date.now();
+        this.history.push({ timestamp, ...sample });
+        while (this.history.length > this.config.historySize) {
+            this.history.shift();
+        }
+
+        const latest = this.history.slice(-5).reverse();
+        this.historyEl.innerHTML = latest.map(entry => {
+            const secondsAgo = Math.max(0, Math.round((timestamp - entry.timestamp) / 1000));
+            const energy = typeof entry.rotationEnergy === 'number' ? `${Math.round(entry.rotationEnergy * 100)}%` : '—';
+            const activity = typeof entry.activity === 'number' ? entry.activity.toFixed(2) : '—';
+            return `<li><span>${secondsAgo}s ago</span><span>energy ${energy}</span><span>activity ${activity}</span></li>`;
+        }).join('');
+    }
+
+    registerPulse(source = 'Input', id = '', parameter = '') {
+        if (!this.pulseEl) return;
+        const descriptor = [source, id].filter(Boolean).join(' · ');
+        const parameterLabel = parameter ? this.getParameterLabel(parameter) : '';
+        const suffix = parameterLabel ? ` → ${parameterLabel}` : '';
+        this.pulseEl.textContent = `${descriptor || source}${suffix}`;
+        this.pulseEl.classList.add('is-active');
+        clearTimeout(this.pulseTimeout);
+        this.pulseTimeout = setTimeout(() => {
+            this.pulseEl?.classList.remove('is-active');
+        }, this.config.pulseFadeMs);
+    }
+
+    getParameterLabel(parameterId) {
+        const def = this.parameterManager?.getParameterDefinition?.(parameterId);
+        if (def?.label) {
+            return def.label;
+        }
+        if (!parameterId) return 'Parameter';
+        return parameterId
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/^./, char => char.toUpperCase())
+            .trim();
+    }
+
+    getParameterValue(parameterId) {
+        if (!parameterId) return 0;
+        if (this.currentValues && Object.prototype.hasOwnProperty.call(this.currentValues, parameterId)) {
+            return this.currentValues[parameterId];
+        }
+        return this.parameterManager?.getParameter?.(parameterId) ?? 0;
+    }
+
+    destroy() {
+        if (this.unsubscribeParams) {
+            this.unsubscribeParams();
+            this.unsubscribeParams = null;
+        }
+        this.subscriptions.forEach(unsub => unsub?.());
+        this.subscriptions = [];
+        if (this.pulseTimeout) {
+            clearTimeout(this.pulseTimeout);
+            this.pulseTimeout = null;
+        }
+        if (this.root) {
+            this.root.innerHTML = '';
+        }
+    }
+}

--- a/src/ui/PerformanceThemePanel.js
+++ b/src/ui/PerformanceThemePanel.js
@@ -1,0 +1,401 @@
+import {
+    mergeThemePalettes,
+    normalizeThemeState,
+    normalizeThemeTransition,
+    resolveThemeDetails,
+    DEFAULT_THEME_TRANSITION,
+    THEME_EASING_PRESETS
+} from './PerformanceThemeUtils.js';
+
+function clone(value) {
+    return value ? JSON.parse(JSON.stringify(value)) : value;
+}
+
+export class PerformanceThemePanel {
+    constructor({ container, config = {}, context = {}, onThemeChange } = {}) {
+        this.container = container;
+        this.config = config;
+        this.context = context;
+        this.onThemeChange = onThemeChange;
+
+        this.palettes = this.composePalettes();
+        this.transitionDefaults = normalizeThemeTransition(
+            config?.transitionDefaults,
+            DEFAULT_THEME_TRANSITION
+        );
+        this.easingOptions = Array.isArray(config?.easingPresets) && config.easingPresets.length
+            ? config.easingPresets.map(option => ({
+                id: option.id || option.value || option.label,
+                label: option.label || option.id || option.value,
+                value: option.value || option.id
+            }))
+            : THEME_EASING_PRESETS;
+        this.state = normalizeThemeState(context.themeState || {}, { transitionDefaults: this.transitionDefaults });
+
+        this.root = null;
+        this.inputs = {};
+
+        this.mount();
+        this.bindEvents();
+        this.render();
+    }
+
+    composePalettes() {
+        const provided = Array.isArray(this.config?.palettes) ? this.config.palettes : [];
+        return mergeThemePalettes(provided);
+    }
+
+    mount() {
+        if (!this.container || typeof document === 'undefined') {
+            return;
+        }
+
+        const template = `
+            <header class="performance-theme__header">
+                <div>
+                    <h3>Color Atmosphere</h3>
+                    <p>Curate the accent glow shared by every module.</p>
+                </div>
+                <button type="button" class="performance-theme__reset" data-role="reset">Reset</button>
+            </header>
+            <div class="performance-theme__body">
+                <label class="performance-theme__field">
+                    <span>Palette</span>
+                    <select data-role="palette"></select>
+                </label>
+                <p class="performance-theme__description" data-role="description"></p>
+                <div class="performance-theme__custom" data-role="custom">
+                    <label class="performance-theme__field performance-theme__field--inline performance-theme__field--color">
+                        <span>Accent Color</span>
+                        <input type="color" data-role="accent" aria-label="Accent color" />
+                    </label>
+                    <label class="performance-theme__field performance-theme__field--inline">
+                        <span>Highlight Bloom</span>
+                        <input type="range" min="0.1" max="0.6" step="0.01" data-role="highlight" />
+                        <span class="performance-theme__value" data-role="highlight-value"></span>
+                    </label>
+                    <label class="performance-theme__field performance-theme__field--inline">
+                        <span>Glow Strength</span>
+                        <input type="range" min="0.2" max="1" step="0.02" data-role="glow" />
+                        <span class="performance-theme__value" data-role="glow-value"></span>
+                    </label>
+                </div>
+                <div class="performance-theme__transitions" data-role="transitions">
+                    <label class="performance-theme__field performance-theme__field--inline">
+                        <span>Transition Time</span>
+                        <input type="range" min="0" max="4000" step="50" data-role="transition-duration" />
+                        <span class="performance-theme__value" data-role="transition-duration-value"></span>
+                    </label>
+                    <label class="performance-theme__field performance-theme__field--inline">
+                        <span>Transition Curve</span>
+                        <select data-role="transition-easing"></select>
+                    </label>
+                </div>
+            </div>
+        `;
+
+        if (this.container.dataset?.role === 'theme') {
+            this.root = this.container;
+            this.root.classList.add('performance-theme', 'performance-suite__stack');
+            this.root.innerHTML = template;
+        } else {
+            this.root = document.createElement('div');
+            this.root.className = 'performance-theme performance-suite__stack';
+            this.root.innerHTML = template;
+            this.container.prepend(this.root);
+        }
+
+        this.inputs.palette = this.root.querySelector('[data-role="palette"]');
+        this.inputs.description = this.root.querySelector('[data-role="description"]');
+        this.inputs.custom = this.root.querySelector('[data-role="custom"]');
+        this.inputs.accent = this.root.querySelector('[data-role="accent"]');
+        this.inputs.highlight = this.root.querySelector('[data-role="highlight"]');
+        this.inputs.highlightValue = this.root.querySelector('[data-role="highlight-value"]');
+        this.inputs.glow = this.root.querySelector('[data-role="glow"]');
+        this.inputs.glowValue = this.root.querySelector('[data-role="glow-value"]');
+        this.inputs.reset = this.root.querySelector('[data-role="reset"]');
+        this.inputs.transitions = this.root.querySelector('[data-role="transitions"]');
+        this.inputs.transitionDuration = this.root.querySelector('[data-role="transition-duration"]');
+        this.inputs.transitionDurationValue = this.root.querySelector('[data-role="transition-duration-value"]');
+        this.inputs.transitionEasing = this.root.querySelector('[data-role="transition-easing"]');
+
+        if (this.inputs.palette) {
+            this.palettes.forEach(palette => {
+                const option = document.createElement('option');
+                option.value = palette.id;
+                option.textContent = palette.label;
+                this.inputs.palette.appendChild(option);
+            });
+        }
+
+        if (this.inputs.transitionEasing) {
+            this.populateTransitionEasingOptions();
+        }
+    }
+
+    bindEvents() {
+        if (!this.root) {
+            return;
+        }
+
+        this.inputs.palette?.addEventListener('change', () => {
+            const paletteId = this.inputs.palette.value;
+            this.applyPalette(paletteId, { notify: true });
+        });
+
+        this.inputs.accent?.addEventListener('input', () => {
+            this.updateOverrides({ accent: this.inputs.accent.value }, { notify: true });
+        });
+
+        this.inputs.highlight?.addEventListener('input', () => {
+            const value = parseFloat(this.inputs.highlight.value);
+            this.updateOverrides({ highlightAlpha: value }, { notify: true });
+        });
+
+        this.inputs.glow?.addEventListener('input', () => {
+            const value = parseFloat(this.inputs.glow.value);
+            this.updateOverrides({ glowStrength: value }, { notify: true });
+        });
+
+        this.inputs.reset?.addEventListener('click', () => {
+            this.resetToSystem();
+        });
+
+        this.inputs.transitionDuration?.addEventListener('input', () => {
+            const value = parseFloat(this.inputs.transitionDuration.value);
+            this.updateTransition({ duration: value }, { notify: true });
+        });
+
+        this.inputs.transitionEasing?.addEventListener('change', () => {
+            const value = this.inputs.transitionEasing.value;
+            this.updateTransition({ easing: value }, { notify: true });
+        });
+    }
+
+    render() {
+        if (!this.root) {
+            return;
+        }
+
+        const palette = this.palettes.find(p => p.id === this.state.paletteId) || this.palettes[0];
+        if (this.inputs.palette) {
+            this.inputs.palette.value = this.state.paletteId;
+        }
+
+        if (this.inputs.description) {
+            const details = resolveThemeDetails(this.state, {
+                palettes: this.palettes,
+                baseTheme: this.context.baseTheme
+            });
+            this.inputs.description.textContent = details.description || palette?.description || '';
+        }
+
+        const showCustom = this.state.paletteId === 'custom';
+        if (this.inputs.custom) {
+            this.inputs.custom.style.display = showCustom ? 'grid' : 'none';
+        }
+
+        const details = resolveThemeDetails(this.state, {
+            palettes: this.palettes,
+            baseTheme: this.context.baseTheme
+        });
+        const accent = details.accent;
+        const highlightAlpha = details.highlightAlpha;
+        const glowStrength = details.glowStrength;
+
+        if (this.inputs.accent) {
+            this.inputs.accent.value = accent;
+        }
+
+        if (this.inputs.highlight) {
+            this.inputs.highlight.value = highlightAlpha.toFixed(2);
+        }
+        if (this.inputs.highlightValue) {
+            this.inputs.highlightValue.textContent = (highlightAlpha * 100).toFixed(0) + '%';
+        }
+
+        if (this.inputs.glow) {
+            this.inputs.glow.value = glowStrength.toFixed(2);
+        }
+        if (this.inputs.glowValue) {
+            this.inputs.glowValue.textContent = glowStrength.toFixed(2);
+        }
+
+        const transition = normalizeThemeTransition(this.state.transition, this.transitionDefaults);
+        if (this.inputs.transitionDuration) {
+            this.inputs.transitionDuration.value = transition.duration.toString();
+        }
+        if (this.inputs.transitionDurationValue) {
+            this.inputs.transitionDurationValue.textContent = this.formatDurationLabel(transition.duration);
+        }
+        if (this.inputs.transitionEasing) {
+            this.ensureTransitionOption(transition.easing);
+            this.inputs.transitionEasing.value = transition.easing;
+        }
+    }
+
+    applyPalette(paletteId, { notify = false } = {}) {
+        const palette = this.palettes.find(p => p.id === paletteId) || this.palettes[0];
+        const nextState = { paletteId: palette.id, overrides: null, transition: this.state.transition };
+
+        if (paletteId === 'custom') {
+            const details = resolveThemeDetails(this.state, {
+                palettes: this.palettes,
+                baseTheme: this.context.baseTheme,
+                transitionDefaults: this.transitionDefaults
+            });
+            nextState.overrides = {
+                accent: details.accent,
+                highlightAlpha: details.highlightAlpha,
+                glowStrength: details.glowStrength
+            };
+        } else if (palette?.accent || typeof palette?.highlightAlpha === 'number' || typeof palette?.glowStrength === 'number') {
+            nextState.overrides = {
+                accent: palette.accent,
+                highlightAlpha: palette.highlightAlpha,
+                glowStrength: palette.glowStrength
+            };
+        }
+
+        this.state = normalizeThemeState(nextState, { transitionDefaults: this.transitionDefaults });
+        this.render();
+        if (notify) {
+            this.emitChange();
+        }
+    }
+
+    updateOverrides(partial = {}, { notify = false } = {}) {
+        const overrides = {
+            ...(this.state.overrides || {})
+        };
+
+        Object.assign(overrides, partial);
+
+        this.state = normalizeThemeState({
+            paletteId: this.state.paletteId,
+            overrides,
+            transition: this.state.transition
+        }, { transitionDefaults: this.transitionDefaults });
+        this.render();
+        if (notify) {
+            this.emitChange();
+        }
+    }
+
+    updateTransition(partial = {}, { notify = false } = {}) {
+        const merged = {
+            ...(this.state.transition || {})
+        };
+        if (Object.prototype.hasOwnProperty.call(partial, 'duration')) {
+            merged.duration = partial.duration;
+        }
+        if (Object.prototype.hasOwnProperty.call(partial, 'easing')) {
+            merged.easing = partial.easing;
+        }
+
+        const transition = normalizeThemeTransition(merged, this.transitionDefaults);
+        this.state = normalizeThemeState({
+            paletteId: this.state.paletteId,
+            overrides: this.state.overrides,
+            transition
+        }, { transitionDefaults: this.transitionDefaults });
+        this.render();
+        if (notify) {
+            this.emitChange();
+        }
+    }
+
+    resetToSystem() {
+        this.state = normalizeThemeState({
+            paletteId: 'system',
+            transition: this.transitionDefaults
+        }, { transitionDefaults: this.transitionDefaults });
+        this.render();
+        this.emitChange();
+    }
+
+    emitChange() {
+        if (typeof this.onThemeChange === 'function') {
+            this.onThemeChange(this.getState());
+        }
+    }
+
+    getState() {
+        return clone(this.state);
+    }
+
+    applyState(state, { notify = false } = {}) {
+        this.state = normalizeThemeState(state || {}, { transitionDefaults: this.transitionDefaults });
+
+        if (this.state.paletteId !== 'custom') {
+            const palette = this.palettes.find(p => p.id === this.state.paletteId);
+            if (!palette) {
+                this.state.paletteId = 'system';
+                this.state.overrides = null;
+            }
+        }
+
+        this.render();
+        if (notify) {
+            this.emitChange();
+        }
+    }
+
+    populateTransitionEasingOptions() {
+        const select = this.inputs.transitionEasing;
+        if (!select) return;
+        select.innerHTML = '';
+        this.easingOptions.forEach(option => {
+            if (!option || !option.value) return;
+            const opt = document.createElement('option');
+            opt.value = option.value;
+            opt.textContent = option.label || option.value;
+            select.appendChild(opt);
+        });
+    }
+
+    ensureTransitionOption(value) {
+        if (!this.inputs.transitionEasing || !value) {
+            return;
+        }
+        const existing = Array.from(this.inputs.transitionEasing.options).some(option => option.value === value);
+        if (!existing) {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = `Custom (${value})`;
+            option.dataset.dynamic = 'true';
+            this.inputs.transitionEasing.appendChild(option);
+        }
+    }
+
+    formatDurationLabel(durationMs) {
+        const value = Number(durationMs);
+        if (!Number.isFinite(value) || value <= 0) {
+            return 'Instant';
+        }
+        if (value < 1000) {
+            return `${Math.round(value)} ms`;
+        }
+        const seconds = value / 1000;
+        return `${seconds % 1 === 0 ? seconds.toFixed(0) : seconds.toFixed(1)} s`;
+    }
+
+    destroy() {
+        ['palette', 'accent', 'highlight', 'glow', 'reset', 'transitionDuration', 'transitionEasing'].forEach(key => {
+            const input = this.inputs[key];
+            if (input && input.parentNode) {
+                input.replaceWith(input.cloneNode(true));
+            }
+        });
+        if (this.root) {
+            if (this.root === this.container) {
+                this.root.innerHTML = '';
+                this.root.classList.remove('performance-theme', 'performance-suite__stack');
+            } else if (this.root.parentNode) {
+                this.root.parentNode.removeChild(this.root);
+            }
+        }
+        this.root = null;
+        this.inputs = {};
+    }
+}

--- a/src/ui/PerformanceThemeUtils.js
+++ b/src/ui/PerformanceThemeUtils.js
@@ -1,0 +1,218 @@
+export const DEFAULT_THEME_TRANSITION = {
+    duration: 1200,
+    easing: 'cubic-bezier(0.45, 0, 0.55, 1)'
+};
+
+export const THEME_EASING_PRESETS = [
+    { id: 'smooth', label: 'Smooth Ease', value: 'cubic-bezier(0.45, 0, 0.55, 1)' },
+    { id: 'ease', label: 'Gentle Ease', value: 'ease' },
+    { id: 'ease-in', label: 'Rise In', value: 'cubic-bezier(0.55, 0.085, 0.68, 0.53)' },
+    { id: 'ease-out', label: 'Glide Out', value: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)' },
+    { id: 'linear', label: 'Linear', value: 'linear' }
+];
+
+export const PERFORMANCE_THEME_PALETTES = [
+    {
+        id: 'system',
+        label: 'System Accent',
+        description: "Follow the current engine's signature colors."
+    },
+    {
+        id: 'aurora',
+        label: 'Aurora Bloom',
+        description: 'Glacial cyan core with wide luminous bloom.',
+        accent: '#6df9ff',
+        highlightAlpha: 0.28,
+        glowStrength: 0.8
+    },
+    {
+        id: 'sunset',
+        label: 'Crimson Sunset',
+        description: 'Fiery magenta gradients with tighter highlight.',
+        accent: '#ff5e9f',
+        highlightAlpha: 0.23,
+        glowStrength: 0.55
+    },
+    {
+        id: 'atmos',
+        label: 'Atmos Drift',
+        description: 'Deep violet core with atmospheric bloom.',
+        accent: '#8f6dff',
+        highlightAlpha: 0.3,
+        glowStrength: 0.72
+    },
+    {
+        id: 'custom',
+        label: 'Custom Blend',
+        description: 'Dial your own accent and bloom intensity.'
+    }
+];
+
+function sanitizeDuration(value, fallback) {
+    const number = typeof value === 'string' ? parseFloat(value) : Number(value);
+    if (!Number.isFinite(number)) {
+        return fallback;
+    }
+    return Math.max(0, Math.min(10000, Math.round(number)));
+}
+
+function normalizeEasing(easing, fallback) {
+    if (typeof easing !== 'string' || !easing.trim()) {
+        return fallback;
+    }
+
+    const trimmed = easing.trim();
+    const preset = THEME_EASING_PRESETS.find(option => option.id === trimmed || option.value === trimmed);
+    return preset ? preset.value : trimmed;
+}
+
+function normalizeTransitionDefaults(defaults = {}) {
+    if (!defaults || typeof defaults !== 'object') {
+        return { ...DEFAULT_THEME_TRANSITION };
+    }
+
+    return {
+        duration: sanitizeDuration(defaults.duration, DEFAULT_THEME_TRANSITION.duration),
+        easing: normalizeEasing(defaults.easing, DEFAULT_THEME_TRANSITION.easing)
+    };
+}
+
+export function normalizeThemeTransition(transition, defaults = DEFAULT_THEME_TRANSITION) {
+    const resolvedDefaults = normalizeTransitionDefaults(defaults);
+
+    if (!transition || typeof transition !== 'object') {
+        return { ...resolvedDefaults };
+    }
+
+    return {
+        duration: sanitizeDuration(transition.duration, resolvedDefaults.duration),
+        easing: normalizeEasing(transition.easing, resolvedDefaults.easing)
+    };
+}
+
+export function mergeThemePalettes(customPalettes = []) {
+    const map = new Map();
+    PERFORMANCE_THEME_PALETTES.forEach(palette => {
+        if (palette?.id) {
+            map.set(palette.id, { ...palette });
+        }
+    });
+
+    customPalettes.forEach(palette => {
+        if (!palette || !palette.id) return;
+        const existing = map.get(palette.id) || {};
+        map.set(palette.id, { ...existing, ...palette });
+    });
+
+    return Array.from(map.values());
+}
+
+export function normalizeThemeState(state = null, { transitionDefaults = DEFAULT_THEME_TRANSITION } = {}) {
+    const normalizedTransitionDefaults = normalizeTransitionDefaults(transitionDefaults);
+    if (!state) {
+        return { paletteId: 'system', overrides: null, transition: { ...normalizedTransitionDefaults } };
+    }
+
+    const paletteId = typeof state.paletteId === 'string' && state.paletteId.trim()
+        ? state.paletteId
+        : 'system';
+
+    let overrides = null;
+    if (state.overrides && typeof state.overrides === 'object') {
+        overrides = {};
+        if (typeof state.overrides.accent === 'string' && state.overrides.accent.trim()) {
+            overrides.accent = state.overrides.accent;
+        }
+        if (typeof state.overrides.highlightAlpha === 'number' && Number.isFinite(state.overrides.highlightAlpha)) {
+            overrides.highlightAlpha = state.overrides.highlightAlpha;
+        }
+        if (typeof state.overrides.glowStrength === 'number' && Number.isFinite(state.overrides.glowStrength)) {
+            overrides.glowStrength = state.overrides.glowStrength;
+        }
+        if (!Object.keys(overrides).length) {
+            overrides = null;
+        }
+    }
+
+    const transition = normalizeThemeTransition(state.transition, normalizedTransitionDefaults);
+
+    return { paletteId, overrides, transition };
+}
+
+export function resolveThemeDetails(
+    themeState,
+    { palettes = PERFORMANCE_THEME_PALETTES, baseTheme = {}, transitionDefaults = DEFAULT_THEME_TRANSITION } = {}
+) {
+    const normalized = normalizeThemeState(themeState, { transitionDefaults });
+    const palette = palettes.find(p => p.id === normalized.paletteId)
+        || palettes.find(p => p.id === 'system')
+        || palettes[0]
+        || { id: 'system', label: 'System Accent' };
+
+    const accent = normalized.overrides?.accent
+        || palette.accent
+        || baseTheme.accent
+        || '#53d7ff';
+
+    const highlightAlpha = typeof normalized.overrides?.highlightAlpha === 'number'
+        ? normalized.overrides.highlightAlpha
+        : typeof palette.highlightAlpha === 'number'
+            ? palette.highlightAlpha
+            : typeof baseTheme.highlightAlpha === 'number'
+                ? baseTheme.highlightAlpha
+                : 0.22;
+
+    const glowStrength = typeof normalized.overrides?.glowStrength === 'number'
+        ? normalized.overrides.glowStrength
+        : typeof palette.glowStrength === 'number'
+            ? palette.glowStrength
+            : typeof baseTheme.glowStrength === 'number'
+                ? baseTheme.glowStrength
+                : 0.65;
+
+    const transition = normalizeThemeTransition(normalized.transition, transitionDefaults);
+
+    return {
+        state: normalized,
+        palette,
+        paletteId: normalized.paletteId,
+        paletteLabel: palette.label || normalized.paletteId,
+        accent,
+        highlightAlpha,
+        glowStrength,
+        description: palette.description || '',
+        transition
+    };
+}
+
+function numbersEqual(a, b, tolerance = 0.0001) {
+    if (typeof a !== 'number' && typeof b !== 'number') return true;
+    if (typeof a !== 'number' || typeof b !== 'number') return false;
+    return Math.abs(a - b) <= tolerance;
+}
+
+export function areThemesEqual(a, b) {
+    const first = normalizeThemeState(a);
+    const second = normalizeThemeState(b);
+
+    if (first.paletteId !== second.paletteId) {
+        return false;
+    }
+
+    const firstOverrides = first.overrides || {};
+    const secondOverrides = second.overrides || {};
+
+    if ((firstOverrides.accent || null) !== (secondOverrides.accent || null)) {
+        return false;
+    }
+
+    if (!numbersEqual(firstOverrides.highlightAlpha, secondOverrides.highlightAlpha)) {
+        return false;
+    }
+
+    if (!numbersEqual(firstOverrides.glowStrength, secondOverrides.glowStrength)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/ui/TouchPadController.js
+++ b/src/ui/TouchPadController.js
@@ -1,0 +1,503 @@
+import { DEFAULT_PERFORMANCE_CONFIG } from './PerformanceConfig.js';
+
+const DEFAULT_PAD_COUNT = 3;
+const AXES = ['x', 'y', 'spread'];
+const POINTER_IDLE_TIMEOUT = 3500;
+
+function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export class TouchPadController {
+    constructor({
+        parameterManager = null,
+        container = null,
+        config = DEFAULT_PERFORMANCE_CONFIG.touchPads,
+        hub = null,
+        onMappingChange = null
+    } = {}) {
+        this.parameterManager = parameterManager;
+        this.hub = hub;
+        this.config = { ...DEFAULT_PERFORMANCE_CONFIG.touchPads, ...(config || {}) };
+        this.onMappingChange = typeof onMappingChange === 'function' ? onMappingChange : () => {};
+        this.parameterOptions = this.getParameterOptions();
+        this.storageKey = this.config.storageKey || 'vib34d-touchpads';
+
+        const storedState = this.loadStoredState();
+        this.padCount = storedState?.padCount || this.config.padCount || DEFAULT_PAD_COUNT;
+        this.mappings = storedState?.mappings || this.createDefaultMappings(this.padCount);
+
+        this.container = container || this.ensureContainer();
+        this.padRefs = [];
+        this.padStates = this.mappings.map(() => this.createPadState());
+        this.animationFrame = null;
+
+        this.render();
+        this.startLoop();
+        this.notifyState();
+    }
+
+    ensureContainer() {
+        const existing = document.getElementById('performance-touchpads');
+        if (existing) {
+            existing.innerHTML = '';
+            return existing;
+        }
+        const section = document.createElement('section');
+        section.id = 'performance-touchpads';
+        return section;
+    }
+
+    getParameterOptions() {
+        if (!this.parameterManager || typeof this.parameterManager.listParameterMetadata !== 'function') {
+            return [];
+        }
+        const tags = this.config.parameterTags;
+        const tagged = Array.isArray(tags) && tags.length
+            ? this.parameterManager.listParameterMetadata({ tags })
+            : [];
+        if (tagged.length) return tagged;
+        return this.parameterManager.listParameterMetadata();
+    }
+
+    loadStoredState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return null;
+        }
+        try {
+            const raw = window.localStorage.getItem(this.storageKey);
+            return raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            console.warn('TouchPadController failed to load state', error);
+            return null;
+        }
+    }
+
+    persistState() {
+        if (typeof window === 'undefined' || !window.localStorage) {
+            return;
+        }
+        try {
+            const payload = JSON.stringify(this.getState());
+            window.localStorage.setItem(this.storageKey, payload);
+        } catch (error) {
+            console.warn('TouchPadController failed to persist state', error);
+        }
+    }
+
+    createDefaultMappings(count) {
+        const templates = Array.isArray(this.config.defaults) ? clone(this.config.defaults) : [];
+        if (!templates.length) {
+            return new Array(count).fill(null).map((_, index) => this.createEmptyMapping(index));
+        }
+        return new Array(count).fill(null).map((_, index) => {
+            return templates[index] ? clone(templates[index]) : this.createEmptyMapping(index);
+        });
+    }
+
+    createEmptyMapping(index) {
+        const id = `pad-${index + 1}`;
+        return {
+            id,
+            label: `Pad ${index + 1}`,
+            axes: {
+                x: { parameter: '', invert: false, smoothing: 0.2 },
+                y: { parameter: '', invert: false, smoothing: 0.2 },
+                spread: { parameter: '', invert: false, smoothing: 0.35 }
+            }
+        };
+    }
+
+    createPadState() {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        return {
+            pointers: new Map(),
+            target: { x: 0.5, y: 0.5, spread: 0 },
+            smoothed: { x: 0.5, y: 0.5, spread: 0 },
+            lastInteraction: now
+        };
+    }
+
+    render() {
+        if (!this.container) return;
+        this.container.classList.add('performance-block');
+        this.container.innerHTML = '';
+
+        const header = document.createElement('header');
+        header.className = 'performance-block__header';
+        header.innerHTML = `
+            <div>
+                <h3 class="performance-block__title">Multi-Touch Pads</h3>
+                <p class="performance-block__subtitle">Assign axes to any parameter and perform gestures with up to three pads at once.</p>
+            </div>
+            <div class="performance-block__actions">
+                <label class="pad-count">
+                    <span>Pads</span>
+                    <input type="number" min="1" max="6" value="${this.padCount}" />
+                </label>
+                <button type="button" class="pad-reset">Reset mappings</button>
+            </div>
+        `;
+        this.container.appendChild(header);
+
+        const countInput = header.querySelector('input[type="number"]');
+        const handleCountChange = (event) => {
+            const next = Math.max(1, Math.min(6, Number(event.target.value) || this.padCount));
+            if (next !== this.padCount) {
+                this.padCount = next;
+                this.syncPadCount();
+                this.render();
+                this.notifyState();
+            } else {
+                event.target.value = this.padCount;
+            }
+        };
+        countInput.addEventListener('change', handleCountChange);
+        countInput.addEventListener('input', handleCountChange);
+
+        header.querySelector('.pad-reset').addEventListener('click', () => {
+            this.mappings = this.createDefaultMappings(this.padCount);
+            this.padStates = this.mappings.map(() => this.createPadState());
+            this.render();
+            this.notifyState();
+        });
+
+        const grid = document.createElement('div');
+        grid.className = 'pad-grid';
+        this.container.appendChild(grid);
+        this.padRefs = [];
+
+        this.mappings.slice(0, this.padCount).forEach((mapping, index) => {
+            const padRef = this.renderPad(mapping, index);
+            this.padRefs.push(padRef);
+            grid.appendChild(padRef.root);
+        });
+    }
+
+    renderPad(mapping, index) {
+        const padState = this.padStates[index] || this.createPadState();
+        this.padStates[index] = padState;
+
+        const root = document.createElement('article');
+        root.className = 'performance-pad';
+
+        const header = document.createElement('header');
+        header.className = 'performance-pad__header';
+        header.innerHTML = `
+            <input class="performance-pad__label" value="${mapping.label || ''}" aria-label="Pad label" />
+            <span class="performance-pad__value" data-role="pad-values">${this.formatPadValues(padState.smoothed)}</span>
+        `;
+        root.appendChild(header);
+
+        const controls = document.createElement('div');
+        controls.className = 'performance-pad__controls';
+
+        AXES.forEach(axis => {
+            controls.appendChild(this.renderAxisControl(mapping, index, axis));
+        });
+
+        root.appendChild(controls);
+
+        const surface = document.createElement('div');
+        surface.className = 'performance-pad__surface';
+        surface.setAttribute('role', 'application');
+        surface.dataset.padIndex = index;
+        surface.innerHTML = `
+            <span class="performance-pad__surface-label">${mapping.label || `Pad ${index + 1}`}</span>
+        `;
+
+        surface.addEventListener('pointerdown', (event) => this.handlePointerDown(index, event));
+        surface.addEventListener('pointermove', (event) => this.handlePointerMove(index, event));
+        surface.addEventListener('pointerup', (event) => this.handlePointerUp(index, event));
+        surface.addEventListener('pointercancel', (event) => this.handlePointerUp(index, event));
+        surface.addEventListener('pointerleave', (event) => this.handlePointerLeave(index, event));
+
+        root.appendChild(surface);
+
+        const labelInput = header.querySelector('.performance-pad__label');
+        labelInput.addEventListener('input', (event) => {
+            mapping.label = event.target.value;
+            surface.querySelector('.performance-pad__surface-label').textContent = event.target.value || `Pad ${index + 1}`;
+            this.notifyState();
+        });
+
+        return {
+            root,
+            header,
+            controls,
+            surface,
+            valueLabel: header.querySelector('[data-role="pad-values"]'),
+            axisControls: this.collectAxisRefs(controls)
+        };
+    }
+
+    collectAxisRefs(controlsRoot) {
+        const refs = {};
+        AXES.forEach(axis => {
+            const scope = controlsRoot.querySelector(`[data-axis="${axis}"]`);
+            refs[axis] = {
+                scope,
+                select: scope?.querySelector('select') || null,
+                invert: scope?.querySelector('input[type="checkbox"]') || null,
+                smoothing: scope?.querySelector('input[type="range"]') || null
+            };
+        });
+        return refs;
+    }
+
+    renderAxisControl(mapping, index, axis) {
+        const axisConfig = mapping.axes?.[axis] || { parameter: '', invert: false, smoothing: 0.2 };
+        const wrapper = document.createElement('div');
+        wrapper.className = 'performance-pad__axis';
+        wrapper.dataset.axis = axis;
+        wrapper.innerHTML = `
+            <label>
+                <span>${axis === 'spread' ? 'Spread / pinch' : axis.toUpperCase()} axis</span>
+                <select aria-label="${axis} axis parameter">
+                    <option value="">Unassigned</option>
+                    ${this.parameterOptions.map(option => `
+                        <option value="${option.id}" ${axisConfig.parameter === option.id ? 'selected' : ''}>${option.label}</option>
+                    `).join('')}
+                </select>
+            </label>
+            <label class="performance-pad__toggle">
+                <input type="checkbox" ${axisConfig.invert ? 'checked' : ''} />
+                <span>Invert</span>
+            </label>
+            <label class="performance-pad__slider">
+                <span>Smoothing</span>
+                <input type="range" min="0" max="0.95" step="0.05" value="${axisConfig.smoothing ?? 0.2}" />
+            </label>
+        `;
+
+        const select = wrapper.querySelector('select');
+        select.addEventListener('change', (event) => {
+            this.updateAxisMapping(index, axis, { parameter: event.target.value });
+        });
+
+        const invert = wrapper.querySelector('input[type="checkbox"]');
+        invert.addEventListener('change', (event) => {
+            this.updateAxisMapping(index, axis, { invert: event.target.checked });
+        });
+
+        const smoothing = wrapper.querySelector('input[type="range"]');
+        smoothing.addEventListener('input', (event) => {
+            this.updateAxisMapping(index, axis, { smoothing: Number(event.target.value) });
+        });
+
+        return wrapper;
+    }
+
+    updateAxisMapping(padIndex, axis, patch) {
+        const mapping = this.mappings[padIndex];
+        if (!mapping.axes[axis]) {
+            mapping.axes[axis] = { parameter: '', invert: false, smoothing: 0.2 };
+        }
+        Object.assign(mapping.axes[axis], patch);
+        this.notifyState();
+    }
+
+    syncPadCount() {
+        if (this.mappings.length < this.padCount) {
+            const additional = this.createDefaultMappings(this.padCount - this.mappings.length);
+            this.mappings = this.mappings.concat(additional);
+        } else if (this.mappings.length > this.padCount) {
+            this.mappings = this.mappings.slice(0, this.padCount);
+        }
+        this.padStates = this.mappings.map(() => this.createPadState());
+    }
+
+    handlePointerDown(index, event) {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        this.storePointer(index, event);
+    }
+
+    handlePointerMove(index, event) {
+        if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+        this.storePointer(index, event);
+    }
+
+    handlePointerLeave(index, event) {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) return;
+        this.removePointer(index, event.pointerId);
+    }
+
+    handlePointerUp(index, event) {
+        this.removePointer(index, event.pointerId);
+    }
+
+    storePointer(index, event) {
+        const padState = this.padStates[index];
+        if (!padState) return;
+        const rect = event.currentTarget.getBoundingClientRect();
+        const x = clamp01((event.clientX - rect.left) / rect.width);
+        const y = clamp01((event.clientY - rect.top) / rect.height);
+        padState.pointers.set(event.pointerId, { x, y });
+        padState.lastInteraction = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        this.updatePadTarget(index);
+    }
+
+    removePointer(index, pointerId) {
+        const padState = this.padStates[index];
+        if (!padState) return;
+        padState.pointers.delete(pointerId);
+        padState.lastInteraction = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        this.updatePadTarget(index);
+    }
+
+    updatePadTarget(index) {
+        const padState = this.padStates[index];
+        if (!padState) return;
+        const pointers = padState.pointers;
+        if (!pointers.size) {
+            padState.target = { ...padState.smoothed };
+            return;
+        }
+        let sumX = 0;
+        let sumY = 0;
+        pointers.forEach(point => {
+            sumX += point.x;
+            sumY += point.y;
+        });
+        const avgX = sumX / pointers.size;
+        const avgY = sumY / pointers.size;
+
+        let spread = 0;
+        if (pointers.size > 1) {
+            let totalDistance = 0;
+            pointers.forEach(point => {
+                const dx = point.x - avgX;
+                const dy = point.y - avgY;
+                totalDistance += Math.sqrt(dx * dx + dy * dy);
+            });
+            const meanDistance = totalDistance / pointers.size;
+            spread = clamp01(meanDistance * Math.sqrt(2));
+        }
+
+        padState.target = { x: avgX, y: avgY, spread };
+    }
+
+    startLoop() {
+        if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+            return;
+        }
+        const loop = () => {
+            this.updatePads();
+            this.animationFrame = window.requestAnimationFrame(loop);
+        };
+        this.animationFrame = window.requestAnimationFrame(loop);
+    }
+
+    updatePads() {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        this.padStates.forEach((padState, index) => {
+            if (!padState) return;
+            const mapping = this.mappings[index];
+            if (!mapping) return;
+
+            AXES.forEach(axis => {
+                const axisConfig = mapping.axes?.[axis];
+                if (!axisConfig || !axisConfig.parameter) return;
+                const target = padState.target?.[axis] ?? 0;
+                const previous = padState.smoothed?.[axis] ?? target;
+                const smoothing = clamp01(axisConfig.smoothing ?? 0);
+                const next = previous + (target - previous) * (1 - smoothing);
+                padState.smoothed[axis] = next;
+
+                const normalized = axisConfig.invert ? 1 - next : next;
+                const clamped = clamp01(normalized);
+                const value = this.normalizedToParameter(axisConfig.parameter, clamped);
+
+                if (value !== null) {
+                    this.parameterManager?.setParameter?.(axisConfig.parameter, value, 'touchpad');
+                    this.hub?.emit?.('touchpad:update', {
+                        padId: mapping.id,
+                        axis,
+                        parameter: axisConfig.parameter,
+                        normalized: clamped,
+                        value
+                    });
+                }
+            });
+
+            if (this.padRefs[index]?.valueLabel) {
+                this.padRefs[index].valueLabel.textContent = this.formatPadValues(padState.smoothed);
+            }
+
+            if (now - padState.lastInteraction > POINTER_IDLE_TIMEOUT && padState.pointers.size === 0) {
+                padState.target = { ...padState.smoothed };
+            }
+        });
+    }
+
+    normalizedToParameter(parameterId, normalizedValue) {
+        if (!this.parameterManager || typeof this.parameterManager.getParameterDefinition !== 'function') {
+            return normalizedValue;
+        }
+        const def = this.parameterManager.getParameterDefinition(parameterId);
+        if (!def) return normalizedValue;
+        const value = def.min + (def.max - def.min) * normalizedValue;
+        if (def.type === 'int') {
+            return Math.round(value);
+        }
+        return value;
+    }
+
+    formatPadValues(values = {}) {
+        const x = (values.x ?? 0).toFixed(2);
+        const y = (values.y ?? 0).toFixed(2);
+        const spread = (values.spread ?? 0).toFixed(2);
+        return `x ${x} / y ${y} / spread ${spread}`;
+    }
+
+    notifyState() {
+        const state = this.getState();
+        this.onMappingChange(state);
+        this.persistState();
+        this.hub?.emit?.('touchpad:mappings', state);
+    }
+
+    getState() {
+        return {
+            padCount: this.padCount,
+            mappings: clone(this.mappings.slice(0, this.padCount))
+        };
+    }
+
+    applyState(state = {}) {
+        if (state.padCount) {
+            this.padCount = Math.max(1, Math.min(6, Number(state.padCount)));
+        }
+        if (Array.isArray(state.mappings)) {
+            this.mappings = clone(state.mappings);
+        }
+        this.syncPadCount();
+        this.render();
+        this.notifyState();
+    }
+
+    applyMappings(mappings = []) {
+        if (!Array.isArray(mappings)) return;
+        this.mappings = clone(mappings);
+        this.syncPadCount();
+        this.render();
+        this.notifyState();
+    }
+
+    destroy() {
+        if (this.animationFrame && typeof window !== 'undefined' && window.cancelAnimationFrame) {
+            window.cancelAnimationFrame(this.animationFrame);
+            this.animationFrame = null;
+        }
+        this.padRefs = [];
+        this.padStates = [];
+        if (this.container) {
+            this.container.innerHTML = '';
+        }
+    }
+}

--- a/styles/performance.css
+++ b/styles/performance.css
@@ -1,0 +1,2366 @@
+:root {
+    --performance-bg: #0c0f1a;
+    --performance-surface: rgba(17, 20, 35, 0.92);
+    --performance-border: rgba(255, 255, 255, 0.08);
+    --performance-text: rgba(255, 255, 255, 0.9);
+    --performance-muted: rgba(255, 255, 255, 0.6);
+    --performance-accent: #53d7ff;
+    --performance-highlight: rgba(83, 215, 255, 0.2);
+    --performance-danger: #ff6767;
+    --performance-glow-strength: 0.65;
+    --performance-theme-transition-ms: 1200;
+    --performance-theme-transition-easing: cubic-bezier(0.45, 0, 0.55, 1);
+    --performance-theme-transition: calc(var(--performance-theme-transition-ms) * 1ms) var(--performance-theme-transition-easing);
+}
+
+.performance-suite {
+    background: linear-gradient(145deg, var(--performance-bg) 0%, rgba(0, 0, 0, 0.65) 100%);
+    color: var(--performance-text);
+    --performance-shell-padding: 24px;
+    --performance-column-gap: 24px;
+    --performance-stack-gap: 24px;
+    --performance-stack-body-gap: 24px;
+    --performance-block-padding: 20px;
+    --performance-block-gap: 16px;
+    --performance-pad-grid-gap: 18px;
+    --performance-pad-min-width: 240px;
+    --performance-pad-surface-height: 180px;
+    --performance-font-scale: 1;
+    padding: var(--performance-shell-padding);
+    border-radius: 18px;
+    position: relative;
+    width: 100%;
+    box-shadow:
+        0 24px 56px rgba(0, 0, 0, 0.35),
+        0 0 calc(120px * var(--performance-glow-strength)) rgba(0, 0, 0, 0.25),
+        0 0 calc(90px * var(--performance-glow-strength)) var(--performance-highlight);
+    font-family: 'Inter', sans-serif;
+    font-size: calc(1rem * var(--performance-font-scale));
+    backdrop-filter: blur(24px);
+    border: 1px solid var(--performance-border);
+    transition:
+        background-color var(--performance-theme-transition),
+        border-color var(--performance-theme-transition),
+        color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.performance-suite--preview-active {
+    max-width: min(100%, var(--performance-suite-preview-width, 100%));
+    margin-left: auto;
+    margin-right: auto;
+    outline: 1px dashed rgba(255, 255, 255, 0.18);
+    outline-offset: 0;
+}
+
+.performance-suite--preview-active::after {
+    content: attr(data-preview-label);
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--performance-muted);
+    background: rgba(10, 18, 32, 0.78);
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.28);
+    pointer-events: none;
+}
+
+.performance-suite__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.performance-suite__header h2 {
+    font-size: 1.6rem;
+    margin: 0 0 4px;
+    color: var(--performance-accent);
+    text-shadow:
+        0 0 14px rgba(0, 0, 0, 0.6),
+        0 0 calc(26px * var(--performance-glow-strength)) var(--performance-highlight);
+    transition: color var(--performance-theme-transition), text-shadow var(--performance-theme-transition);
+}
+
+.performance-suite__header p {
+    margin: 0;
+    color: var(--performance-muted);
+}
+
+.performance-suite__status {
+    background: var(--performance-accent);
+    color: #04121e;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+    transition: background-color var(--performance-theme-transition), color var(--performance-theme-transition), box-shadow var(--performance-theme-transition);
+}
+
+.performance-suite__columns {
+    display: grid;
+    gap: var(--performance-column-gap);
+}
+
+@media (min-width: 1040px) {
+    .performance-suite__columns {
+        grid-template-columns: var(--performance-column-template, 1.1fr 0.9fr 1fr);
+    }
+}
+
+.performance-suite__mobile-tabs {
+    display: none;
+    margin: 0 0 20px;
+    gap: 12px;
+}
+
+.performance-suite__mobile-tabs button {
+    appearance: none;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    border: 1px solid var(--performance-border);
+    border-radius: 999px;
+    color: var(--performance-muted);
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 10px 18px;
+    transition:
+        background-color 180ms ease,
+        color 180ms ease,
+        border-color 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.22);
+}
+
+.performance-suite__mobile-tabs button.is-active {
+    background: var(--performance-accent);
+    border-color: rgba(255, 255, 255, 0.2);
+    color: #04121e;
+    box-shadow:
+        0 18px 32px rgba(0, 0, 0, 0.28),
+        0 0 calc(45px * var(--performance-glow-strength)) var(--performance-highlight);
+    transform: translateY(-1px);
+}
+
+.performance-suite__mobile-tabs button:focus-visible {
+    outline: 2px solid var(--performance-accent);
+    outline-offset: 2px;
+}
+
+.performance-suite__column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--performance-stack-gap);
+}
+
+.performance-suite__stack {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.performance-suite__stack-toggle {
+    appearance: none;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    border: 1px solid var(--performance-border);
+    border-radius: 16px;
+    box-shadow:
+        0 20px 36px rgba(0, 0, 0, 0.24),
+        0 0 calc(45px * var(--performance-glow-strength)) rgba(0, 0, 0, 0.16);
+    color: var(--performance-text);
+    cursor: pointer;
+    display: grid;
+    gap: 6px;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    align-items: center;
+    padding: 16px 20px;
+    position: relative;
+    text-align: left;
+    transition:
+        background-color 200ms ease,
+        border-color 200ms ease,
+        box-shadow 200ms ease,
+        transform 200ms ease,
+        color var(--performance-theme-transition);
+    width: 100%;
+}
+
+.performance-suite__stack-toggle:hover {
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.05));
+    border-color: rgba(255, 255, 255, 0.16);
+    transform: translateY(-1px);
+}
+
+.performance-suite__stack-toggle:focus-visible {
+    outline: 2px solid var(--performance-accent);
+    outline-offset: 2px;
+}
+
+.performance-suite__stack-title {
+    font-size: 1rem;
+    font-weight: 600;
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.performance-suite__stack-meta {
+    color: var(--performance-muted);
+    font-size: 0.85rem;
+    grid-column: 1;
+    grid-row: 2;
+}
+
+.performance-suite__stack-icon {
+    align-items: center;
+    background: var(--performance-highlight);
+    border-radius: 999px;
+    color: #04121e;
+    display: grid;
+    font-size: 1.2rem;
+    font-weight: 700;
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    height: 30px;
+    justify-items: center;
+    width: 30px;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+    transition: transform 200ms ease, background-color var(--performance-theme-transition);
+}
+
+.performance-suite__stack-icon::before {
+    content: '−';
+}
+
+.performance-suite__stack.is-collapsed .performance-suite__stack-icon::before {
+    content: '+';
+}
+
+.performance-suite__stack.is-collapsed .performance-suite__stack-toggle {
+    opacity: 0.82;
+    box-shadow:
+        0 14px 26px rgba(0, 0, 0, 0.2),
+        0 0 calc(28px * var(--performance-glow-strength)) rgba(0, 0, 0, 0.12);
+}
+
+.performance-suite__stack.is-collapsed .performance-suite__stack-icon {
+    transform: rotate(0deg) scale(0.94);
+}
+
+.performance-suite__stack-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--performance-stack-body-gap);
+}
+
+.performance-suite__stack.is-collapsed .performance-suite__stack-body {
+    display: none;
+}
+
+.performance-theme {
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.05) 0%, var(--performance-surface) 80%);
+    border: 1px solid var(--performance-border);
+    border-radius: 18px;
+    padding: 20px;
+    isolation: isolate;
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+        0 16px 36px rgba(0, 0, 0, 0.28),
+        0 0 calc(70px * var(--performance-glow-strength)) var(--performance-highlight);
+    transition:
+        background-color var(--performance-theme-transition),
+        border-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.performance-theme::before {
+    content: '';
+    position: absolute;
+    inset: -30% -20% auto;
+    height: 120px;
+    background: radial-gradient(circle at top, var(--performance-highlight) 0%, transparent 70%);
+    opacity: 0.7;
+    z-index: -1;
+    filter: blur(20px);
+}
+
+.performance-theme__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.performance-theme__header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--performance-accent);
+    text-shadow: 0 0 calc(14px * var(--performance-glow-strength)) var(--performance-highlight);
+}
+
+.performance-theme__header p {
+    margin: 4px 0 0;
+    color: var(--performance-muted);
+    font-size: 0.9rem;
+}
+
+.performance-suite[data-layout-mode='mobile'] .performance-suite__mobile-tabs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.performance-suite[data-layout-mode='mobile'] .performance-suite__columns {
+    display: flex;
+    flex-direction: column;
+}
+
+.performance-suite[data-layout-mode='mobile'] .performance-suite__column {
+    display: none;
+}
+
+.performance-suite[data-layout-mode='mobile'][data-active-panel='pads'] .performance-suite__column[data-panel='pads'],
+.performance-suite[data-layout-mode='mobile'][data-active-panel='audio'] .performance-suite__column[data-panel='audio'],
+.performance-suite[data-layout-mode='mobile'][data-active-panel='presets'] .performance-suite__column[data-panel='presets'] {
+    display: flex;
+}
+
+.performance-suite[data-layout-mode='mobile'] .performance-suite__stack-toggle {
+    padding: 14px 18px;
+}
+
+@media (max-width: 900px) {
+    .performance-suite {
+        padding: 18px;
+        border-radius: 16px;
+    }
+
+    .performance-suite__header {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .performance-suite__status {
+        width: 100%;
+        text-align: center;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 640px) {
+    .performance-suite__mobile-tabs {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .performance-suite__stack-toggle {
+        grid-template-columns: 1fr auto;
+        padding: 14px 16px;
+    }
+
+    .performance-suite__stack-title {
+        font-size: 0.95rem;
+    }
+
+    .performance-suite__stack-meta {
+        font-size: 0.8rem;
+    }
+}
+
+.performance-theme__reset {
+    background: rgba(0, 0, 0, 0.35);
+    color: var(--performance-accent);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.performance-theme__reset:hover {
+    background: rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.35);
+}
+
+.performance-theme__body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.performance-theme__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--performance-muted);
+    font-size: 0.9rem;
+}
+
+.performance-theme__field select,
+.performance-theme__field input[type="color"],
+.performance-theme__field input[type="range"] {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--performance-text);
+    border-radius: 12px;
+    padding: 10px 12px;
+    font-size: 0.95rem;
+    accent-color: var(--performance-accent);
+}
+
+.performance-theme__field input[type="range"] {
+    padding: 0;
+    height: 6px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.1), rgba(0, 0, 0, 0.35));
+}
+
+.performance-theme__field--inline {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+}
+
+.performance-theme__field--inline input[type="color"] {
+    width: 60px;
+    height: 38px;
+    padding: 0;
+    border-radius: 12px;
+    border: none;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.25);
+}
+
+.performance-theme__field--color {
+    grid-template-columns: auto auto;
+}
+
+.performance-theme__field--color input[type="color"] {
+    justify-self: end;
+}
+
+.performance-theme__value {
+    min-width: 52px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--performance-text);
+}
+
+.performance-theme__custom {
+    display: grid;
+    gap: 16px;
+}
+
+.performance-theme__transitions {
+    display: grid;
+    gap: 16px;
+    margin-top: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.performance-theme__description {
+    margin: 0;
+    color: var(--performance-muted);
+    font-size: 0.88rem;
+}
+
+.performance-block {
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.04) 0%, var(--performance-surface) 65%);
+    border: 1px solid var(--performance-border);
+    border-radius: 18px;
+    padding: var(--performance-block-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--performance-block-gap);
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.28);
+    transition:
+        background-color var(--performance-theme-transition),
+        border-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.performance-block__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.performance-block__title {
+    margin: 0 0 4px;
+    font-size: 1.2rem;
+    color: var(--performance-accent);
+}
+
+.performance-block__subtitle {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--performance-muted);
+}
+
+.performance-block__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.performance-block button,
+.performance-block input,
+.performance-block select,
+.performance-block textarea {
+    font: inherit;
+}
+
+.pad-count {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.pad-count input {
+    width: 52px;
+    background: transparent;
+    border: none;
+    color: var(--performance-text);
+    text-align: center;
+}
+
+.pad-reset,
+.performance-block button {
+    background: linear-gradient(135deg, var(--performance-highlight) 0%, rgba(255, 255, 255, 0.05) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: var(--performance-text);
+    border-radius: 999px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+}
+
+.performance-block button:hover {
+    background: var(--performance-accent);
+    color: #04121e;
+}
+
+.performance-block button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.performance-layout__grid {
+    display: grid;
+    gap: 18px;
+}
+
+@media (min-width: 680px) {
+    .performance-layout__grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
+.performance-layout__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.performance-layout__field--preview {
+    grid-column: 1 / -1;
+    padding-top: 6px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.performance-layout__field--columns {
+    grid-column: 1 / -1;
+}
+
+.performance-layout__label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.88rem;
+    color: var(--performance-muted);
+    gap: 12px;
+}
+
+.performance-layout__value {
+    color: var(--performance-text);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.performance-layout__range {
+    width: 100%;
+    accent-color: var(--performance-accent);
+}
+
+.performance-layout__scale {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.72rem;
+    color: var(--performance-muted);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.performance-layout__profile-description {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+    line-height: 1.4;
+}
+
+.performance-layout__hint {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--performance-muted);
+}
+
+.performance-layout__hint--inline {
+    font-size: 0.74rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.performance-layout__columns-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.performance-layout__columns-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.performance-layout__column-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(8, 20, 36, 0.58);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 12px;
+    padding: 10px 14px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.22);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-layout__column-item:hover {
+    border-color: rgba(255, 255, 255, 0.24);
+    box-shadow: 0 12px 22px rgba(0, 0, 0, 0.26);
+}
+
+.performance-layout__column-label {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--performance-text);
+}
+
+.performance-layout__column-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.performance-layout__column-button {
+    appearance: none;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 8px;
+    color: var(--performance-text);
+    width: 34px;
+    height: 30px;
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.performance-layout__column-button:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: var(--performance-accent);
+    color: var(--performance-accent);
+    transform: translateY(-1px);
+}
+
+.performance-layout__column-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.performance-layout__column-button:focus-visible {
+    outline: 2px solid var(--performance-accent);
+    outline-offset: 2px;
+}
+
+.performance-layout__order-summary {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+}
+
+.performance-layout__preview-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.performance-layout__preview {
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    background: rgba(8, 20, 36, 0.58);
+    color: var(--performance-text);
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
+    transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+}
+
+.performance-layout__preview:hover {
+    border-color: var(--performance-accent);
+    color: var(--performance-accent);
+}
+
+.performance-layout__preview.is-active {
+    background: linear-gradient(135deg, var(--performance-accent) 0%, rgba(255, 255, 255, 0.12) 95%);
+    color: #04121e;
+    border-color: transparent;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.3);
+}
+
+.performance-layout__preview:focus-visible {
+    outline: 2px solid var(--performance-accent);
+    outline-offset: 2px;
+}
+
+.performance-layout__preview-note {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--performance-muted);
+}
+
+.performance-layout__field--profiles {
+    grid-column: 1 / -1;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.performance-layout__profiles-select {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: stretch;
+}
+
+.performance-layout__profiles-select select {
+    flex: 1 1 200px;
+    min-width: 160px;
+    background: rgba(8, 20, 36, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: var(--performance-text);
+    border-radius: 12px;
+    padding: 8px 12px;
+    font-size: 0.86rem;
+}
+
+.performance-layout__profiles-select select:disabled {
+    opacity: 0.5;
+}
+
+.performance-layout__profile-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.performance-layout__profile-actions button {
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    background: rgba(8, 20, 36, 0.58);
+    color: var(--performance-text);
+    border-radius: 10px;
+    padding: 6px 14px;
+    font-size: 0.8rem;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-layout__profile-actions button:hover:not(:disabled) {
+    border-color: var(--performance-accent);
+    color: var(--performance-accent);
+}
+
+.performance-layout__profile-actions button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.performance-layout__profile-save {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.performance-layout__profile-save input {
+    flex: 1 1 220px;
+    min-width: 160px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(4, 16, 28, 0.72);
+    color: var(--performance-text);
+    padding: 8px 12px;
+}
+
+.performance-layout__profile-save button {
+    appearance: none;
+    border: none;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--performance-accent) 0%, rgba(255, 255, 255, 0.18) 100%);
+    color: #04121e;
+    padding: 8px 18px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-layout__profile-save button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.performance-layout__profile-description--saved {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--performance-muted);
+    line-height: 1.45;
+}
+
+.performance-layout__empty {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+    font-style: italic;
+}
+
+.performance-layout__reset {
+    background: none;
+    border: 1px dashed rgba(255, 255, 255, 0.22);
+    color: var(--performance-muted);
+    border-radius: 999px;
+    padding: 6px 16px;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+
+.performance-layout__reset:hover {
+    border-color: var(--performance-accent);
+    color: var(--performance-text);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.performance-telemetry__header {
+    align-items: center;
+}
+
+.performance-telemetry__energy-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 64px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--performance-accent) 0%, rgba(255, 255, 255, 0.08) 90%);
+    color: #04121e;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+}
+
+.performance-telemetry__body {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.performance-telemetry__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.performance-telemetry__section h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--performance-text);
+}
+
+.performance-telemetry__metrics {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.performance-telemetry__metric {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+}
+
+.performance-telemetry__metric-label {
+    font-size: 0.9rem;
+    color: var(--performance-muted);
+}
+
+.performance-telemetry__metric-bar {
+    position: relative;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.performance-telemetry__metric-fill {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--performance-accent), rgba(255, 255, 255, 0.65));
+    border-radius: inherit;
+    transition: width 0.18s ease-out;
+    box-shadow: 0 0 14px rgba(83, 215, 255, 0.45);
+}
+
+.performance-telemetry__metric-value {
+    font-variant-numeric: tabular-nums;
+    color: var(--performance-text);
+    font-size: 0.9rem;
+}
+
+.performance-telemetry__activity {
+    font-size: 0.9rem;
+    color: var(--performance-muted);
+}
+
+.performance-telemetry__activity strong {
+    color: var(--performance-text);
+    margin-left: 6px;
+}
+
+.performance-telemetry__pulse {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 14px;
+    padding: 10px 14px;
+    font-size: 0.92rem;
+    color: var(--performance-muted);
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-telemetry__pulse.is-active {
+    background: rgba(83, 215, 255, 0.15);
+    color: var(--performance-text);
+    box-shadow: 0 0 24px rgba(83, 215, 255, 0.4);
+}
+
+.performance-telemetry__history {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.performance-telemetry__history li {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--performance-muted);
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.performance-telemetry__history li span:last-child {
+    color: var(--performance-text);
+}
+
+@media (max-width: 720px) {
+    .performance-telemetry__history li {
+        grid-template-columns: 1fr;
+    }
+}
+
+.pad-grid {
+    display: grid;
+    gap: var(--performance-pad-grid-gap);
+}
+
+@media (min-width: 840px) {
+    .pad-grid {
+        grid-template-columns: repeat(auto-fit, minmax(var(--performance-pad-min-width), 1fr));
+    }
+}
+
+.performance-pad {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    border: 1px solid var(--performance-border);
+    border-radius: 16px;
+    padding: 16px;
+    background: rgba(12, 16, 28, 0.65);
+}
+
+.performance-pad__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.performance-pad__label {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--performance-border);
+    color: var(--performance-text);
+    padding: 6px 10px;
+    border-radius: 999px;
+}
+
+.performance-pad__value {
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+}
+
+.performance-pad__controls {
+    display: grid;
+    gap: 12px;
+}
+
+.performance-pad__axis {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) auto minmax(0, 1fr);
+    gap: 10px;
+    align-items: center;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 12px;
+}
+
+.performance-pad__axis label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.performance-pad__axis select,
+.performance-pad__axis input[type="range"] {
+    width: 100%;
+}
+
+.performance-pad__toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.performance-pad__toggle input {
+    accent-color: var(--performance-accent);
+}
+
+.performance-pad__slider span {
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.performance-pad__surface {
+    position: relative;
+    border-radius: 14px;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    background: radial-gradient(circle at center, rgba(83, 215, 255, 0.16), rgba(83, 215, 255, 0.02));
+    min-height: var(--performance-pad-surface-height);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+}
+
+.performance-pad__surface::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, transparent 0%, rgba(83, 215, 255, 0.1) 100%);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.performance-pad__surface:active::after,
+.performance-pad__surface:focus-within::after {
+    opacity: 1;
+}
+
+.performance-pad__surface-label {
+    font-size: 0.95rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--performance-muted);
+}
+
+.toggle-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.toggle-pill input {
+    accent-color: var(--performance-accent);
+}
+
+.slider-control {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.slider-control input[type="range"] {
+    accent-color: var(--performance-accent);
+}
+
+.audio-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.audio-panel__fieldset {
+    border: 1px solid var(--performance-border);
+    border-radius: 14px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.audio-panel__fieldset legend {
+    padding: 0 6px;
+    font-size: 0.9rem;
+    color: var(--performance-muted);
+}
+
+.audio-panel__band-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1.1fr);
+    align-items: center;
+    gap: 12px;
+}
+
+.audio-panel__band-label span {
+    font-weight: 600;
+    color: var(--performance-text);
+}
+
+.audio-panel__flourish-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.audio-panel__flourish-actions button {
+    background: var(--performance-accent);
+    color: #011627;
+    border: none;
+    padding: 8px 18px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.performance-hardware {
+    gap: 18px;
+}
+
+.hardware-bridge__status {
+    align-self: flex-start;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    color: var(--performance-muted);
+}
+
+.hardware-bridge__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.hardware-bridge__controls button {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    color: var(--performance-text);
+    padding: 6px 14px;
+    border-radius: 10px;
+}
+
+.hardware-bridge__controls button:hover:not(:disabled) {
+    background: var(--performance-accent);
+    color: #04121e;
+}
+
+.hardware-bridge__inputs {
+    min-width: 180px;
+    padding: 6px 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--performance-text);
+}
+
+.hardware-bridge__warning {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--performance-muted);
+    background: rgba(255, 86, 86, 0.12);
+    border: 1px solid rgba(255, 86, 86, 0.3);
+    padding: 12px 14px;
+    border-radius: 12px;
+}
+
+.hardware-bridge__mappings {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.hardware-bridge__mappings-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.hardware-bridge__mappings-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--performance-muted);
+}
+
+.hardware-bridge__list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.hardware-bridge__mapping {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(120px, 0.8fr) minmax(80px, 0.5fr) auto;
+    gap: 12px;
+    align-items: center;
+    padding: 12px 16px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.hardware-bridge__mapping--armed {
+    border-color: var(--performance-accent);
+    background: rgba(83, 215, 255, 0.08);
+    box-shadow: 0 0 0 1px rgba(83, 215, 255, 0.3);
+}
+
+.hardware-bridge__mapping-target label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.hardware-bridge__mapping-target select {
+    padding: 6px 10px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    color: var(--performance-text);
+}
+
+.hardware-bridge__mapping-binding {
+    font-size: 0.9rem;
+    color: var(--performance-text);
+    opacity: 0.85;
+}
+
+.hardware-bridge__mapping-value {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+    text-align: right;
+}
+
+.hardware-bridge__mapping-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.hardware-bridge__mapping-actions button {
+    padding: 6px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.hardware-bridge__mapping-actions button[data-action="learn"] {
+    background: rgba(83, 215, 255, 0.18);
+    border-color: rgba(83, 215, 255, 0.35);
+    color: var(--performance-text);
+}
+
+.hardware-bridge__empty {
+    padding: 18px;
+    border-radius: 14px;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    color: var(--performance-muted);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.hardware-bridge__hint {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--performance-muted);
+}
+
+.performance-osc {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.osc-bridge__status {
+    align-self: flex-start;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    padding: 6px 16px;
+    font-size: 0.85rem;
+    letter-spacing: 0.03em;
+    color: var(--performance-muted);
+    text-transform: uppercase;
+}
+
+.osc-bridge__controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    align-items: center;
+}
+
+.osc-bridge__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.82rem;
+    color: var(--performance-muted);
+}
+
+.osc-bridge__field input {
+    padding: 8px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--performance-text);
+}
+
+.osc-bridge__toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.osc-bridge__toggle input {
+    transform: scale(1.05);
+    accent-color: var(--performance-accent);
+}
+
+.osc-bridge__connect.is-active {
+    background: var(--performance-accent);
+    color: #04121e;
+}
+
+.osc-bridge__forward {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.osc-bridge__forward h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--performance-text);
+}
+
+.osc-bridge__forward-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
+}
+
+.osc-bridge__forward-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.osc-bridge__forward-item input {
+    accent-color: var(--performance-accent);
+}
+
+.osc-bridge__log {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.osc-bridge__log h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--performance-text);
+}
+
+.osc-bridge__log ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.osc-bridge__log-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 14px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 0.82rem;
+}
+
+.osc-bridge__log-item.is-outgoing {
+    border-color: rgba(109, 249, 255, 0.4);
+    box-shadow: 0 0 18px rgba(109, 249, 255, 0.2);
+}
+
+.osc-bridge__log-item.is-pending {
+    border-style: dashed;
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.osc-bridge__log-item.is-error {
+    border-color: rgba(255, 92, 92, 0.6);
+    box-shadow: 0 0 18px rgba(255, 92, 92, 0.25);
+}
+
+.osc-bridge__log-time {
+    min-width: 78px;
+    font-variant-numeric: tabular-nums;
+    color: var(--performance-muted);
+}
+
+.osc-bridge__log-event {
+    flex: 1;
+    color: var(--performance-text);
+}
+
+.osc-bridge__log-category {
+    color: var(--performance-accent);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+}
+
+.osc-bridge__log-empty {
+    font-size: 0.82rem;
+    color: var(--performance-muted);
+    padding: 4px 0;
+}
+
+.gesture-recorder {
+    position: relative;
+}
+
+.gesture-recorder--recording {
+    box-shadow: 0 0 24px rgba(255, 94, 159, 0.4);
+    border-color: rgba(255, 94, 159, 0.55);
+}
+
+.gesture-recorder--playing {
+    box-shadow: 0 0 22px rgba(109, 249, 255, 0.35);
+}
+
+.gesture-recorder__header {
+    align-items: center;
+}
+
+.gesture-recorder__status {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 6px 18px;
+    color: var(--performance-accent);
+    font-weight: 600;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.gesture-recorder__tempo {
+    display: inline-block;
+    margin-left: 8px;
+    color: var(--performance-accent);
+    font-weight: 500;
+}
+
+.gesture-recorder__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.gesture-recorder__controls button[data-action="record"] {
+    background: linear-gradient(135deg, rgba(255, 94, 159, 0.8) 0%, rgba(255, 94, 159, 0.25) 100%);
+    color: #140612;
+    font-weight: 600;
+}
+
+.gesture-recorder__controls button[data-action="record"]:hover {
+    background: rgba(255, 94, 159, 0.95);
+}
+
+.gesture-recorder__controls button[data-action="play"] {
+    background: linear-gradient(135deg, rgba(109, 249, 255, 0.8) 0%, rgba(109, 249, 255, 0.25) 100%);
+    color: #041c20;
+    font-weight: 600;
+}
+
+.gesture-recorder__controls button[data-action="play"]:hover {
+    background: rgba(109, 249, 255, 0.95);
+}
+
+.gesture-recorder__library-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.gesture-recorder__export {
+    padding: 6px 14px;
+    border-radius: 999px;
+}
+
+.gesture-recorder__import {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.gesture-recorder__import:hover {
+    background: rgba(255, 255, 255, 0.16);
+}
+
+.gesture-recorder__import input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.gesture-recorder__takes {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.gesture-recorder__takes-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    color: var(--performance-muted);
+}
+
+.gesture-recorder__takes-header h4 {
+    margin: 0;
+    color: var(--performance-text);
+}
+
+.gesture-recorder__hint {
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+}
+
+.gesture-recorder__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.gesture-recorder__take {
+    display: flex;
+    gap: 12px;
+    align-items: stretch;
+    border: 1px solid var(--performance-border);
+    border-radius: 14px;
+    background: rgba(4, 10, 18, 0.55);
+    padding: 12px 14px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gesture-recorder__take--selected {
+    border-color: var(--performance-accent);
+    box-shadow: 0 0 18px rgba(0, 0, 0, 0.28);
+}
+
+.gesture-recorder__take-select {
+    flex: 1;
+    text-align: left;
+    background: none;
+    border: none;
+    color: var(--performance-text);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.gesture-recorder__take-name {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.gesture-recorder__take-meta {
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.gesture-recorder__take-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.gesture-recorder__take-actions button {
+    padding: 6px 10px;
+    border-radius: 10px;
+}
+
+.gesture-recorder__empty {
+    text-align: center;
+    padding: 28px;
+    border: 1px dashed rgba(255, 255, 255, 0.16);
+    border-radius: 14px;
+    color: var(--performance-muted);
+}
+
+.audio-select span {
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.audio-select select {
+    width: 100%;
+}
+
+.preset-save {
+    display: grid;
+    gap: 12px;
+}
+
+.preset-save label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.preset-save input,
+.preset-save textarea {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--performance-border);
+    border-radius: 12px;
+    padding: 8px 12px;
+    color: var(--performance-text);
+}
+
+.preset-save button {
+    justify-self: end;
+    background: var(--performance-accent);
+    color: #011627;
+    border: none;
+    padding: 10px 22px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.preset-lists {
+    display: grid;
+    gap: 18px;
+}
+
+@media (min-width: 840px) {
+    .preset-lists {
+        grid-template-columns: 1fr;
+    }
+}
+
+.preset-list,
+.preset-playlist {
+    border: 1px solid var(--performance-border);
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    background: rgba(12, 16, 28, 0.65);
+}
+
+.preset-list__header,
+.preset-playlist__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.preset-list__actions,
+.preset-playlist__actions {
+    display: flex;
+    gap: 12px;
+}
+
+.preset-list__items,
+.preset-playlist__items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.preset-list__item,
+.preset-playlist__item {
+    --preset-theme-accent: var(--performance-accent);
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+    padding: 12px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--performance-border);
+}
+
+.preset-list__meta,
+.preset-playlist__meta {
+    margin-top: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.preset-list__details,
+.preset-playlist__item > div:first-child {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.preset-list__theme,
+.preset-playlist__theme {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    font-size: 0.72rem;
+    border-radius: 999px;
+    border: 1px solid var(--preset-theme-accent, var(--performance-accent));
+    color: var(--preset-theme-accent, var(--performance-accent));
+    background: rgba(255, 255, 255, 0.05);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.preset-list__theme::before,
+.preset-playlist__theme::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--preset-theme-accent, var(--performance-accent));
+    box-shadow: 0 0 10px -2px var(--preset-theme-accent, rgba(83, 215, 255, 0.5));
+}
+
+.preset-list__item--active-theme,
+.preset-playlist__item--active-theme {
+    border-color: var(--preset-theme-accent, var(--performance-accent));
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 0 26px -10px var(--preset-theme-accent, rgba(83, 215, 255, 0.35));
+}
+
+.preset-list__theme--active,
+.preset-playlist__theme--active {
+    background: var(--preset-theme-accent, var(--performance-accent));
+    color: #04121f;
+    box-shadow: 0 0 18px -8px var(--preset-theme-accent, rgba(83, 215, 255, 0.4));
+}
+
+.preset-list__item p,
+.preset-playlist__item p {
+    margin: 4px 0 0;
+    color: var(--performance-muted);
+    font-size: 0.85rem;
+}
+
+.preset-list__buttons,
+.preset-playlist__buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.preset-list__buttons button,
+.preset-playlist__buttons button,
+.preset-playlist__actions button,
+.preset-list__actions button {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--performance-border);
+    color: var(--performance-text);
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.preset-playlist__empty,
+.preset-list__empty {
+    padding: 18px;
+    text-align: center;
+    color: var(--performance-muted);
+    border: 1px dashed var(--performance-border);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.preset-import {
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--performance-border);
+    border-radius: 999px;
+    padding: 6px 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.preset-import input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+button[data-action="delete"] {
+    color: var(--performance-danger);
+}
+
+button[data-action="delete"]:hover {
+    background: rgba(255, 103, 103, 0.15);
+}
+
+.show-planner__status {
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--performance-border);
+    transition: background-color var(--performance-theme-transition), color var(--performance-theme-transition), border-color var(--performance-theme-transition);
+}
+
+.show-planner__status[data-state="running"] {
+    background: rgba(83, 215, 255, 0.16);
+    color: var(--performance-accent);
+}
+
+.show-planner__run {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+@media (min-width: 820px) {
+    .show-planner__run {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: flex-end;
+    }
+}
+
+.show-planner__controls {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.show-planner__tempo {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.show-planner__tempo label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__tempo input {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--performance-border);
+    border-radius: 10px;
+    padding: 6px 10px;
+    color: var(--performance-text);
+    width: 80px;
+}
+
+.show-planner__toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__toggle input {
+    accent-color: var(--performance-accent);
+}
+
+.show-planner__form {
+    display: grid;
+    gap: 12px;
+    align-items: flex-end;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.show-planner__form label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__theme-controls {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    padding: 6px 0;
+}
+
+.show-planner__theme-controls label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.82rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__theme-controls input,
+.show-planner__theme-controls select {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 10px;
+    color: var(--performance-text);
+    padding: 6px 10px;
+}
+
+.show-planner__theme-controls--disabled {
+    opacity: 0.6;
+}
+
+.show-planner__theme-controls--disabled input,
+.show-planner__theme-controls--disabled select {
+    cursor: not-allowed;
+    background: rgba(255, 255, 255, 0.03);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.show-planner__form input,
+.show-planner__form select,
+.show-planner__form textarea {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--performance-border);
+    border-radius: 12px;
+    color: var(--performance-text);
+    padding: 8px 10px;
+}
+
+.show-planner__timeline {
+    margin: 18px 0 12px;
+    padding: 18px 16px;
+    border-radius: 18px;
+    border: 1px solid var(--performance-border);
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.03) 0%, rgba(12, 14, 29, 0.68) 100%);
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    transition:
+        background-color var(--performance-theme-transition),
+        border-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.show-planner__timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.show-planner__timeline-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--timeline-accent, var(--performance-accent));
+    text-shadow: 0 0 calc(22px * var(--performance-glow-strength)) var(--performance-highlight);
+}
+
+.show-planner__timeline-summary {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.show-planner__timeline-summary span {
+    font-size: 0.78rem;
+    color: var(--performance-muted);
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.show-planner__timeline-cues {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.show-planner__timeline-empty {
+    text-align: center;
+    padding: 18px;
+    border-radius: 14px;
+    border: 1px dashed var(--performance-border);
+    color: var(--performance-muted);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.show-planner__timeline-cue {
+    --timeline-color: var(--timeline-preset-accent, var(--timeline-accent, var(--performance-accent)));
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    padding: 14px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.26);
+    transition:
+        border-color var(--performance-theme-transition),
+        background-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.show-planner__timeline-cue--active {
+    border-color: var(--timeline-color);
+    box-shadow: 0 0 24px -8px var(--timeline-color);
+}
+
+.show-planner__timeline-bar {
+    position: relative;
+    flex: 0 0 110px;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    overflow: hidden;
+}
+
+.show-planner__timeline-progress {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.25) 0%, var(--timeline-color) 100%);
+    box-shadow: 0 0 18px rgba(83, 215, 255, 0.35);
+    transition:
+        width 320ms ease,
+        background-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.show-planner__timeline-details {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+}
+
+.show-planner__timeline-title {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: baseline;
+}
+
+.show-planner__timeline-title strong {
+    font-size: 0.95rem;
+    color: var(--performance-text);
+}
+
+.show-planner__timeline-title span {
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__timeline-details footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.75rem;
+    color: var(--performance-muted);
+}
+
+@media (max-width: 720px) {
+    .show-planner__timeline {
+        padding: 16px 14px;
+    }
+
+    .show-planner__timeline-bar {
+        flex-basis: 80px;
+    }
+}
+
+.show-planner__notes {
+    grid-column: span 2;
+}
+
+@media (max-width: 720px) {
+    .show-planner__notes {
+        grid-column: span 1;
+    }
+}
+
+.show-planner__cues {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.show-planner__empty {
+    text-align: center;
+    padding: 24px;
+    border: 1px dashed var(--performance-border);
+    border-radius: 16px;
+    color: var(--performance-muted);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.show-planner__cue {
+    --cue-theme-accent: var(--performance-accent);
+    --active-theme-accent: var(--performance-accent);
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px;
+    border-radius: 16px;
+    border: 1px solid var(--performance-border);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+    transition:
+        background-color var(--performance-theme-transition),
+        border-color var(--performance-theme-transition),
+        box-shadow var(--performance-theme-transition);
+}
+
+.show-planner__cue--active {
+    border-color: var(--active-theme-accent, var(--performance-accent));
+    box-shadow: 0 0 26px -12px var(--active-theme-accent, rgba(83, 215, 255, 0.35));
+}
+
+.show-planner__cue--theme-match:not(.show-planner__cue--active) {
+    border-color: var(--cue-theme-accent, var(--performance-accent));
+    box-shadow: 0 0 20px -10px var(--cue-theme-accent, rgba(83, 215, 255, 0.25));
+}
+
+.show-planner__cue-details {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+}
+
+.show-planner__cue-title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.show-planner__cue-theme {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    font-size: 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--cue-theme-accent, var(--performance-accent));
+    color: var(--cue-theme-accent, var(--performance-accent));
+    background: rgba(255, 255, 255, 0.05);
+    letter-spacing: 0.04em;
+}
+
+.show-planner__cue-theme::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--cue-theme-accent, var(--performance-accent));
+    box-shadow: 0 0 8px -2px var(--cue-theme-accent, rgba(83, 215, 255, 0.4));
+}
+
+.show-planner__cue-theme--active {
+    background: var(--cue-theme-accent, var(--performance-accent));
+    color: #04121f;
+    box-shadow: 0 0 18px -8px var(--cue-theme-accent, rgba(83, 215, 255, 0.4));
+}
+
+.show-planner__cue-theme--hold {
+    opacity: 0.85;
+    border-style: dashed;
+    color: var(--performance-muted);
+    border-color: rgba(255, 255, 255, 0.18);
+}
+
+.show-planner__cue-title span {
+    font-size: 0.8rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__cue-details p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--performance-muted);
+}
+
+.show-planner__cue-details footer {
+    display: flex;
+    gap: 12px;
+    font-size: 0.75rem;
+    color: var(--performance-muted);
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.show-planner__cue-details footer span {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--performance-text);
+    padding: 4px 10px;
+    border-radius: 999px;
+}
+
+.show-planner__cue-actions {
+    display: grid;
+    gap: 8px;
+    align-content: flex-start;
+}
+
+.show-planner__cue-actions button {
+    min-width: 84px;
+}


### PR DESCRIPTION
## Summary
- add column order management to the layout panel with reorder controls, live summaries, and profile integration
- persist and apply the chosen column sequence through the suite via config defaults, responsive layout wiring, and mobile tab ordering
- document the new workflow and QA expectations while styling the column order controls to match the performance theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc05caa6508329ab27b723e3f7b18c