### PR TITLE
Harden adaptive SDK for headless environments

### DIFF
--- a/DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md
+++ b/DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,68 @@
+# Adaptive Engine Architecture Review
+
+## Purpose
+This document captures a ground-truth assessment of the adaptive VIB34D code introduced in the previous refactor. It records what currently exists, how it is wired together, and whether the implementation is suitable as a commercial core for extensible wearable/ambient UI design.
+
+## 1. Current System Inventory
+### 1.1 Core Runtime Layer
+- `src/core/AdaptiveInterfaceEngine.js` extends the historical `VIB34DIntegratedEngine` and owns the adaptive pipeline (sensory bridge → layout synthesizer → parameter writes).【F:src/core/AdaptiveInterfaceEngine.js†L1-L95】
+- The base holographic subsystems (FACETED/QUANTUM/HOLOGRAPHIC/POLYCHORA) remain intact under `src/` and are still parameter-driven via the shared `parameterManager` foundation documented in `SYSTEM_STATUS.md`.【F:SYSTEM_STATUS.md†L59-L129】
+- `src/core/Engine.js` now normalizes environment options so headless/test consumers can disable canvas visualizers, DOM-bound controls, gallery/export wiring, and status messaging while the adaptive SDK surfaces a matching `environment` configuration hook.【F:src/core/Engine.js†L1-L212】【F:src/core/AdaptiveSDK.js†L1-L142】
+
+### 1.2 Adaptive Input & Layout Layer
+- `src/ui/adaptive/SensoryInputBridge.js` normalizes intent, biometric, ambient, and gesture events with configurable decay and subscription hooks.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】
+- `src/ui/adaptive/SpatialLayoutSynthesizer.js` converts the sensory snapshot into multi-zone layout descriptors, typography guidance, and motion cues.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L124】
+- `src/ui/adaptive/InterfacePatternRegistry.js` catalogs monetizable UI patterns and exposes filtering/export APIs.【F:src/ui/adaptive/InterfacePatternRegistry.js†L1-L87】
+
+### 1.3 Commercialization Layer
+- `src/features/DesignLanguageManager.js` maps variation names to registry patterns, generates monetization/integration descriptors, and controls the active "design language" mode.【F:src/features/DesignLanguageManager.js†L1-L80】
+- `src/product/ProductTelemetryHarness.js` classifies events, enforces consent gates, records audit logs, forwards audit entries to providers, buffers telemetry for dispatch, and now orchestrates remote license attestation through a reusable profile registry and pack importer.【F:src/product/ProductTelemetryHarness.js†L1-L487】
+- `src/product/telemetry/ComplianceVaultTelemetryProvider.js` persists compliance-classified records via pluggable storage adapters to support export/review workflows.【F:src/product/telemetry/ComplianceVaultTelemetryProvider.js†L1-L111】
+- `src/product/licensing/LicenseManager.js` centralizes license validation, validator orchestration, feature gating, and history tracking while feeding license state into the telemetry harness.【F:src/product/licensing/LicenseManager.js†L1-L237】
+- `src/product/licensing/RemoteLicenseAttestor.js` performs remote attestation, revocation checks, entitlement synchronization, and scheduling hooks that integrate with the telemetry harness and SDK surface.【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】
+- `src/product/licensing/LicenseAttestationProfileRegistry.js` centralizes partner endpoint profiles, SLA metadata, and attestor overrides so commercialization teams can ship curated configurations per market segment.【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】
+- `src/product/licensing/LicenseAttestationProfileCatalog.js` packages enterprise, studio, and indie attestation profiles with SLA defaults and metadata so partner teams can register curated packs in one call.【F:src/product/licensing/LicenseAttestationProfileCatalog.js†L1-L302】
+- `src/product/licensing/LicenseCommercializationReporter.js` aggregates pack/profile registrations, adoption activity, and SLA benchmarks so commercialization dashboards can consume telemetry-driven coverage summaries without duplicating logic.【F:src/product/licensing/LicenseCommercializationReporter.js†L1-L290】
+- `src/product/licensing/LicenseCommercializationSnapshotStore.js` captures commercialization KPI snapshots, enforces retention, exposes `whenReady()` for async hydration, and exports JSON/CSV payloads for BI workflows while the telemetry harness schedules captures by default.【F:src/product/licensing/LicenseCommercializationSnapshotStore.js†L1-L238】【F:src/product/ProductTelemetryHarness.js†L35-L168】
+- `src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js` provides commercialization snapshot storage builders (generic + signed S3/log broker) with context redaction, payload serialization, and async error handling so remote vault uploads stay aligned with privacy controls.【F:src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js†L1-L142】
+
+### 1.4 Experience Layer
+- `wearable-designer.html` (now ~280 lines) acts as the showcase shell that instantiates `AdaptiveInterfaceEngine`, renders marketing UI, and exposes monetization toggles alongside a live adaptive blueprint panel with export controls.【F:wearable-designer.html†L1-L120】【F:wearable-designer.html†L520-L620】【F:wearable-designer.html†L828-L940】 The file is still large, tightly coupled, and currently lacks modular structure for reuse.
+- `src/ui/adaptive/renderers/LayoutBlueprintRenderer.js` renders the layout synthesis output across layered canvases, highlights focus vectors, and surfaces monetization-aware component recommendations for wearables while providing a reusable export helper.【F:src/ui/adaptive/renderers/LayoutBlueprintRenderer.js†L1-L314】
+- `src/ui/adaptive/renderers/ProjectionFieldComposer.js` translates layout blueprints into 4D projection-field data (halo radius, depth bands, gesture contours, activation matrices) and renders the layered visualization for demo canvases or partner plug-ins.【F:src/ui/adaptive/renderers/ProjectionFieldComposer.js†L1-L273】
+- `src/ui/adaptive/simulators/ProjectionScenarioSimulator.js` orchestrates reusable projection scenarios, applies modulation curves, and emits simulation frames so the experience shell can showcase non-realtime gesture/attention handoffs.【F:src/ui/adaptive/simulators/ProjectionScenarioSimulator.js†L1-L178】
+
+## 2. Architectural Strengths
+1. **Separation of concerns** – Sensory normalization, layout synthesis, design language mapping, and telemetry are isolated classes with single responsibilities.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L124】
+2. **Non-breaking integration** – `AdaptiveInterfaceEngine` still relies on the historical parameter manager so legacy visualizers continue to function.【F:src/core/AdaptiveInterfaceEngine.js†L40-L71】
+3. **Commercial hooks present** – Design-language metadata, license-aware telemetry, attestation profile registries, curated attestation packs, and SDK surface updates—including remote attestation helpers—outline viable monetization paths, fulfilling the productization brief.【F:src/features/DesignLanguageManager.js†L36-L67】【F:src/product/ProductTelemetryHarness.js†L1-L487】【F:src/product/licensing/LicenseManager.js†L1-L237】【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】【F:src/product/licensing/LicenseAttestationProfileCatalog.js†L1-L302】【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】【F:src/core/AdaptiveSDK.js†L1-L210】
+4. **License gate introduced** – The adaptive SDK now ships with a reusable license manager, attestation profile registry, and remote attestation pipeline, ensuring telemetry and downstream monetization features are blocked until validation succeeds or policy-driven fail-open rules apply.【F:src/product/licensing/LicenseManager.js†L1-L237】【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】【F:src/core/AdaptiveSDK.js†L1-L210】
+5. **Blueprint & projection visualization** – The new `LayoutBlueprintRenderer` renders adaptive layout zones, focus highlights, and monetization-aware component stacks onto the demo canvas while exposing downloadable blueprint exports that partners can inspect outside the engine runtime. The companion `ProjectionFieldComposer` and scenario simulator extend this into a 4D projection pipeline that visualizes halo depth, gesture contours, and compliance-ready scenario playback for wearables without extra tooling.【F:src/ui/adaptive/renderers/LayoutBlueprintRenderer.js†L1-L314】【F:src/ui/adaptive/renderers/ProjectionFieldComposer.js†L1-L273】【F:src/ui/adaptive/simulators/ProjectionScenarioSimulator.js†L1-L178】【F:wearable-designer.html†L520-L760】【F:wearable-designer.html†L940-L1180】
+
+## 3. Critical Gaps & Risks
+1. **Instantiation coupling** – Only the bespoke `wearable-designer.html` consumes the adaptive engine. No modular entry point exists for reuse across apps, making it hard to sell as a SDK.
+2. **Input validation maturity** – New `SensorSchemaRegistry` clamps and normalizes gaze/neural/biometric payloads, but hardware-specific adapters, consent prompts, and type definitions are still missing for production wearables.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L248】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1-L218】
+3. **Monolithic layout logic** – `SpatialLayoutSynthesizer` blends heuristics, presets, and annotation emission in a single class, complicating testability and alternative layout strategies.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L9-L111】
+4. **Telemetry abstraction still maturing** – The harness now supports consent gating, audit trails, retention/encryption metadata on remote exports, and request-signing middleware, but still lacks hardened batching and certified partner integrations required by enterprise clients.【F:src/product/ProductTelemetryHarness.js†L1-L207】【F:src/product/telemetry/storage/RemoteStorageAdapters.js†L1-L187】【F:src/product/telemetry/middleware/createRequestSigningMiddleware.js†L1-L94】
+5. **Documentation drift** – Marketing-heavy README and plan documents claim full product readiness, while there is no engineering validation, API reference, or integration samples beyond the demo shell.【F:README.md†L1-L53】【F:DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md†L1-L40】
+6. **Headless parity gaps** – Environment gating now prevents canvas/DOM crashes in CI, but the stack lacks mock visualizers/export shims for deterministic renders, and wearable-designer modularization must expose injectable UI facades to keep headless and browser experiences aligned.【F:src/core/Engine.js†L1-L212】【F:wearable-designer.html†L1-L1568】
+
+## 4. Suitability as Commercial Core
+- **Short term:** The adaptive stack can power exploratory demos and concept pitches thanks to the isolated modules, new sensor schema validation, and compatibility with the existing visualization engine. Remaining risks involve SDK packaging, telemetry privacy, and end-to-end hardware validation.
+- **Long term:** Without a refactor focused on interface contracts, plugin architecture, and modular packaging, the current code will not scale. It risks becoming another bespoke demo rather than a reusable platform.
+
+## 5. Recommended Refactor Themes
+1. **SDK Boundary Definition** – Extract a framework-neutral package (`packages/adaptive-core`) exposing `AdaptiveInterfaceEngine`, sensor adapter interfaces, and TypeScript definitions.
+2. **Input Contract Hardening** – Extend the new schema validation layer with TypeScript definitions, consent workflows, and adapter lifecycle hooks (connect/disconnect/test) for real sensor hardware.
+3. **Layout Strategy Pipeline** – Split `SpatialLayoutSynthesizer` into strategy modules (zoning, motion, chroma) and allow dependency injection for alternative heuristics.
+4. **Telemetry Provider Interface** – Expand the provider catalog (Segment, Mixpanel), add signed requests/encryption, and formalize consent export APIs on top of the new classification/audit layer.
+6. **Attestation SLAs & tooling** – Remote attestation, revocation, entitlement sync, and the attestation profile registry now exist. The new profile catalog ships enterprise/studio/indie defaults, but partner endpoint catalogs, SLA benchmarking, and operational tooling still need to be formalized for enterprise rollouts.【F:src/product/licensing/LicenseAttestationProfileCatalog.js†L1-L302】【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】【F:src/product/ProductTelemetryHarness.js†L1-L487】【F:src/core/AdaptiveSDK.js†L1-L210】
+5. **Experience Layer Modularization** – Rebuild `wearable-designer.html` as a composable UI kit (e.g., Web Components or React wrapper) with smaller example scenes.
+
+## 6. Next Steps Snapshot
+- Phase 0 (Now): Create engineering roadmap & tracking system, align documentation with reality.
+- Phase 1: Carve out SDK boundary, formalize schema registration workflows, and codify telemetry privacy guardrails.
+- Phase 2: Modularize layout/telemetry subsystems and add automated tests.
+- Phase 3: Produce integration samples and extension templates for tooling partners.
+
+Refer to `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` for task-level tracking and status updates as the refactor progresses.

--- a/DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md
+++ b/DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md
@@ -1,0 +1,45 @@
+# Adaptive Engine Core Viability Assessment
+
+## 1. Session Context (2025-10-07)
+- **Objective:** Validate whether the current adaptive stack can serve as the commercial core for wearable/ambient UI tooling.
+- **Inputs Reviewed:** `AdaptiveInterfaceEngine`, sensory/layout modules, commercialization utilities, and the wearable designer shell.
+- **Outcome:** The existing structure is a strong prototype but requires a refactor programme before being packaged as a core SDK.
+
+## 2. Capability Fit Analysis
+| Layer | Strengths | Limitations | Decision |
+|-------|-----------|-------------|----------|
+| Core Runtime (`AdaptiveInterfaceEngine`) | Preserves legacy visualizer compatibility while introducing adaptive pipeline hooks for sensory updates.【F:src/core/AdaptiveInterfaceEngine.js†L16-L201】 | Lifecycle and variation flows are hardwired to demo hooks instead of a published API surface. | Keep, but extract public methods + TypeScript definitions during SDK boundary work (Phase 1). |
+| Sensory Input (`SensoryInputBridge`) | Extensible channel registry, configurable decay, schema normalization, adapter lifecycle hooks, and snapshot export suitable for eye/neural adapters.【F:src/ui/adaptive/SensoryInputBridge.js†L10-L296】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1-L230】 | Lifecycle hooks exist but need production hardening, reporting contracts, and hardware certification guidance. | Retain architecture, finalize adapter lifecycle contracts + error telemetry. |
+| Layout (`SpatialLayoutSynthesizer`) | Multi-zone descriptors with chroma/motion heuristics already mapped to engine parameters.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L18-L111】 | Monolithic heuristics make alternative strategies/testing difficult. | Split into strategy modules (zoning/motion/color) and expose injection API. |
+| Commercialization (`DesignLanguageManager`, `InterfacePatternRegistry`, `ProductTelemetryHarness`, `LicenseManager`, `RemoteLicenseAttestor`, `LicenseAttestationProfileRegistry`, `LicenseAttestationProfileCatalog`, `LicenseCommercializationReporter`, `LicenseCommercializationSnapshotStore`, `CommercializationSnapshotStorageAdapters`) | Provides monetization metadata, consent-aware + license-gated telemetry, remote attestation history, curated attestation packs, commercialization analytics summaries, KPI snapshot persistence/export helpers with async hydration, remote storage builders (generic/S3), and adapter lifecycle instrumentation.【F:src/features/DesignLanguageManager.js†L18-L78】【F:src/ui/adaptive/InterfacePatternRegistry.js†L11-L87】【F:src/product/ProductTelemetryHarness.js†L7-L495】【F:src/product/licensing/LicenseManager.js†L1-L237】【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】【F:src/product/licensing/LicenseAttestationProfileCatalog.js†L1-L302】【F:src/product/licensing/LicenseCommercializationReporter.js†L1-L290】【F:src/product/licensing/LicenseCommercializationSnapshotStore.js†L1-L238】【F:src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js†L1-L142】 | Telemetry still needs signed provider integrations while commercialization now requires retry/backoff policies for remote adapters and partner-facing analytics documentation. | Expand provider catalog, codify attestation SLA guidance + endpoint schema docs, benchmark the new packs, harden remote storage (retry/backoff, telemetry), and expose commercialization dashboards with partner ingestion guides. |
+| Experience Shell (`wearable-designer.html`) | Demonstrates adaptive behaviour + commercialization toggles end-to-end, now including a live layout blueprint renderer/export flow and a 4D projection-field composer with scenario simulator layered onto the canvas stack.【F:wearable-designer.html†L1-L160】【F:wearable-designer.html†L520-L760】【F:wearable-designer.html†L940-L1180】 | Single ~280-line file prevents reuse, testing, or partner integration samples despite the richer visualization. | Rebuild as modular demo kit (Phase 3). |
+
+## 3. Scalability & Elegance Gaps
+1. **API Boundary Ambiguity** – Consumers must import internal modules directly; no SDK packaging, versioning, or compatibility guarantees.
+2. **Data Contract Fragility** – Runtime schema validation now clamps payloads, but missing hardware lifecycle hooks and consent flows still threaten production integrations.
+3. **Testing & Automation Debt** – Vitest now covers layout, sensor validation, and telemetry paths, yet Playwright smoke/visual suites remain absent pending the new automation plan.
+4. **Commercialization Hardening** – Consent layer, license gating, remote attestation, remote export retention/encryption hooks, the attestation profile registry, and curated profile packs landed, but telemetry still needs signed provider integrations while partner-facing profile docs, SLA benchmarking, and monetization metadata exports require documentation/persistence for partner platforms.
+5. **Headless/Test Gaps** – Environment gating prevents canvas-related crashes in Node/CI, but we still owe injectable visualizer facades, deterministic export mocks, and README guidance so partners know how to operate the SDK outside a browser shell.【F:src/core/Engine.js†L1-L212】【F:README.md†L100-L132】
+
+## 4. Core Decision
+- **Go-Forward Stance:** The prototype is a viable foundation *if and only if* we execute the refactor roadmap. A rewrite is unnecessary; strategic modularization and contract hardening will yield an SDK-grade core.
+- **KPIs for Graduation:**
+  - Public SDK entry point with semantic versioning and documentation.
+  - Validated sensory adapter contracts (runtime schemas + adapter lifecycle tests).
+  - Pluggable layout/telemetry strategies with baseline automated coverage.
+  - Modular demo kit showcasing partner integration flows.
+
+## 5. Refactor Programme Synopsis
+| Phase | Focus | Key Deliverables |
+|-------|-------|------------------|
+| Phase 0 (now) | Planning & alignment | Updated tracker, session log, viability assessment (this doc). |
+| Phase 1 | SDK boundary & contracts | Package `AdaptiveInterfaceEngine`, define adapter interfaces, add schema validation. |
+| Phase 2 | Modular subsystems | Strategy modules for layout, provider pattern for telemetry, baseline Playwright smoke tests. |
+| Phase 3 | Commercialization assets | Modular demo kit, partner starter templates, monetization analytics documentation. |
+
+## 6. Immediate Next Actions
+1. Wire the new Playwright smoke lane into CI with cached Chromium binaries and smoke-only triggers.
+2. Publish telemetry provider configuration samples that consume `registerTelemetryRequestMiddleware` and the signing middleware helper.
+3. Socialize the remote encryption templates with compliance/legal stakeholders and capture approval notes.
+4. Continue session logging (see `PLANNING/SESSION_LOG.md`) to trace decisions and unblockers for commercialization milestones.
+

--- a/DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md
+++ b/DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md
@@ -1,0 +1,43 @@
+# Adaptive UI Productization Plan
+
+## Vision
+Transform the existing VIB34D holographic engine into a commercial-grade adaptive interface design platform targeted at future-facing wearable and ambient devices. The product will enable designers to prototype and deploy 4D-projection-inspired user interfaces that respond to non-traditional inputs such as eye focus, neural gestures, biometric signals, and spatial gestures.
+
+## Strategic Objectives
+1. **Product Repositioning** – Reframe the core engine as a UI/UX prototyping suite instead of a gallery-only renderer.
+2. **Adaptive Input Layer** – Introduce abstractions for sensor-driven inputs (eye tracking, neural intent, biometric feedback, ambient context).
+3. **UI Component Language** – Replace variation-only focus with reusable UI schema modules that map to wearable experience patterns.
+4. **Design Workflow Integration** – Prepare extension points for Figma, Framer, Webflow, and custom plugin ecosystems.
+5. **Monetization Foundations** – Provide subscription hooks, analytics, and licensing toggles for enterprise support.
+6. **Documentation & Support** – Deliver comprehensive docs, roadmap, and onboarding artifacts.
+
+## Work Breakdown Structure
+- [x] Create adaptive input bridge module (sensor abstraction).
+- [x] Build responsive layout synthesizer for non-screen surfaces.
+- [x] Extend variation manager into design pattern registry.
+- [x] Add commercialization hooks (licensing, telemetry, modular add-ons).
+- [x] Produce new HTML entry point showcasing wearable/adaptive UI workflow.
+- [x] Update README and craft go-to-market documentation.
+- [x] Outline partner & plugin integration strategy.
+
+## Implementation Log
+This section will be filled while executing the plan to provide transparent, time-ordered documentation of every change.
+
+- ✅ **Initialized documentation** – Captured vision, objectives, and work breakdown for adaptive UI productization.
+- ✅ **Created SensoryInputBridge** – Added `src/ui/adaptive/SensoryInputBridge.js` to normalize multi-modal sensor data for wearable interfaces.
+- ✅ **Added SpatialLayoutSynthesizer** – Introduced `src/ui/adaptive/SpatialLayoutSynthesizer.js` to translate adaptive signals into wearable-friendly layout descriptors.
+- ✅ **Established InterfacePatternRegistry** – Added `src/ui/adaptive/InterfacePatternRegistry.js` to catalogue monetizable adaptive UI blueprints.
+- ✅ **Bound geometry to design** – Implemented `src/features/DesignLanguageManager.js` to map holographic variations to sellable UI languages.
+- ✅ **Productized core engine** – Created `src/core/AdaptiveInterfaceEngine.js` with sensory-driven layout synthesis and telemetry hooks.
+- ✅ **Telemetry foundation** – Added `src/product/ProductTelemetryHarness.js` for licensing-aware analytics.
+- ✅ **Consent & lifecycle upgrade** – Extended telemetry with consent classifications/audit trails and added sensor adapter lifecycle hooks documented in `DOCS/TELEMETRY_PRIVACY_AND_CONSENT_GUIDE.md`.
+- ✅ **Wearable designer experience** – Authored `wearable-designer.html` showcasing adaptive UI workflow and commercial hooks.
+- ✅ **Updated README** – Reframed project messaging around adaptive wearable UI productization.
+- ✅ **Partner strategy** – Documented plugin ecosystems and monetization roadmap in `DOCS/PARTNER_INTEGRATION_STRATEGY.md`.
+- ✅ **License attestation profiles** – Added `src/product/licensing/LicenseAttestationProfileRegistry.js` plus SDK/telemetry wiring so commercialization teams can package partner-specific validation endpoints and SLAs.
+- ✅ **Attestation profile catalog** – Shipped `src/product/licensing/LicenseAttestationProfileCatalog.js` and `DOCS/LICENSE_ATTESTATION_PROFILE_CATALOG.md` with enterprise/studio/indie packs, SDK registration helpers, and audit coverage so monetization teams can onboard partners without hand-coding attestation configs.
+- ✅ **Commercialization analytics bridge** – Added `src/product/licensing/LicenseCommercializationReporter.js`, exposed summary APIs through the telemetry harness/SDK, updated `wearable-designer.html` with a commercialization coverage panel, and refreshed documentation so partner dashboards can visualize attestation pack adoption and SLA health.
+- ✅ **Commercialization KPI persistence** – Landed `LicenseCommercializationSnapshotStore`, wired snapshot capture/scheduling + exports through the telemetry harness/SDK, upgraded the wearable demo with snapshot controls/export downloads, and documented the new KPI workflow for partners.【F:src/product/licensing/LicenseCommercializationSnapshotStore.js†L1-L214】【F:src/product/ProductTelemetryHarness.js†L35-L168】【F:wearable-designer.html†L318-L474】【F:DOCS/LICENSE_COMMERCIALIZATION_ANALYTICS.md†L1-L51】
+- ✅ **Adaptive blueprint renderer** – Implemented `src/ui/adaptive/renderers/LayoutBlueprintRenderer.js`, extended the wearable designer with blueprint metrics/export controls, and exposed SDK type definitions/tests so partners can preview adaptive surfaces without reverse-engineering the layout payloads.【F:src/ui/adaptive/renderers/LayoutBlueprintRenderer.js†L1-L314】【F:wearable-designer.html†L520-L620】【F:tests/vitest/layout-blueprint-renderer.test.js†L1-L84】【F:types/adaptive-sdk.d.ts†L600-L676】
+- ✅ **Projection field composer & simulator** – Added `src/ui/adaptive/renderers/ProjectionFieldComposer.js` and `src/ui/adaptive/simulators/ProjectionScenarioSimulator.js`, wired the wearable designer with a 4D projection panel + scenario controls, surfaced SDK helpers/types, and documented/tests to help partners visualize halo depth, gesture contours, and licensing-friendly playback flows alongside the blueprint export.【F:src/ui/adaptive/renderers/ProjectionFieldComposer.js†L1-L273】【F:src/ui/adaptive/simulators/ProjectionScenarioSimulator.js†L1-L178】【F:wearable-designer.html†L520-L760】【F:tests/vitest/projection-field-composer.test.js†L1-L36】【F:tests/vitest/projection-scenario-simulator.test.js†L1-L54】【F:types/adaptive-sdk.d.ts†L700-L886】
+

--- a/DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md
+++ b/DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md
@@ -1,0 +1,52 @@
+# Layout & Telemetry Modularization Brief
+
+## Purpose
+Establish the target architecture and acceptance criteria for splitting the adaptive layout and telemetry layers into modular, swappable components. This brief seeds Backlog items B-03, B-04, and B-08.
+
+## Current Pain Points
+- `SpatialLayoutSynthesizer` combines intensity heuristics, zone allocation, motion synthesis, and annotation plug-ins in a single class, making it difficult to extend for new wearable surfaces or haptic-only interfaces.【F:src/ui/adaptive/SpatialLayoutSynthesizer.js†L1-L113】
+- `ProductTelemetryHarness` handles licensing, buffering, and network flushing without any provider abstraction or privacy controls, limiting monetization readiness for enterprise deployments.【F:src/product/ProductTelemetryHarness.js†L1-L63】
+- Demo wiring in `wearable-designer.html` binds these modules directly to UI controls, preventing SDK consumers from selecting only the pieces they need.
+
+## Target End-State
+> **Implementation Update (2025-10-10):** Baseline strategy/annotation interfaces now live in `src/ui/adaptive/strategies` and
+> `src/ui/adaptive/annotations` with runtime registration exercised by the wearable designer demo.
+
+1. **Layout Strategy Plug-ins**
+   - Introduce a `LayoutStrategy` interface with `prepare(context)` and `compose(layoutDraft)` hooks.
+   - Provide reference strategies: `FocusWeightedStrategy` (current behavior), `PeripheralHandoffStrategy`, and `HapticFallbackStrategy`.
+   - Move annotation handling into discrete `LayoutAnnotation` modules that declare dependencies and priority.
+> **Implementation Update (2025-10-10):** `ProductTelemetryHarness` now delegates to provider implementations under
+> `src/product/telemetry` and supports runtime registration via the adaptive engine.
+
+2. **Telemetry Provider Interface**
+   - Define `TelemetryProvider` with `identify`, `track`, and `flush` methods plus metadata about storage locations.
+   - Ship `ConsoleTelemetryProvider` (default), `HttpTelemetryProvider` (configurable endpoint), and a stub `PartnerTelemetryProvider` for integrations.
+   - Require opt-in data minimization flags and anonymization options for biometric streams.
+> **Implementation Update (2025-10-10):** The new `createAdaptiveSDK` factory composes sensors, strategies, and telemetry
+> providers for partner demos.
+
+3. **SDK Composition Layer**
+   - Create a lightweight `AdaptiveSDK` factory that wires `SensoryInputBridge`, layout strategies, and telemetry providers via dependency injection.
+   - Ensure UI shells (demo experiences, partner plug-ins) can import from this factory without bundling unused adapters.
+
+## Acceptance Criteria
+- Strategies, annotations, and telemetry providers can be registered and swapped at runtime without modifying core classes.
+- Unit tests cover registration lifecycles and conflict resolution rules for layout and telemetry modules.
+- Documentation includes migration notes for partners adopting the new interfaces.
+- Demo shell loads default strategies/providers but can toggle alternatives via configuration JSON.
+
+## Deliverables
+- Updated module scaffolding in `/src/ui/adaptive` and `/src/product` that reflects the interfaces above.
+- Integration tests or smoke scripts validating end-to-end signal → layout → telemetry flow using the new abstractions.
+- README and partner collateral updates summarizing the modular architecture.
+
+## Dependencies & Risks
+- Requires decision on the lightweight testing stack to avoid reintroducing the Playwright blocker.
+- Telemetry provider changes must align with privacy/legal review before public release.
+- Layout strategy plug-ins may increase bundle size; consider tree-shaking guidance for partner SDKs.
+
+## Next Actions
+1. Finalize testing stack recommendation (see `DOCS/TESTING_STACK_EVALUATION.md`).
+2. Define SDK public API boundary (Backlog item B-01) to inform dependency injection design.
+3. Produce migration checklist for existing demo experiences to adopt modular interfaces.

--- a/DOCS/LICENSE_ATTESTATION_PROFILE_CATALOG.md
+++ b/DOCS/LICENSE_ATTESTATION_PROFILE_CATALOG.md
@@ -1,0 +1,94 @@
+# License Attestation Profile Catalog
+
+This catalog curates commercialization-ready attestation packs that partners can import without reinventing telemetry or licensing primitives. Each pack bundles remote attestation endpoints, SLA defaults, and metadata for a target customer segment. Packs are delivered through the `LicenseAttestationProfileCatalog` module and can be registered via the Adaptive SDK or directly on the `ProductTelemetryHarness`.
+
+## Available Packs
+
+### Enterprise SaaS Compliance Pack (`enterprise-saas`)
+- **Audience:** Highly regulated enterprise programs that require multi-region redundancy and strict fail-closed behaviour.
+- **Regions:** `global`, `na`, `eu` by default. Override with `regions` when registering the pack.
+- **SLA Defaults:** 900 ms response target, 99.9% availability, 5-minute breach detection window, fail-open disabled.
+- **Headers:** Adds `x-sdk-product` and `x-sdk-tier=enterprise` to every request.
+- **Metadata:** Marks profiles with `segment=enterprise` and `complianceTier=regulated` for downstream analytics.
+
+### Studio Collaboration Pack (`studio-collab`)
+- **Audience:** Design studios collaborating on shared wearable experiences that balance reliability with creative agility.
+- **Regions:** `global`, `latam` by default with optional `collaborationId` scoping.
+- **SLA Defaults:** 1.5 s response target, 99.5% availability, 15-minute breach window, fail-open enabled to favour iteration.
+- **Headers:** Includes `x-sdk-tier=studio` and injects the `x-collaboration-id` supplied during registration.
+- **Metadata:** Adds `segment=studio`, `collaborationId`, and `complianceTier=managed` for reporting.
+
+### Indie Lab Starter Pack (`indie-lab`)
+- **Audience:** Independent labs and prototyping collectives that need light-touch attestation with permissive fail-open defaults.
+- **Regions:** `global` default with optional overrides and `projectCode` scoping.
+- **SLA Defaults:** 2.5 s response target, 99.0% availability, 30-minute breach window, fail-open enabled.
+- **Headers:** Adds `x-sdk-tier=indie` alongside the provided `x-project-code`.
+- **Metadata:** Annotates profiles with `segment=indie`, `projectCode`, and `complianceTier=experimental`.
+
+## Registration Options
+
+Each pack accepts a shared options object when registered:
+
+| Option | Description |
+|--------|-------------|
+| `regions` | Array of region slugs to generate profiles for (defaults come from the pack). |
+| `baseUrl` | Root service URL used to compose attestation, revocation, and entitlement endpoints. |
+| `pollIntervalMs` / `minimumPollIntervalMs` | Override cadence for scheduled attestation. |
+| `failOpen` | Force fail-open or fail-closed regardless of the pack default. |
+| `headers` | Additional HTTP headers merged into the remote attestor configuration. |
+| `collaborationId` / `projectCode` | Segment identifiers for studio and indie packs. |
+| `defaultProfileId` | Overrides the default profile used when no explicit profile is supplied. |
+| `applyDefault` | Set to `false` to register a pack without changing the current default profile. |
+| `sla` | Partial overrides for response target, availability, breach window, and notes. |
+| `metadata` | Additional metadata merged into the pack summary for analytics. |
+
+## Usage Examples
+
+### Registering During SDK Bootstrap
+```js
+const sdk = createAdaptiveSDK({
+  licenseAttestationProfilePackId: 'enterprise-saas',
+  licenseAttestationProfilePackOptions: {
+    regions: ['global', 'apac'],
+    baseUrl: 'https://licensing.partner.example.com',
+    pollIntervalMs: 10 * 60 * 1000
+  }
+});
+```
+
+### Registering Multiple Packs at Runtime
+```js
+const packSummary = sdk.registerLicenseAttestationProfilePack('studio-collab', {
+  collaborationId: 'aurora',
+  regions: ['global', 'latam'],
+  applyDefault: false
+});
+
+console.log(packSummary.profileIds);
+// => ['studio-collab/aurora/global', 'studio-collab/aurora/latam']
+```
+
+### Registering a Custom Pack Descriptor
+```js
+sdk.registerLicenseAttestationProfilePack({
+  id: 'partner-managed',
+  defaults: { baseUrl: 'https://licenses.partner.example.com' },
+  buildProfiles: ({ baseUrl }) => ([
+    {
+      id: 'partner-managed/global',
+      attestor: { attestationUrl: `${baseUrl}/global/attest` },
+      metadata: { segment: 'partner', complianceTier: 'shared' }
+    }
+  ])
+});
+```
+
+## Audit & Compliance Notes
+- Pack registration emits `system.license.attestation_profile_pack_registered` events in the telemetry audit log.
+- Individual profile registrations and default changes continue to produce their existing audit entries.
+- Pack metadata is preserved so compliance exports can reason about segment/region coverage without additional lookups.
+
+## Next Steps
+- Publish SLA benchmarks per region based on telemetry collected from early adopter partners.
+- ✅ Pack metadata now flows into the commercialization dashboard via `LicenseCommercializationReporter`, enabling entitlement coverage and SLA adoption views directly in the telemetry harness/SDK summary APIs.
+- Expand the catalog with marketplace-specific packs (e.g., healthcare, defense) once legal review completes.

--- a/DOCS/LICENSE_COMMERCIALIZATION_ANALYTICS.md
+++ b/DOCS/LICENSE_COMMERCIALIZATION_ANALYTICS.md
@@ -1,0 +1,116 @@
+# License Commercialization Analytics Bridge
+
+The commercialization analytics bridge turns license attestation registrations into dashboard-ready summaries. It is implemented by `src/product/licensing/LicenseCommercializationReporter.js` and consumed by the telemetry harness/Adaptive SDK so partners can see entitlement coverage without reimplementing audit logic.
+
+## What It Tracks
+
+- **Pack registrations.** Every call to `registerLicenseAttestationProfilePack()` records the pack id, metadata, default profile, and which profiles were registered.
+- **Profile registrations.** Direct calls to `registerLicenseAttestationProfile()` (from packs or partner code) are captured with source metadata so dashboards can distinguish catalog packs from bespoke profiles.
+- **Default changes and adoption.** Applying or changing a default profile, plus invoking `setLicenseAttestorFromProfile()`, updates adoption counters and timestamps. The reporter aggregates adoption counts per profile, segment, region, and pack.
+- **SLA benchmarks.** Response targets, availability, and breach windows are summarised (min/max/average) to highlight SLA outliers.
+
+## Accessing Summaries
+
+```js
+const sdk = createAdaptiveSDK({
+  telemetry: {
+    commercialization: {
+      onUpdate(summary) {
+        console.log('Updated commercialization metrics', summary);
+      }
+    }
+  },
+  licenseAttestationProfilePacks: ['enterprise-saas']
+});
+
+const summary = sdk.getLicenseCommercializationSummary();
+console.table(summary.packs.map(pack => ({
+  id: pack.id,
+  adoption: pack.adoptionCount,
+  defaultProfile: pack.defaultProfileId
+})));
+```
+
+The summary object mirrors the Vitest expectations documented in `tests/vitest/license-commercialization-reporter.test.js`. It includes:
+
+- `packs`: pack-level adoption data, metadata, and default profile identifiers.
+- `profiles`: per-profile adoption counts, SLA snapshots, and pack references.
+- `segments` / `regions`: aggregated coverage counts with adoption totals.
+- `sla`: aggregate metrics for response time, availability, and breach windows.
+- `defaultProfileId`: the current default applied by the telemetry harness.
+- `lastUpdated`: ISO timestamp for the most recent change.
+
+## UI Integration
+
+`wearable-designer.html` consumes `getLicenseCommercializationSummary()` to render a commercialization coverage panel. The panel updates automatically via the `telemetry.commercialization.onUpdate` callback passed to `createAdaptiveSDK`, showcasing how partners can bind the summary to analytics dashboards or BI tooling.【F:wearable-designer.html†L318-L453】
+
+## KPI Snapshots & Exports
+
+The commercialization bridge now ships with `LicenseCommercializationSnapshotStore`, which captures periodic KPI snapshots and exposes BI-friendly exports. The telemetry harness wires the store automatically (unless disabled) and provides helper methods for manual capture, scheduling, and exporting:
+
+```js
+const sdk = createAdaptiveSDK({
+  telemetry: {
+    commercialization: {
+      snapshotIntervalMs: 60_000,
+      snapshotStore: {
+        maxSnapshots: 48
+      }
+    }
+  }
+});
+
+// Manual capture + KPI reporting
+sdk.captureLicenseCommercializationSnapshot({ trigger: 'quarterly-review' });
+const kpiReport = sdk.getLicenseCommercializationKpiReport();
+
+// Export for BI tooling
+const exportJson = sdk.exportLicenseCommercializationSnapshots({ format: 'json', includeSummary: false });
+const csv = sdk.exportLicenseCommercializationSnapshots({ format: 'csv' });
+```
+
+Within the wearable designer demo, the "Commercialization Coverage" panel now includes snapshot controls, KPI deltas, export triggers, and a remote persistence log so stakeholders can experience the workflow without writing additional code.【F:wearable-designer.html†L318-L476】
+
+## Remote Persistence & Async Hydration
+
+`LicenseCommercializationSnapshotStore` now supports asynchronous storage adapters and exposes a `whenReady()` helper so partner dashboards can await remote hydration before rendering KPIs. Use the new storage builders in `src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js` to stream snapshots directly into enterprise vaults:
+
+```js
+import {
+  createSignedS3CommercializationSnapshotStorage,
+  createCommercializationSnapshotPayload
+} from 'vib34d-ultimate-viewer/src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js';
+
+const remoteStorage = createSignedS3CommercializationSnapshotStorage({
+  signingEndpoint: '/api/sign-kpi-upload',
+  fetchImplementation: window.fetch.bind(window),
+  redactContextKeys: ['licenseKey'],
+  serialize: (snapshots, context) => createCommercializationSnapshotPayload(snapshots, {
+    ...context,
+    channel: 'wearable-sdk'
+  })
+});
+
+const sdk = createAdaptiveSDK({
+  telemetry: {
+    commercialization: {
+      snapshotStoreOptions: {
+        storage: remoteStorage,
+        onChange: snapshots => renderDashboard(snapshots)
+      },
+      snapshotIntervalMs: 86_400_000 // nightly captures
+    }
+  }
+});
+
+await sdk.getLicenseCommercializationSnapshotStore().whenReady();
+renderDashboard(sdk.getLicenseCommercializationSnapshots());
+```
+
+The wearable designer demo showcases this flow by wiring an asynchronous remote storage adapter, rendering upload history, and waiting on `whenReady()` to refresh the KPI history once remote hydration completes.【F:wearable-designer.html†L318-L485】
+
+## Follow-Ups
+
+- Expand the pack catalog (healthcare, education) with commercialization metadata so KPI snapshots can highlight regulated market coverage.
+- Harden production-grade storage adapters with retry/backoff policies and connect nightly KPI jobs to downstream partner BI pipelines.
+- Extend partner docs with KPI interpretation guidance and sample dashboard widgets fed by the CSV/JSON exports.

--- a/DOCS/PARTNER_INTEGRATION_STRATEGY.md
+++ b/DOCS/PARTNER_INTEGRATION_STRATEGY.md
@@ -1,0 +1,31 @@
+# Partner & Plugin Integration Strategy
+
+## Target Ecosystems
+- **Figma** – Primary design plugin delivering adaptive component previews and intent-driven variants.
+- **Framer** – Real-time prototyping integration enabling neural/gesture simulation controls.
+- **Webflow** – Code export and hosted telemetry integration for adaptive websites.
+- **Unity / Unreal** – Wearable companion apps and holographic installations.
+
+## Integration Layers
+1. **Design Tokens API** – Surface color/motion tokens from `DesignLanguageManager` via REST or local bridge.
+2. **Pattern Catalog Sync** – Use `AdaptiveInterfaceEngine.exportMarketplaceCatalog()` to populate plugin storefronts.
+3. **Telemetry Webhooks** – Forward `ProductTelemetryHarness` buffers to partner analytics endpoints for shared insights while leveraging the new commercialization summaries for entitlement dashboards.
+4. **Sensor Simulation Kits** – Bundle `SensoryInputBridge` adapters that emulate gaze, EEG, and biometrics inside each tool.
+5. **License Attestation Profiles** – Distribute curated packs from `LicenseAttestationProfileCatalog` (see `DOCS/LICENSE_ATTESTATION_PROFILE_CATALOG.md`) with endpoint URLs, headers, and SLA metadata aligned to partner support tiers.
+6. **Commercialization Coverage Feeds** – Expose `getLicenseCommercializationSummary()` and the new KPI snapshot/export helpers so commerce teams can visualise pack adoption, SLA health, and longitudinal KPI deltas without duplicating telemetry pipelines.【F:src/product/ProductTelemetryHarness.js†L468-L532】【F:types/adaptive-sdk.d.ts†L452-L489】
+
+## Commercial Opportunities
+- Tiered subscriptions aligned with pattern tiers (Starter, Pro, Enterprise).
+- Revenue share with platform marketplaces for premium holographic UI packs.
+- Enterprise support contracts bundling integration assistance and custom pattern creation.
+
+## Roadmap Highlights
+- Q1: Deliver Figma plugin alpha with adaptive preview controls.
+- Q2: Launch marketplace-ready pattern packs with licensing telemetry enabled.
+- Q3: Expand to neural hardware OEM SDK partnership leveraging SensoryInputBridge adapters.
+
+## Support Structure
+- Dedicated partner portal referencing `wearable-designer.html` demo flows.
+- API documentation generated from `DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md` milestones.
+- Community Discord & knowledge base for indie creators.
+

--- a/DOCS/REMOTE_STORAGE_ENCRYPTION_TEMPLATES.md
+++ b/DOCS/REMOTE_STORAGE_ENCRYPTION_TEMPLATES.md
@@ -1,0 +1,106 @@
+# Remote Storage Encryption Templates
+
+## Purpose
+Partner teams integrating the compliance vault into regulated environments need concrete examples of how to encrypt audit exports before they leave the device or trusted network. This playbook expands on the hooks described in the Telemetry Privacy & Consent Guide by providing reusable templates for customer-managed keys, envelope encryption, and metadata propagation.
+
+## Template 1 – AWS KMS + AES-GCM Wrapper
+```js
+import { subtle } from 'crypto'.webcrypto;
+
+export async function createKmsAesGcmEncryptor({ kmsClient, keyId }) {
+  if (!kmsClient || !keyId) {
+    throw new Error('[createKmsAesGcmEncryptor] `kmsClient` and `keyId` are required.');
+  }
+
+  return async function encryptPayload(payload, { adapter, retentionPolicy }) {
+    const plaintext = typeof payload === 'string' ? new TextEncoder().encode(payload) : payload;
+
+    // 1. Ask KMS for a data key (returns plaintext + ciphertext versions).
+    const { Plaintext: dataKey, CiphertextBlob: encryptedKey } = await kmsClient.generateDataKey({
+      KeyId: keyId,
+      KeySpec: 'AES_256'
+    });
+
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const key = await subtle.importKey('raw', dataKey, 'AES-GCM', false, ['encrypt']);
+    const cipherBuffer = await subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+    return {
+      body: cipherBuffer,
+      contentType: 'application/octet-stream',
+      headers: {
+        'x-adaptive-encryption': 'kms-aes-gcm',
+        'x-adaptive-encryption-key': Buffer.from(encryptedKey).toString('base64'),
+        'x-adaptive-encryption-iv': Buffer.from(iv).toString('base64')
+      },
+      metadata: {
+        kmsKeyId: keyId,
+        adapter,
+        retentionPolicy
+      }
+    };
+  };
+}
+```
+
+**When to use:** Customers already approved for AWS KMS, require per-export data keys, and can store encrypted data keys alongside compliance logs.
+
+## Template 2 – Envelope Encryption with Partner Broker
+```js
+export function createEnvelopeEncryptionHook({ signEndpoint, fetchImplementation = fetch }) {
+  if (!signEndpoint) {
+    throw new Error('[createEnvelopeEncryptionHook] `signEndpoint` is required.');
+  }
+
+  return async function encryptPayload(payload, { records, retentionPolicy }) {
+    const response = await fetchImplementation(signEndpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        operation: 'ENVELOPE_ENCRYPT',
+        retentionPolicy,
+        recordCount: records.length
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`[createEnvelopeEncryptionHook] Signing service returned ${response.status}`);
+    }
+
+    const { encryptedPayload, algorithm, keyReference, additionalHeaders = {} } = await response.json();
+
+    return {
+      body: encryptedPayload,
+      contentType: 'application/octet-stream',
+      headers: {
+        'x-adaptive-encryption': algorithm,
+        'x-adaptive-key-reference': keyReference,
+        ...additionalHeaders
+      },
+      metadata: {
+        algorithm,
+        keyReference,
+        retentionPolicy
+      }
+    };
+  };
+}
+```
+
+**When to use:** Partners maintain a central signing/encryption broker (e.g., health network, trading desk) that must approve every export before it leaves an on-device vault.
+
+## Metadata & Audit Guidance
+- Always include a `retentionPolicy` entry in the returned metadata so downstream dashboards can verify export intent.
+- Surface key identifiers (`kmsKeyId`, `keyReference`) to help compliance teams prove which controls protected each batch.
+- Pair these hooks with `createRequestSigningMiddleware` to stamp signature headers that match the encryption artifacts for a full audit trail.
+
+## Implementation Checklist
+- [x] Provide AES-GCM + KMS wrapper example for on-device encryption.
+- [x] Provide envelope encryption example for partner signing brokers.
+- [ ] Add language-specific snippets (TypeScript, Python) for partners not using Node runtimes.
+- [ ] Document key rotation strategy and deletion workflows per retention policy.
+
+## Next Steps
+1. Review these templates with legal/privacy stakeholders before distributing to external partners.
+2. Publish provider configuration samples that call both `encryptPayload` and `registerTelemetryRequestMiddleware` so partners see the full pipeline.
+3. Expand the playbook with decrypt/verify utilities for compliance auditors.

--- a/DOCS/SDK_BOUNDARY_PROPOSAL.md
+++ b/DOCS/SDK_BOUNDARY_PROPOSAL.md
@@ -1,0 +1,65 @@
+# Adaptive SDK Boundary Proposal
+
+## Purpose
+Define an explicit, supportable interface for product teams and partners consuming the adaptive engine. The proposal captures the initial module surface, dependency injection patterns, and packaging considerations required to evolve the prototype into a salable SDK.
+
+## Guiding Principles
+1. **Composable inputs and outputs.** Sensor feeds, layout strategies, and telemetry providers must be replaceable without deep
+   engine changes.
+2. **Progressive adoption.** Downstream products should be able to adopt a subset (e.g., layout only) before integrating full
+   adaptive control loops.
+3. **Commercial hardening.** Licensing checks, telemetry consent, and extension hooks ship as part of the boundary rather than
+   ad-hoc demo logic.
+
+## Proposed Public Surface
+| Area | Export | Responsibilities |
+|------|--------|------------------|
+| Core | `AdaptiveInterfaceEngine` | Lifecycle orchestration, module registry, high-level `renderAdaptiveFrame(context)` API. |
+| Inputs | `SensoryInputBridge`, `SensorSchemaRegistry`, `registerSensorSchema`, sensor adapter interfaces | Normalization + validation contracts for gaze, neural, biometric, ambient signals plus adapter lifecycle controls. |
+| Layout | `SpatialLayoutSynthesizer`, `LayoutStrategy`, `LayoutContext` types | Strategy registration, generation of layout descriptors, annotations, and motion cues. |
+| Patterns | `InterfacePatternRegistry`, `DesignLanguageManager` | Mapping between layout descriptors and monetizable UI packages. |
+| Telemetry | `TelemetryClient`, `TelemetryProvider`, `ComplianceVaultTelemetryProvider`, `createSignedS3StorageAdapter`, `createLogBrokerStorageAdapter`, `createRequestSigningMiddleware`, `ProductTelemetryHarness` compatibility shim, `LicenseCommercializationSnapshotStore`, `createCommercializationSnapshotRemoteStorage`, `createSignedS3CommercializationSnapshotStorage`, `createLogBrokerCommercializationSnapshotStorage`, `createCommercializationSnapshotPayload` | Event buffering, request middleware orchestration, consent state, compliance exports, commercialization coverage summaries/KPI exports, commercialization remote persistence adapters, and attestation/audit stream publication for licensing events. |
+| Licensing | `LicenseManager`, `LicenseStatus`, `LicenseValidator`, `RemoteLicenseAttestor`, `LicenseAttestationProfileRegistry`, `LicenseAttestationProfileCatalog`, `LicenseCommercializationReporter` types, `LicenseCommercializationSnapshotStore` types | Centralized license validation, feature gating, remote attestation/revocation checks, entitlement synchronization, curated attestation packs, commercialization analytics summaries, KPI snapshot persistence/export helpers (`whenReady`, async storage hooks), and commercialization reporting feeding telemetry guards. |
+| Experience | `createConsentPanel`, `LayoutBlueprintRenderer`, `createLayoutBlueprintRenderer`, `buildLayoutBlueprint`, `ProjectionFieldComposer`, `createProjectionFieldComposer`, `composeProjectionField`, `ProjectionScenarioSimulator` | Reusable consent UI plus adaptive layout blueprint visualization/export helpers **and** 4D projection-field composition/simulation APIs so partners can render halo depth, gesture contours, and scripted scenarios. |
+| Utilities | `createAdaptiveSDK(config)`, `AdaptiveError`, `AdaptiveLogger`, `types/adaptive-sdk.d.ts` | Bootstrapping helper returning configured engine + telemetry/consent/license hooks with type definitions. |
+
+### Telemetry Provider Hardening Expectations
+- **Signed requests:** Providers that leave the device/network (HTTP/partner adapters) must expose a `registerRequestMiddleware` hook or accept `requestSigner` configuration so the SDK can enforce tenant-specific signing (HMAC, OAuth2 client credentials, etc.). The harness now ships with `registerTelemetryRequestMiddleware` plus `createRequestSigningMiddleware` to normalize signing payloads before `track`/`flush`.
+- **Consent customization:** `createAdaptiveSDK` forwards `consentOptions` to `createConsentPanel`, enabling downstream products to override labels, default states, or add jurisdiction-specific toggles while reusing the shared UX contract. Partner plug-ins should rely on these options rather than forking the component to maintain parity with compliance copy updates.
+- **Retention/encryption reporting:** Remote storage adapters propagate `retentionPolicy` and `encryptionMetadata` through upload callbacks and signing payloads. Providers must log these values alongside export identifiers so customer success teams can audit compliance posture without raw data access.
+
+## Dependency Injection Model
+- **Sensors:** supply adapters via `createAdaptiveSDK({ sensorAdapters: [...] })` or manually call `registerSensorAdapter(type, adapter)`. Adapters may implement `connect`, `disconnect`, `test`, and `read` (pull) or use the `ingest` hook (push). Schemas can be registered via `sensorSchemas` config or `registerSensorSchema` helper.
+- **Layout Strategies:** `SpatialLayoutSynthesizer` exposes `registerStrategy(strategy)` and `clearStrategies()` for swapping
+  out bundles. Built-in strategies remain available as fallbacks.
+- **Environment Modes:** `createAdaptiveSDK({ environment: { mode: 'headless' } })` skips browser-only bootstrapping (canvas
+  visualizers, DOM bindings, export inputs) while keeping sensory, telemetry, licensing, and projection workflows operational in
+  server-side or automated test environments.
+- **Telemetry Providers:** Providers implement `identify`, `track`, and `flush`. The runtime defaults to buffered mode via
+  `ProductTelemetryHarness` + `ConsoleTelemetryProvider` when no provider is specified.
+- **Pattern Packs:** `InterfacePatternRegistry` accepts packaged bundles containing metadata, monetization hints, and renderers.
+- **License Attestation Packs:** `ProductTelemetryHarness` and `createAdaptiveSDK` accept curated attestation packs via `LicenseAttestationProfileCatalog` so commercialization teams can register enterprise/studio/indie defaults in one call.
+- **Commercialization KPI Snapshots:** `ProductTelemetryHarness` exposes snapshot capture/scheduling/export APIs, `LicenseCommercializationSnapshotStore` now supports async storage with `whenReady()`, and `createAdaptiveSDK` mirrors the helpers so partners can persist commercialization KPIs and feed BI tools without bespoke pipelines.【F:src/product/ProductTelemetryHarness.js†L468-L534】【F:types/adaptive-sdk.d.ts†L452-L506】
+
+## Packaging Plan
+1. **Phase 1:** Ship as ESM bundle + type definitions. Provide factory `createAdaptiveSDK` returning
+   `{ engine, sensoryBridge, telemetry, projectionComposer, projectionSimulator, licenseManager, licenseAttestor, registerSensorSchema, registerSensorAdapter, connectSensorAdapter, disconnectSensorAdapter, testSensorAdapter, registerTelemetryProvider, registerTelemetryRequestMiddleware, clearTelemetryRequestMiddleware, registerLicenseAttestationProfile, registerLicenseAttestationProfilePack, getLicenseAttestationProfiles, getLicenseAttestationProfile, setDefaultLicenseAttestationProfile, setLicenseAttestorFromProfile, updateTelemetryConsent, getTelemetryConsent, getTelemetryAuditTrail, getLicenseCommercializationSummary, getLicenseCommercializationReporter, getLicenseCommercializationSnapshotStore, captureLicenseCommercializationSnapshot, getLicenseCommercializationSnapshots, getLicenseCommercializationKpiReport, exportLicenseCommercializationSnapshots, startLicenseCommercializationSnapshotSchedule, stopLicenseCommercializationSnapshotSchedule, setLicense, validateLicense, getLicenseStatus, getLicenseHistory, getLicenseAttestationHistory, setLicenseAttestor, requestLicenseAttestation, onLicenseStatusChange, composeProjectionField, getProjectionFrame, stepProjectionSimulation, registerProjectionScenario, removeProjectionScenario, listProjectionScenarios, getProjectionScenario, setActiveProjectionScenario, getActiveProjectionScenario, createConsentPanel }` and honoring `sensorSchemas`, `sensorAdapters`, `consentOptions`, `telemetryConsent`, `projection`, `license`, `licenseAttestor`, `licenseAttestationProfiles`, `licenseAttestationProfilePacks`, and `licenseAttestorProfileId`/`licenseAttestorProfileOverrides` configuration while bundling `createConsentPanel`, layout blueprint helpers (`createLayoutBlueprintRenderer`, `buildLayoutBlueprint`), projection helpers (`createProjectionFieldComposer`, `composeProjectionField`, `ProjectionScenarioSimulator`), request signing middleware, and the compliance/commercialization storage adapters for partner reuse.
+2. **Phase 2:** Publish adapters for React/Vue/Web Components. Ensure wearable demo consumes the same factory to avoid drift.
+3. **Phase 3:** Release plug-in kits (Figma/Webflow) that call into the SDK boundary for previews and telemetry capture.
+
+## Acceptance Criteria
+- Runtime initialization requires only the configuration object defined above.
+- Layout/telemetry modules expose abstract strategy/provider interfaces with Vitest coverage.
+- Telemetry consent + license keys enforced before any `send` call, including partner-provided signing middleware registered via `registerTelemetryRequestMiddleware`, and remote attestation failures default to blocking telemetry unless fail-open is explicitly configured.
+- README and integration docs reference the SDK surface rather than internal files.
+
+## Open Questions
+- How should we version pattern packs relative to engine releases?
+- Do we need a compatibility layer for legacy VIB34D gallery consumers?
+- Should licensing checks block engine boot or degrade gracefully with limited features?
+- How should we distribute additional attestation packs (healthcare, education) without bloating the base bundle?
+
+## Next Steps
+1. Align backlog item **B-01** with this boundary and break down implementation tasks.
+2. Provide type sketches (TypeScript or JSDoc) for the exported interfaces.
+3. Schedule design review with partner teams to validate packaging expectations.

--- a/DOCS/TELEMETRY_PRIVACY_AND_CONSENT_GUIDE.md
+++ b/DOCS/TELEMETRY_PRIVACY_AND_CONSENT_GUIDE.md
@@ -1,0 +1,116 @@
+# Telemetry Privacy & Consent Guide
+
+This guide captures the privacy, consent, and data minimization practices that govern telemetry usage across the Adaptive Interface Engine and associated SDK deliverables.
+
+## Objectives
+- Provide clear default classifications for emitted telemetry so partners understand when explicit consent is required.
+- Describe how to gate analytics/biometric streams and expose audit trails for compliance reviews.
+- Outline integration hooks for partner teams to extend consent flows and hardware adapter lifecycle events.
+
+## Telemetry Classifications
+The `ProductTelemetryHarness` now tags every event with a classification before dispatch. Default mappings:
+
+| Classification | Description | Consent Default |
+|----------------|-------------|-----------------|
+| `system` | Operational health, adapter lifecycle, SDK boot events. | Allowed |
+| `interaction` | Real-time adaptive focus/gesture streams required for UI responsiveness. | Allowed |
+| `analytics` | Monetization, layout strategy, and design activation metrics. | Blocked until consent |
+| `biometric` | Physiological streams (stress, heart rate, temperature). | Blocked until consent |
+| `compliance` | Schema validation issues, consent updates, audit reporting. | Allowed |
+
+Partners can append custom rules via `registerClassificationRule` or override defaults during SDK bootstrap (`telemetry.defaultConsent`).
+
+## Consent Lifecycle
+- `updateTelemetryConsent(map, metadata)` toggles any classification at runtime. The harness logs every change under `privacy.consent.updated` for audit review and exposes a snapshot via `getTelemetryConsent()`.
+- Events that lack consent are dropped. The harness writes a `privacy.event.blocked` audit record containing the event name and classification so teams can surface consent dialogs or fallback UI.
+- Identity calls default to the `system` classification. Pass `{ classification: 'analytics' }` to `identify` if identity is tied to analytics consent.
+
+### Audit Trail
+Call `telemetry.getAuditTrail()` (or `engine.getTelemetryAuditTrail()` via the SDK) to retrieve the rolling window (default 200 entries) of compliance events. The array includes timestamps, payload metadata, and the classification associated with each entry.
+
+### Compliance Vault Provider
+Use `ComplianceVaultTelemetryProvider` when compliance teams need a persisted export of consent changes and schema issues. The provider accepts a custom storage adapter (defaulting to `localStorage` or in-memory fallback), captures both telemetry events and audit log entries, and exposes `getRecords()`, `clear()`, `flush()`, and `whenReady()` helpers. The wearable designer demo now registers the vault by default, surfaces consent toggles, and lets reviewers download the captured JSON log. Partners can supply remote persistence by wiring one of the storage adapters below:
+
+- `createSignedS3StorageAdapter` – requests a pre-signed S3 URL from a signing endpoint, uploads the JSON payload, and optionally deletes prior exports.
+- `createLogBrokerStorageAdapter` – batches audit entries to a log or compliance broker endpoint via HTTP POST.
+
+These adapters ship under `src/product/telemetry/storage/RemoteStorageAdapters.js` and can be customized with bespoke `fetch` implementations, serialization strategies, and error hooks.
+
+#### Retention & Encryption Controls
+
+- **Retention metadata baked into every export.** Both adapters now accept a `retentionPolicy` option (string identifiers such as `"regulatory"`, millisecond durations, or structured objects) that is normalized and injected into signing requests, upload headers (`x-amz-meta-retention`), and broker headers (`x-retention-policy`). Compliance teams can rely on the vault stream to include the declared retention window for downstream deletion workflows.
+- **Encryption hooks for partner KMS/HSM pipelines.** Provide `encryptPayload(payload, context)` to either adapter to transform the serialized audit package before transport. The hook can return a raw encrypted string/ArrayBuffer or an object describing the encrypted body, `contentType`, additional headers (e.g., `x-amz-server-side-encryption`), and metadata (surfaced back to the signing service and vaulted audit log). This enables customer-managed keys, HSM signatures, or attestation tokens without forking the adapters.
+- **Metadata surfaced for auditing.** The signing call receives any encryption metadata so downstream services can stamp key IDs or envelope references alongside the retention policy. `onUploadComplete` now reports both `retentionPolicy` and `encryptionMetadata` so compliance dashboards can show the exact controls applied to every export.
+
+Recommended defaults:
+
+1. **Biometric/health data:** `retentionPolicy: { strategy: 'timeboxed', maxAgeMs: 30 * 24 * 60 * 60 * 1000 }` plus an encryption hook that wraps payloads with AES-GCM via customer KMS.
+2. **Analytics only:** `retentionPolicy: 'retain-until-deleted'` with optional signing metadata (no encryption required if data is anonymized).
+3. **Regulated markets (HIPAA/GDPR):** Require encryption hooks, log broker signing headers, and periodic export verification using `telemetry.getAuditTrail()` vs. persisted vault records.
+
+See [`DOCS/REMOTE_STORAGE_ENCRYPTION_TEMPLATES.md`](./REMOTE_STORAGE_ENCRYPTION_TEMPLATES.md) for concrete AES-GCM/KMS wrapper examples and envelope metadata guidance you can hand to partner engineering teams.
+
+#### Request Signing Middleware
+
+- **Baseline middleware.** `ProductTelemetryHarness` now exposes `registerRequestMiddleware` (surfaced via `AdaptiveInterfaceEngine.registerTelemetryRequestMiddleware`) so partners can enforce signing/authorization logic on every provider flush. Use `createRequestSigningMiddleware` when you need a structured payload containing method, endpoint, timestamp, event digest, and prior metadata for HMAC/KMS signing services.
+- **Provider expectations.** Outbound providers (e.g., `HttpTelemetryProvider`, remote storage adapters) must implement `registerRequestMiddleware` and execute middleware before shipping payloads. This ensures license checks, consent state, and encryption metadata flow through partner signing services before any network hop.
+- **Audit propagation.** Middleware results can append headers, override endpoints, or attach `metadata` (e.g., key IDs, signature algorithms). The compliance vault captures this metadata through provider audit hooks so export reviewers can confirm which signature path approved each batch.
+
+### License Validation & Feature Gating
+
+- **Centralized license state.** `createAdaptiveSDK` now instantiates (or accepts) a `LicenseManager` that validates license keys, orchestrates custom validators, and exposes a status history. The telemetry harness consumes this manager and blocks `identify`/`track` calls whenever the license is missing, expired, or rejected, recording `compliance.license.blocked` audit entries for downstream review.【F:src/product/licensing/LicenseManager.js†L1-L189】【F:src/product/ProductTelemetryHarness.js†L1-L240】
+- **Bootstrap options.** Pass `license` or `licenseManager` into `createAdaptiveSDK` to preload license details, validators, and auto-validation behavior. The factory now returns helpers—`setLicense`, `validateLicense(context)`, `getLicenseStatus()`, `getLicenseHistory()`, `getLicenseAttestationHistory()`, `registerLicenseAttestationProfile()`, `getLicenseAttestationProfiles()`, `setDefaultLicenseAttestationProfile()`, `setLicenseAttestorFromProfile()`, `setLicenseAttestor()`, `requestLicenseAttestation()`, and `onLicenseStatusChange()`—so partner shells can refresh entitlements, observe live status updates, or trigger remote attestation checks during startup flows.【F:src/core/AdaptiveSDK.js†L1-L210】
+- **Remote attestation pipeline.** Provide `license.attestor` (or top-level `licenseAttestor`) configuration to instantiate a `RemoteLicenseAttestor` with attestation, revocation, and entitlement endpoints. You can register reusable profiles via `licenseAttestationProfiles`/`registerLicenseAttestationProfile()` or import curated packs (`licenseAttestationProfilePackId`, `licenseAttestationProfilePacks`, or `registerLicenseAttestationProfilePack()`) from the catalog so commercialization teams ship enterprise/studio/indie defaults without hand-assembling endpoints. The telemetry harness subscribes to attestation events and records `compliance.license.attestation`, `compliance.license.attestor_error`, `system.license.attestation_scheduled`, and `system.license.attestation_profile_pack_registered` audit entries, ensuring compliance dashboards track every remote check, scheduling decision, and pack registration.【F:src/product/licensing/RemoteLicenseAttestor.js†L1-L253】【F:src/product/licensing/LicenseAttestationProfileRegistry.js†L1-L172】【F:src/product/licensing/LicenseAttestationProfileCatalog.js†L1-L302】【F:src/product/ProductTelemetryHarness.js†L1-L487】
+- **Feature gating.** `LicenseManager.requireFeature(feature)` throws when entitlements are missing. Use this within optional modules (e.g., haptic packs) to deliver tier-specific upsells while ensuring telemetry remains compliant if a customer downgrades mid-session.【F:src/product/licensing/LicenseManager.js†L155-L189】
+
+### Reusable Consent Panel Component
+The consent UI inside `wearable-designer.html` now uses `createConsentPanel` (see `src/ui/components/ConsentPanel.js`). The component accepts consent options, telemetry hooks, and compliance vault accessors, rendering:
+
+1. Toggle controls for each classification with automatic synchronization to the current consent snapshot.
+2. A consent status summary listing enabled/disabled classifications and audit entry counts.
+3. A compliance log preview with timestamped events.
+4. A download action that exports the captured vault records.
+
+Partners can reuse the component inside plug-ins or dashboards by passing their own DOM container, consent callbacks, and telemetry getters. Use `createAdaptiveSDK({ consentOptions }).createConsentPanel({ container, ... })` when bootstrapping the SDK to ensure default consent copy stays synchronized across surfaces. The component also exposes `handleConsentDecision` so external workflows (e.g., server acknowledgements) can drive UI updates.
+
+## Sensor Validation Feedback
+The `SensoryInputBridge` now publishes schema issues through three surfaces:
+1. `sensoryBridge.setValidationReporter(fn)` – synchronous callback invoked whenever validation issues occur.
+2. `sensoryBridge.getValidationLog()` – retrieves the rolling buffer of validation events.
+3. `telemetry.recordSchemaIssue(issue)` – automatically invoked by `AdaptiveInterfaceEngine` to emit a `sensors.schema_issue` event with `compliance` classification.
+
+Partners should use these signals to tie consent prompts or trust indicators back to raw hardware validation failures.
+
+## Hardware Adapter Lifecycle
+Sensor adapters can now implement optional `connect`, `disconnect`, and `test` methods. Use the new SDK wrappers to manage lifecycle state:
+
+```js
+const sdk = createAdaptiveSDK();
+
+sdk.registerSensorAdapter('neural-intent', neuralAdapter);
+await sdk.connectSensorAdapter('neural-intent');
+const status = sdk.sensoryBridge.getAdapterState('neural-intent'); // { status: 'connected' }
+```
+
+`AdaptiveInterfaceEngine` emits telemetry events for registration, connection success, and failure paths (`sensors.adapter.*`), allowing downstream compliance tooling to verify adapter readiness before collecting biometric data.
+
+## Implementation Checklist
+- [x] Classify all telemetry events and gate analytics/biometric payloads behind consent.
+- [x] Record consent changes and schema violations in an auditable log.
+- [x] Expose adapter lifecycle hooks via the SDK and emit lifecycle telemetry.
+- [x] Integrate UI consent prompts inside `wearable-designer.html` and expose a reusable component for partner plug-ins. *(Demo shell now packages the consent experience via `createConsentPanel`; partner kits can import the same module.)*
+- [x] Provide remote persistence adapters (`createSignedS3StorageAdapter`, `createLogBrokerStorageAdapter`) so compliance teams can stream vault data into approved storage.
+- [x] Add telemetry request signing middleware and harness/provider APIs to enforce outbound authentication.
+- [x] Gate telemetry on active licenses and expose audit events for blocked usage through `LicenseManager` integration.
+- [x] Wire remote attestation, revocation checks, and entitlement sync into the license manager/telemetry harness so audit logs capture each remote validation.
+- [x] Publish curated license attestation packs and surface pack registration APIs/audit events through the telemetry harness and SDK.
+- [x] Surface commercialization coverage summaries via `LicenseCommercializationReporter` so compliance dashboards can audit pack adoption, SLA ranges, and default profile changes straight from the telemetry harness/SDK.
+- [x] Capture commercialization KPI snapshots + exports via `LicenseCommercializationSnapshotStore`, ensuring snapshot contexts omit license keys when `dataMinimization.omitLicense` is enabled, redacting `licenseKey` automatically in the remote storage adapters, and providing JSON/CSV exports for BI teams.【F:src/product/licensing/LicenseCommercializationSnapshotStore.js†L1-L238】【F:src/product/ProductTelemetryHarness.js†L468-L534】【F:src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js†L1-L142】
+- [ ] Extend schema validation reports to persist in long-term storage with partner-provided retention policies.
+
+## Next Steps
+1. Align with legal/privacy stakeholders on retention windows and cross-border data transfer policies for compliance telemetry.
+2. Harden the remote storage adapters with encryption-at-rest options and signed deletion flows aligned to partner policies (iterate on the new templates after stakeholder review).
+3. Provide partner-ready provider configurations that consume `registerTelemetryRequestMiddleware` and `createRequestSigningMiddleware`.
+4. Socialize the new attestation profile catalog (payload templates, SLA defaults, registration examples) with partner onboarding teams and collect feedback for healthcare/education-specific packs.
+5. Evaluate TypeScript adoption for `ProductTelemetryHarness` to surface classifications and consent APIs at compile time.

--- a/DOCS/TESTING_STACK_EVALUATION.md
+++ b/DOCS/TESTING_STACK_EVALUATION.md
@@ -1,0 +1,51 @@
+# Adaptive Engine Testing Stack Evaluation
+
+## Goals
+- Provide automated coverage for the adaptive pipeline without exceeding lightweight container limits.
+- Maintain compatibility with headless CI providers and partner SDK contributors.
+- Support future visual regression checks for projection-based interfaces.
+
+## Options Assessed
+
+### 1. Vitest + jsdom
+- **Pros:**
+  - Lightweight dependency footprint; no system-level browser binaries required.
+  - Fast feedback loop for unit tests covering `SensoryInputBridge`, layout strategies, and telemetry providers.
+  - Built-in mocking utilities suitable for sensor stream simulations.
+- **Cons:**
+  - Limited fidelity for actual rendering or 4D projection previews.
+  - Requires manual wiring for accessibility or visual assertions.
+- **Use Cases:** Core unit/integration coverage for modularized layout/telemetry logic; contract tests for SDK APIs.
+
+### 2. Playwright (current default)
+- **Pros:**
+  - High-fidelity browser automation for demo shells and partner plug-in prototypes.
+  - Supports screenshot baselines and cross-browser compatibility testing.
+- **Cons:**
+  - Installation requires ~500 MB of OS packages (`npx playwright install-deps`) which exceeds current container constraints.
+  - Slower execution; overkill for logic-focused modules pre-UI hardening.
+- **Use Cases:** Targeted smoke suites once SDK stabilizes and CI environment accommodates heavier dependencies.
+
+### 3. WebdriverIO + Chromium Snapshot
+- **Pros:**
+  - Configurable to use system Chromium already present in some CI images.
+  - Plugin ecosystem for visual diffing.
+- **Cons:**
+  - More configuration overhead; duplicates effort if we eventually standardize on Playwright.
+  - Still requires maintaining browser binaries for deterministic runs.
+- **Use Cases:** Backup option if Playwright licensing or footprint remains unresolved.
+
+## Recommendation
+1. **Adopt Vitest + jsdom as the primary test runner for Phase 1** to unlock unit coverage of modular strategies and providers without waiting on OS-level dependencies.
+2. **Retain Playwright tooling in the repo but mark it optional** until we have an approved container image or CI tier that bundles the required packages.
+
+## Implementation Status (2025-10-09 Update)
+- Vitest + jsdom dependencies added to `package.json`; configuration lives in `vitest.config.js`.
+- Baseline suites cover `SpatialLayoutSynthesizer` and `ProductTelemetryHarness` under `tests/vitest/`.
+- Playwright scripts remain callable via `npm run test:e2e*`; browser installation is still deferred pending blocker B-07.
+3. **Document a staged testing strategy**: unit (Vitest), contract (Vitest + lightweight DOM), high-fidelity (Playwright/manual) so partners understand expectation levels.
+
+## Next Steps
+- Add Vitest, jsdom, and supporting typings to `package.json` devDependencies.
+- Draft initial test skeletons for `SpatialLayoutSynthesizer` strategies and `TelemetryProvider` registry.
+- Update the development tracker environment checklist to reflect the two-tier testing plan and unblock B-07 decision.

--- a/PLANNING/ADAPTIVE_ENGINE_TRACKER.md
+++ b/PLANNING/ADAPTIVE_ENGINE_TRACKER.md
@@ -1,0 +1,94 @@
+# Adaptive Engine Development Tracker
+
+This tracker translates the architecture review into actionable engineering work. Update it with every change to maintain transparency and ensure we stay aligned with commercialization goals.
+
+## How to Use
+1. **Capture work items** in the Backlog with clear acceptance criteria.
+2. **Promote items** into the Current Sprint when actively working on them and log daily notes.
+3. **Close items** in the Completed section with links to commits/PRs and recorded learnings.
+4. **Review blockers** during async/weekly check-ins and document decisions here.
+
+## Environment & Tooling Checklist
+- [x] Node.js dependencies installed via `npm install` (Playwright for browser automation).【3edf52†L1-L5】
+- [x] Vitest + jsdom stack configured for Phase 1 unit coverage. *(Configured 2025-10-09 with `vitest.config.js` + baseline layout/telemetry tests.)*
+- [ ] Playwright browsers installed (`npx playwright install`). *(Remains optional until Vitest baseline is stable or CI image includes OS deps.)*
+- [x] Python3 available for static server (`python3 -m http.server`).
+- [ ] Optional: Add `zod` and `typescript` once schema validation and type definitions are prioritized.
+
+## Backlog
+| ID | Title | Description | Owner | Status | Target Milestone |
+|----|-------|-------------|-------|--------|------------------|
+| B-01 | Define SDK boundary | Design the public API surface for `AdaptiveInterfaceEngine`, sensor adapters, and telemetry providers. | Core Team | ⏳ In Progress | Phase 1 |
+| B-02 | Sensor schema validation | Introduce runtime schemas (likely Zod) and adapters for gaze, neural, biometrics, ambient inputs. | Core Team | ✅ Done | Phase 1 |
+| B-03 | Layout strategy modularization | Break the monolithic `SpatialLayoutSynthesizer` into interchangeable strategies with tests. | Core Team | ✅ Done | Phase 1 |
+| B-04 | Telemetry provider interface | Implement provider pattern + privacy controls to replace `ProductTelemetryHarness`'s console fallback. | Core Team | ✅ Done | Phase 1 |
+| B-05 | Demo shell modularization | Rebuild `wearable-designer.html` as documented UI components and integration samples. | Experience Team | Planned | Phase 3 |
+| B-06 | Partner integration starter kits | Create Figma/Webflow plugin scaffolds referencing the SDK boundary. | Platform Team | Planned | Phase 3 |
+| B-07 | Environment automation plan | Decide on lightweight browser automation stack or pre-baked Playwright image to unblock CI. | Core Team | ✅ Done | Phase 1 |
+| B-08 | Layout/telemetry modularization brief | Capture target module structure + acceptance for strategy/provider refactor. | Core Team | ✅ Done | Phase 2 |
+| B-09 | Privacy & consent hardening | Document telemetry data classifications and provider consent requirements. | Core Team | ✅ Done | Phase 1 |
+| B-10 | Strategy pack starter kits | Package reference strategies/annotations for partner SDK add-ons. | Platform Team | Planned | Phase 2 |
+| B-11 | Consent UI components | Build reusable consent toggles for demos and partner plug-ins. | Experience Team | ✅ Done | Phase 2 |
+| B-12 | Compliance telemetry export | Persist validation/audit events to partner-approved storage. | Core Team | ✅ Done | Phase 2 |
+| B-13 | License attestation pipeline | Integrate remote validation, revocation checks, and entitlement sync for the license manager. | Core Team | ✅ Done | Phase 2 |
+| B-14 | Commercialization remote persistence | Provide commercialization snapshot storage adapters, async hydration, and demo instrumentation. | Core Team | ✅ Done | Phase 2 |
+| B-15 | Adaptive blueprint visualization | Ship reusable layout blueprint renderer + demo instrumentation with export hooks so partners can inspect adaptive surfaces. | Experience Team | ✅ Done | Phase 2 |
+| B-16 | Projection field composer | Deliver 4D projection composer + scenario simulator with SDK/types and wearable demo wiring so partners can visualize gesture/attention flows. | Experience Team | ✅ Done | Phase 2 |
+
+## Current Sprint (Phase 0)
+| ID | Task | Acceptance Criteria | Status | Notes |
+|----|------|---------------------|--------|-------|
+| S0-01 | Document architecture baseline | Architecture review published with current inventory, risk analysis, and refactor themes. | ✅ Done | See `DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md`. |
+| S0-02 | Stand up development tracker | Central tracker document (this file) with backlog, sprint view, and environment checklist. | ✅ Done | Initial backlog seeded from architecture review recommendations. |
+| S0-03 | Align README with reality | Update README messaging to distinguish between demo capabilities and planned SDK roadmap. | ✅ Done | README updated in Phase 0 baseline; keep monitoring for drift. |
+| S0-04 | Core viability assessment | Produce deep-dive evaluation on suitability of current stack as commercial core. | ✅ Done | See `DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md`. |
+| S0-05 | Environment readiness audit | Run dependency sync, document blockers, and log next steps. | ✅ Done | Dependencies aligned (Vitest + jsdom) and Playwright deferred; blockers tracked under B-07. |
+| S0-07 | Establish Vitest baseline coverage | Add Vitest + jsdom dependencies, config, and initial unit tests for adaptive modules. | ✅ Done | See `vitest.config.js` and `tests/vitest/*`. |
+| S0-08 | Draft SDK boundary proposal | Capture initial API surface, DI model, and packaging plan for commercialization. | ✅ Done | See `DOCS/SDK_BOUNDARY_PROPOSAL.md`. |
+| S0-09 | Outline wearable designer migration plan | Create checklist for porting the demo shell onto modular runtime interfaces. | ✅ Done | See `PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md`. |
+| S0-06 | Testing stack recommendation | Document comparative analysis and recommendation for lightweight automated testing. | ✅ Done | See `DOCS/TESTING_STACK_EVALUATION.md`. |
+
+## Completed Log
+| Date | Item | Outcome | Follow-ups |
+|------|------|---------|------------|
+| 2025-10-24 | B-15 | Adaptive blueprint renderer exported through SDK types, demo blueprint metrics/export UI shipped, and baseline Vitest coverage added. | Break renderer into shareable UI component kit during demo modularization (B-05) and publish partner blueprint usage guide. |
+| 2025-10-24 | B-16 | Projection field composer + scenario simulator exposed through the SDK, wearable demo, and Vitest suites so partners can inspect real-time vs. scripted projection flows. | Publish projection scenario authoring guide and port the composer into modular UI components during B-05. |
+| 2025-10-25 | B-17 | Headless environment bootstrap delivered: engine/gallery/export gating, SDK `environment` config, type updates, and headless Vitest coverage unblock CI/partner automation. | Add injectable visualizer facades + headless demo modules to B-05 and document environment guidelines in README/test playbooks. |
+| 2025-10-23 | B-14 | Commercialization remote storage adapters, async hydration, and wearable demo instrumentation shipped. | Add retry/backoff to remote adapters and connect nightly KPI exports to downstream partner BI ingestion. |
+| 2025-10-22 | B-13 | Commercialization KPI snapshot store + SDK/export hooks delivered with wearable demo controls. | Wire external persistence (vault/S3) and schedule nightly KPI exports ahead of partner beta. |
+| 2025-10-21 | B-13 | Commercialization analytics bridge delivered with commercialization summaries exposed via telemetry/SDK and wearable demo coverage panel. | Wire summary feed into partner dashboards and persist periodic snapshots for KPI reporting. |
+| 2025-01-25 | S0-01 | Architecture review delivered and checked into repository. | Feed tasks into backlog items B-01..B-05. |
+| 2025-01-25 | S0-02 | Development tracker established with environment checklist and backlog. | Maintain as source of truth for prioritization. |
+| 2025-10-07 | S0-03 | README alignment verified; messaging matches prototype reality. | Monitor marketing collateral for scope creep. |
+| 2025-10-07 | S0-04 | Core viability assessment published for stakeholder review. | Feed recommendations into Phase 1/2 planning docs. |
+| 2025-10-08 | S0-06 | Testing stack recommendation documented with path forward. | Schedule dependency update task and Vitest baseline implementation. |
+| 2025-10-09 | S0-05 | Environment readiness audit completed with Vitest deps installed; Playwright optional. | Continue tracking automation decision under B-07. |
+| 2025-10-09 | S0-07 | Vitest baseline coverage delivered with layout/telemetry suites. | Expand coverage to additional strategies/providers as they land. |
+| 2025-10-09 | S0-08 | SDK boundary proposal authored to guide Phase 1 implementation. | Review with partner tooling teams. |
+| 2025-10-09 | S0-09 | Wearable designer migration checklist captured for experience team coordination. | Revisit after SDK boundary solidifies. |
+| 2025-10-10 | B-03 | Layout strategies + annotations extracted into modular registry with Vitest coverage. | Extend to partner-specific strategy packs. |
+| 2025-10-10 | B-04 | Telemetry provider interface + SDK factory implemented with demo adoption. | Add privacy review + provider catalog. |
+| 2025-10-11 | B-02 | Sensor schema registry + validation integrated into sensory bridge with Vitest coverage. | Layer consent prompts + hardware adapter lifecycle into follow-up tasks. |
+| 2025-10-12 | B-09 | Telemetry consent classifications, audit logging, and sensor lifecycle hooks documented and implemented. | Ship consent UI components (B-11) and persistence plan (B-12). |
+| 2025-10-13 | B-11/B-12 | Wearable designer updated with consent toggles + compliance export provider to exercise the telemetry vault. | Package UI into reusable components and define partner storage adapters/policies. |
+| 2025-10-14 | B-11/B-12 | Consent panel extracted into reusable component; remote compliance storage adapters (S3 presign, log broker) implemented with documentation and tests. | Monitor partner adoption feedback, add encryption + retention enforcement to remote adapters. |
+| 2025-10-15 | B-07 | Environment automation plan documented with container-friendly Playwright guidance and CI action items. | Implement smoke-tagged Playwright specs and wire caching into CI. |
+| 2025-10-16 | B-07/B-01 | Consent/compliance Playwright smoke spec landed; telemetry request middleware and signing helper readied for SDK boundary, plus encryption templates for remote adapters. | Wire smoke lane + cache into CI, publish provider configs, and validate encryption guidance with compliance/legal stakeholders. |
+| 2025-10-17 | B-01 | License manager integrated into SDK bootstrap + telemetry harness to enforce monetization gates and audit blocked usage. | Implement remote attestation, revocation handling, and entitlement synchronization (tracked as B-13). |
+| 2025-10-18 | B-13 | Remote attestation pipeline delivered with scheduling, telemetry audit events, and entitlement sync surfaced through the SDK + harness. | Document partner endpoint expectations, fail-open SLAs, and packaging guidance for attestor configuration. |
+| 2025-10-19 | B-13 | License attestation profile registry integrated with telemetry harness + SDK so curated endpoint/SLA catalogs can be packaged for partners. | Publish partner profile documentation, capture SLA defaults per segment, and wire curated packs into onboarding materials. |
+| 2025-10-20 | B-13 | License attestation profile catalog shipped with enterprise/studio/indie packs, SDK pack registration APIs, and documentation/audit updates. | Gather partner feedback on catalog coverage, plan healthcare/education packs, and connect catalog metadata to commercialization dashboards. |
+
+## Blockers & Risks
+- **Documentation credibility:** Marketing-heavy messaging conflicts with current engineering readiness. Resolving S0-03 is critical for stakeholder trust.
+- **Strategy validation:** Partner-specific layout strategy packs still need authoring and validation against real wearable surfaces.
+- **Environment footprint:** Playwright OS dependencies exceed lightweight container limits. Chromium-only smoke spec exists; next up is wiring cache + smoke lane into CI.
+- **Telemetry/privacy follow-up:** Consent gating exists, but signed provider integrations and long-term audit storage policies still need definition (focus shifts to B-01 follow-ups, remote adapter hardening, and license attestation under B-13).
+- **License validation maturity:** Remote attestation, revocation checks, entitlement sync, and curated attestation packs now exist; remaining work focuses on partner-specific pack expansion, SLA benchmarking, and support tooling.
+- **Commercialization analytics persistence:** Remote storage adapters and async hydration shipped; next step is layering retries/backoff and connecting scheduled KPI jobs to downstream partner BI pipelines.
+- **Dependency security:** `npm install` reports four moderate vulnerabilities; schedule audit once SDK packaging stabilizes.
+
+## Next Review
+- **Owner:** Core Team Lead
+- **Date:** 2025-10-20
+- **Agenda:** Verify Playwright smoke lane wiring in CI, lock SDK boundary acceptance criteria (B-01) around request middleware, and secure sign-off on the new encryption template roadmap for remote adapters.

--- a/PLANNING/ENVIRONMENT_AUTOMATION_PLAN.md
+++ b/PLANNING/ENVIRONMENT_AUTOMATION_PLAN.md
@@ -1,0 +1,43 @@
+# Environment Automation Plan
+
+## Purpose
+Define a pragmatic testing automation path that balances lightweight container environments with the need for high-fidelity wearable UI validation. This plan closes backlog item **B-07** by specifying tooling lanes, configuration requirements, and follow-up tasks for CI enablement.
+
+## Testing Lanes
+| Lane | Tooling | Primary Goal | Execution Notes |
+|------|---------|--------------|-----------------|
+| **Unit/contract** | `vitest` + `jsdom` | Fast feedback on adaptive layout, telemetry, and consent logic. | Runs via `npm test` inside any Node 18+ environment. Uses pure JS—no browser dependencies. |
+| **Smoke UI** | Playwright (Chromium-only) | Validate wearable demo shell wiring, consent UI, and audit downloads. | Trigger manually or in CI with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` when running inside slim containers. Uses pre-bundled browsers or shared cache. |
+| **Visual/regression** | Playwright (full matrix) | Capture screenshots/video for wearable shells, pattern packs, and partner plug-ins. | Runs inside dedicated CI jobs backed by the Playwright Docker image (`mcr.microsoft.com/playwright:v1.55.0-focal`). Optional for MVP but required before GA. |
+
+## Configuration Matrix
+| Scenario | Command | Dependencies |
+|----------|---------|--------------|
+| Local dev (unit) | `npm test` | Node 18+, no browsers. |
+| Local dev (smoke) | `npm run test:e2e:smoke` | Requires one-time `npx playwright install`. |
+| Container/CI smoke | `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm run test:e2e:smoke` | Supply Chromium via cached `/ms-playwright` volume or Docker image. |
+| Full visual regression | GitHub Actions/Buildkite job using Playwright image | Access to >4 GB disk and system dependencies. |
+
+## Action Items
+1. **Cache Playwright browsers in CI.** Mount `/ms-playwright` as a persistent workspace volume so `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` still finds cached binaries. GitHub Actions example:
+   ```yaml
+   - uses: actions/cache@v4
+     with:
+       path: ~/.cache/ms-playwright
+       key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+   - run: npx playwright install chromium
+   ```
+2. **Add Chromium-only smoke job.** Configure CI to run `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm run test:e2e:smoke` after `npm test`. Tag lightweight scenarios with `@smoke` (see `tests/consent-compliance-smoke.spec.js`) and expand coverage as new UI modules stabilize.
+3. **Adopt Playwright Docker image for full runs.** Provision a weekly or release-branch job that uses `mcr.microsoft.com/playwright:v1.55.0-focal` and executes the full suite (Chromium + WebKit + Firefox) once OS dependency approvals land.
+4. **Monitor footprint.** Track install size and execution time in the development tracker; adjust caching strategy or split jobs if Playwright continues to strain the base container.
+
+## Status
+- ✅ Vitest + jsdom lane operational (`npm test`).
+- ✅ Automation plan approved (this document) with clear smoke vs. visual expectations.
+- ✅ Playwright smoke spec authored (`tests/consent-compliance-smoke.spec.js`) and tagged `@smoke` for CI gating.
+- 🔄 Pending: Integrate browser cache + container image selection into CI configs.
+
+## Next Review
+- **Owner:** Core Team Lead
+- **Date:** 2025-10-20
+- **Agenda:** Verify smoke job integration, decide on browser cache location, and assess whether remote rendering partners require additional automation hooks.

--- a/PLANNING/SESSION_LOG.md
+++ b/PLANNING/SESSION_LOG.md
@@ -1,0 +1,426 @@
+# Adaptive Engine Work Session Log
+
+## 2025-10-07 – Session 01
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Environment readiness check for adaptive development.
+  - Deep viability assessment of adaptive stack as commercial core.
+  - Planning updates to ensure ongoing documentation and tracking.
+- **Actions Taken:**
+  1. Ran `npm install` to sync Node dependencies (no repo changes committed).
+  2. Attempted `npx playwright install` and `npx playwright install-deps`; aborted due to heavy system package requirements after validating the risk (logged for follow-up).
+  3. Authored the [Adaptive Engine Core Viability Assessment](../DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md) capturing module-level strengths, gaps, and phased refactor strategy.
+  4. Planned new tracker updates to reflect environment blockers and Phase 1 refactor tasks.
+- **Decisions:**
+  - Proceed with refactor (no rewrite) contingent on Phase 1–3 roadmap execution.
+  - Defer full Playwright dependency installation until we evaluate lighter-weight browser automation options or container base images.
+- **Risks/Issues Raised:**
+  - Environment setup requires ~500 MB of OS packages; we need an approved path before making it a standard prerequisite.
+  - Lack of formal SDK boundary remains the top technical blocker for commercialization.
+- **Next Planned Actions:**
+  1. Update `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` with environment blocker status and new sprint/backlog items.
+  2. Draft a modularization brief for layout/telemetry refactor (Phase 2 seeding).
+  3. Evaluate alternative testing stacks (e.g., Vitest + jsdom) before committing to Playwright-deps installation.
+
+## 2025-10-08 – Session 02
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Document lightweight testing stack recommendation to unblock automation planning.
+  - Define modularization blueprint for layout and telemetry layers.
+  - Update tracker artifacts to reflect new decisions and deliverables.
+- **Actions Taken:**
+  1. Authored the [Adaptive Engine Testing Stack Evaluation](../DOCS/TESTING_STACK_EVALUATION.md) recommending Vitest + jsdom for Phase 1 and keeping Playwright optional.
+  2. Produced the [Layout & Telemetry Modularization Brief](../DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md) outlining strategy/provider interfaces and acceptance criteria.
+  3. Updated `PLANNING/ADAPTIVE_ENGINE_TRACKER.md` with the Vitest checklist item, backlog status changes, and new sprint/completed log entries.
+- **Decisions:**
+  - Adopt Vitest + jsdom as the default automated test stack for Phase 1 while deferring Playwright browser installs to optional workflows.
+  - Close backlog item B-08 with the published modularization brief; treat subsequent work as implementation tasks under Phase 2.
+- **Risks/Issues Raised:**
+  - Dependency installation for Vitest still pending; must ensure additions do not conflict with existing Playwright tooling.
+  - Need to socialize modularization plan with partner tooling teams to confirm compatibility with plug-in roadmaps.
+- **Next Planned Actions:**
+  1. Update `package.json` with Vitest/jsdom dependencies and scaffold baseline tests.
+  2. Draft SDK boundary proposal supporting dependency injection model described in the modularization brief.
+ 3. Coordinate with experience team on migration checklist for `wearable-designer.html` once modular interfaces land.
+
+## 2025-10-09 – Session 03
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Execute Vitest + jsdom adoption to unblock adaptive module coverage.
+  - Capture commercialization-facing specs (SDK boundary, migration checklist).
+  - Close out environment readiness follow-ups noted in prior sessions.
+- **Actions Taken:**
+  1. Added Vitest/jsdom dependencies, scripts, and config; authored baseline unit suites for `SpatialLayoutSynthesizer` and `ProductTelemetryHarness`.
+  2. Published the [Adaptive SDK Boundary Proposal](../DOCS/SDK_BOUNDARY_PROPOSAL.md) describing public surface, DI model, and packaging roadmap.
+  3. Created the [Wearable Designer Migration Checklist](WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md) to guide demo refactor activities.
+- **Decisions:**
+  - Marked environment audit complete now that Vitest stack is configured; Playwright remains optional until B-07 resolves.
+  - Began backlog item B-01 with the authored SDK boundary proposal to steer upcoming implementation work.
+- **Risks/Issues Raised:**
+  - `npm install` surfaced four moderate vulnerabilities; schedule follow-up security review once dependency graph stabilizes.
+  - Vitest currently emits deprecation warning about CJS API usage—track for future tooling update.
+- **Next Planned Actions:**
+  1. Extend Vitest coverage to sensor normalization once channel abstractions land.
+  2. Break down B-01 into implementation tickets aligned with the SDK boundary proposal.
+  3. Coordinate with experience team to prioritize wearable designer migration once runtime factory is in place.
+
+## 2025-10-10 – Session 04
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Implement runtime-pluggable layout strategies, annotations, and telemetry providers per modularization brief.
+  - Introduce Adaptive SDK factory for dependency-injected integrations and update wearable demo wiring.
+  - Extend Vitest coverage to validate new strategy/provider registries and data minimization logic.
+- **Actions Taken:**
+  1. Refactored `SpatialLayoutSynthesizer` into strategy/annotation registries with default Focus/Peripheral/Haptic strategies and stress annotations.
+  2. Rebuilt `ProductTelemetryHarness` around provider interfaces (console/http/partner) and shipped the `createAdaptiveSDK` factory consumed by `wearable-designer.html`.
+  3. Updated Vitest suites for layout + telemetry, refreshed README, SDK proposal, modularization brief, tracker, and session log to reflect the new runtime architecture.
+- **Decisions:**
+  - Close backlog items B-03 and B-04; shift upcoming work toward provider privacy review (B-09) and partner strategy packs (B-10).
+  - Use `createAdaptiveSDK` as the canonical bootstrap path for demos and partner plug-ins going forward.
+- **Risks/Issues Raised:**
+  - Need dedicated privacy review before enabling HTTP telemetry provider in production contexts.
+  - Strategy API now supports pluggability; require UX validation to tune defaults for specific wearable modalities.
+- **Next Planned Actions:**
+  1. Draft privacy/consent guidance for telemetry providers (B-09).
+  2. Break B-01 into concrete API docs now that `createAdaptiveSDK` exists.
+  3. Coordinate with experience team on migrating remaining demos to the SDK factory and capturing screenshots for marketing.
+
+## 2025-10-11 – Session 05
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Harden sensory input contracts with runtime schema validation and partner extension hooks.
+  - Extend the SDK boundary to expose schema registration ergonomics.
+  - Update documentation and planning artifacts to reflect the new validation layer and privacy follow-ups.
+- **Actions Taken:**
+  1. Implemented `SensorSchemaRegistry` with default schemas for gaze, neural, biometric, ambient, and gesture inputs plus runtime registration hooks.
+  2. Integrated schema validation into `SensoryInputBridge`, exposed `registerSensorSchema` through `AdaptiveInterfaceEngine`/`createAdaptiveSDK`, and added Vitest coverage for sanitization flows.
+  3. Refreshed README, SDK boundary proposal, architecture review, tracker, and session log to capture the validation milestone and highlight remaining privacy tasks.
+- **Decisions:**
+  - Marked backlog item B-02 complete; follow-up work will focus on consent prompts and hardware adapter lifecycle guidance.
+  - Treat telemetry privacy hardening (B-09) as the next critical documentation deliverable before expanding partner demos.
+- **Risks/Issues Raised:**
+  - Schema validation currently logs to console; need structured reporting for consent/audit purposes.
+  - No TypeScript definitions yet—partners still lack compile-time assurances around sensor payloads.
+- **Next Planned Actions:**
+  1. Author telemetry privacy & consent guidance (B-09) covering provider expectations and schema issue reporting.
+  2. Draft TypeScript/JSDoc definitions for sensor schemas as part of the SDK boundary documentation.
+  3. Prototype hardware adapter lifecycle hooks (connect/disconnect/test) and integrate into the tracker as a new backlog item.
+
+
+## 2025-10-12 – Session 06
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Deliver telemetry consent classifications, audit logging, and compliance guidance (B-09).
+  - Introduce hardware adapter lifecycle hooks and expose them through the SDK.
+  - Seed TypeScript definitions for partner SDK consumers and refresh planning artifacts.
+- **Actions Taken:**
+  1. Enhanced `ProductTelemetryHarness` with event classification rules, consent gating, audit logging, and schema issue reporting.
+  2. Implemented adapter lifecycle management (`connect`/`disconnect`/`test`) inside `SensoryInputBridge`, surfaced helpers via `AdaptiveInterfaceEngine`/`createAdaptiveSDK`, and added Vitest coverage.
+  3. Authored the [Telemetry Privacy & Consent Guide](../DOCS/TELEMETRY_PRIVACY_AND_CONSENT_GUIDE.md), published sensor schema type definitions in `types/adaptive-sdk.d.ts`, and updated tracker/backlog entries (B-09 complete, B-11/B-12 added).
+- **Decisions:**
+  - Treat consent UI components and compliance telemetry persistence as follow-up backlog items (B-11, B-12) targeting Phase 2.
+  - Default telemetry consent to opt-in for analytics/biometric streams to simplify regulatory review.
+- **Risks/Issues Raised:**
+  - Signed provider integrations remain outstanding; HTTP provider currently sends data without auth.
+  - Audit trail retention still in-memory; requires persistence design (B-12).
+- **Next Planned Actions:**
+  1. Prototype consent UI toggles in `wearable-designer.html` aligned with B-11.
+  2. Define telemetry export adapters (S3/log broker) for B-12 and evaluate provider signing approach.
+  3. Continue B-01 by documenting the extended SDK surface (including consent/lifecycle APIs) for partner review.
+
+
+## 2025-10-13 – Session 07
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Deliver a demonstrable consent UI inside the wearable designer to progress backlog item B-11.
+  - Implement a persistence-friendly telemetry provider to advance B-12.
+  - Extend SDK/documentation surfaces so partners can access audit logs and compliance exports.
+- **Actions Taken:**
+  1. Added the Telemetry & Consent panel to `wearable-designer.html`, wiring checkboxes to `updateTelemetryConsent`, refreshing audit summaries, and surfacing a downloadable compliance log.
+  2. Shipped `ComplianceVaultTelemetryProvider` with storage adapter hooks, audit forwarding, and Vitest coverage alongside harness updates that notify providers of audit entries.
+  3. Updated README, telemetry privacy guide, SDK boundary proposal, tracker, and types to reflect the new consent UI flow, vault provider, and `getTelemetryAuditTrail` exposure.
+- **Decisions:**
+  - Marked B-11/B-12 as in progress: demo UX and vault plumbing are ready, but reusable component packaging and partner storage adapters remain open.
+  - Default wearable demo telemetry to enabled state so consent toggles showcase gating immediately.
+- **Risks/Issues Raised:**
+  - Compliance vault currently persists to localStorage/memory; enterprise retention policies and encryption strategies still need to be defined.
+  - Consent UI lives in the demo shell; reusable componentization for plugins is pending.
+- **Next Planned Actions:**
+  1. Extract the consent panel into shareable UI modules and document integration guidance for partner plug-ins.
+  2. Design storage adapters for S3/log brokers with signing/authentication guidance to complete B-12.
+ 3. Capture UX copy/behavior guidelines for consent prompts in the product plan to ensure consistent messaging across surfaces.
+
+## 2025-10-14 – Session 08
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Convert the wearable consent UI into a reusable component for partner plug-ins (B-11).
+  - Deliver remote compliance storage adapters to complete telemetry export persistence (B-12).
+  - Refresh documentation, tracker status, and tests to reflect the new reusable assets.
+- **Actions Taken:**
+  1. Extracted the consent UI into `src/ui/components/ConsentPanel.js`, updated `wearable-designer.html` to consume it, and added Vitest coverage for the component’s lifecycle and download workflow.
+  2. Implemented `createSignedS3StorageAdapter` and `createLogBrokerStorageAdapter`, enhanced the compliance vault to handle async storage, and expanded tests to cover async persistence paths.
+  3. Updated README, telemetry privacy guide, SDK boundary proposal, tracker, session log, and type definitions to surface the reusable consent component and remote storage adapters.
+- **Decisions:**
+  - Marked backlog items B-11 and B-12 complete; future work will harden remote adapters with encryption/retention policies rather than new core features.
+  - Treat `createConsentPanel` as the baseline consent experience for partner kits, ensuring demos and plug-ins stay aligned.
+- **Risks/Issues Raised:**
+  - Remote storage adapters currently rely on partner-provided signing endpoints; lack of standardized encryption could block regulated customers.
+  - Additional telemetry provider signing/authentication remains unresolved (ties back to B-01 scope expansion).
+- **Next Planned Actions:**
+  1. Document encryption and retention requirements for remote storage adapters and engage compliance stakeholders.
+  2. Expand SDK boundary docs to cover provider signing expectations and consent component customization hooks.
+  3. Evaluate CI/browser automation strategy (B-07) now that Vitest coverage spans the new UI component.
+
+## 2025-10-15 – Session 09
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Harden remote compliance storage adapters with explicit retention metadata and encryption hooks.
+  - Expand SDK boundary documentation to cover provider signing, consent customization, and reporting expectations.
+  - Close backlog item B-07 by publishing the environment automation plan for Vitest/Playwright lanes.
+- **Actions Taken:**
+  1. Extended `createSignedS3StorageAdapter` and `createLogBrokerStorageAdapter` with normalized retention policies, encryption payload hooks, metadata propagation, and updated Vitest coverage.
+  2. Updated the Telemetry Privacy & Consent Guide, SDK boundary proposal, README, and type definitions to describe the new retention/encryption controls and consent customization contract.
+  3. Authored the Environment Automation Plan outlining unit vs. smoke vs. visual lanes, CI caching strategy, and next review cadence; marked tracker item B-07 complete and logged the session outcome.
+- **Decisions:**
+  - Require all remote compliance exports to declare a retention strategy and forward encryption metadata for downstream auditing.
+  - Treat request-signing middleware as part of the SDK boundary so partner providers cannot bypass consent/licensing checks.
+  - Adopt Chromium-only Playwright smoke jobs as the interim automation target while full matrix runs remain optional.
+- **Risks/Issues Raised:**
+  - Playwright smoke tags still need to be authored; without them the automation plan cannot be enforced in CI.
+  - Remote adapters rely on partner-provided encryption hooks—need validation templates to ensure consistent implementations.
+- **Next Planned Actions:**
+  1. Author Playwright smoke specs for the consent panel + compliance export flow and tag them `@smoke`.
+  2. Draft encryption template examples (KMS wrapper, envelope metadata) for partner teams adopting the remote adapters.
+  3. Continue SDK boundary hardening by formalizing request signing middleware and publishing example provider configurations.
+
+## 2025-10-16 – Session 10
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Deliver the first Playwright `@smoke` spec for the consent/compliance workflow per the automation plan.
+  - Formalize telemetry request signing middleware so providers can enforce licensed exports.
+  - Package encryption template guidance for remote compliance adapters and update SDK docs accordingly.
+- **Actions Taken:**
+  1. Authored `tests/consent-compliance-smoke.spec.js`, added a Chromium-only `npm run test:e2e:smoke` script, and updated the automation plan/tracker to log the new smoke lane.
+  2. Added request middleware registration to `ProductTelemetryHarness`, extended `HttpTelemetryProvider` to execute middleware, and exposed helper methods through `AdaptiveInterfaceEngine`/`createAdaptiveSDK` with fresh Vitest coverage.
+  3. Published `createRequestSigningMiddleware`, introduced encryption template documentation, and refreshed privacy/SDK boundary guidance plus the session tracker entry.
+- **Decisions:**
+  - Treat request middleware as the canonical path for partner signing/auth layers across all telemetry providers.
+  - Anchor smoke automation on the consent/compliance flow before expanding to broader wearable scenarios.
+- **Risks/Issues Raised:**
+  - CI still needs cached Playwright binaries and scripting to run the new smoke lane.
+  - Encryption templates require review from compliance/legal before being shared with partners.
+- **Next Planned Actions:**
+  1. Wire the Chromium smoke lane into CI using cached browsers per the automation plan.
+  2. Publish provider configuration samples that consume `createRequestSigningMiddleware`.
+  3. Collect stakeholder feedback on the encryption templates and incorporate regulatory requirements.
+
+## 2025-10-17 – Session 11
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Establish license enforcement as part of the SDK boundary and telemetry workflow (B-01 follow-up).
+  - Provide reusable licensing APIs/definitions for partner integrations and commercialization tooling.
+  - Refresh documentation, tracker, and tests to capture the new monetization guardrails.
+- **Actions Taken:**
+  1. Implemented `src/product/licensing/LicenseManager.js` with validator orchestration, history tracking, feature gating, and status subscriptions, plus Vitest coverage for validation, expiry, and feature checks.
+  2. Integrated the license manager into `ProductTelemetryHarness` and `createAdaptiveSDK`, gating `identify`/`track` calls, exposing `setLicense`/`validateLicense`, and updating type definitions and SDK packaging guidance.
+  3. Updated README, architecture review, telemetry privacy guide, SDK boundary proposal, tracker/backlog, and session log to document the new license workflow and queued B-13 attestation follow-up.
+- **Decisions:**
+  - Treat the license manager as part of the Phase 1 SDK surface; remote attestation/entitlement sync moves to new backlog item B-13.
+  - Block telemetry by default when licenses are missing/invalid to avoid unmonetized deployments.
+- **Risks/Issues Raised:**
+  - License validation currently runs locally; remote revocation, tenant entitlements, and customer support tooling still required.
+  - Need provider configuration samples illustrating license-aware onboarding flows for plug-ins.
+- **Next Planned Actions:**
+  1. Prototype remote attestation + revocation checks (B-13) and feed outcomes into telemetry audit trails.
+  2. Document partner onboarding workflow covering license provisioning, renewal, and support escalation.
+  3. Prepare consent/compliance smoke CI integration once license gating is validated end-to-end.
+
+## 2025-10-18 – Session 12
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Deliver the B-13 remote license attestation pipeline with scheduling, revocation checks, and entitlement sync.
+  - Surface attestation history and controls through the Adaptive SDK + telemetry harness for partner integrations.
+  - Update documentation, types, and planning artifacts to reflect the new commercialization milestone.
+- **Actions Taken:**
+  1. Implemented `RemoteLicenseAttestor` with attestation/revocation/entitlement fetches, scheduling, history, and fail-open support, binding it to the license manager and telemetry harness.
+  2. Extended `AdaptiveSDK` and `ProductTelemetryHarness` with attestor configuration, new license helper APIs, and audit wiring; added Vitest coverage for the attestor, harness events, and SDK helpers.
+  3. Documented the attestation workflow across README, SDK boundary proposal, privacy guide, architecture/core assessments, tracker, and session log while marking backlog item B-13 complete.
+- **Decisions:**
+  - Default remote attestation to fail-closed unless integrators explicitly opt into fail-open via configuration.
+  - Treat attestation scheduling metadata (`nextCheckInMs`, `ttlMs`) as the canonical cadence and record audit events for each schedule/error path.
+- **Risks/Issues Raised:**
+  - Need partner endpoint schema docs and SLA definitions for the attestor before external roll-out.
+  - Signed provider integrations remain outstanding; next focus is publishing configuration samples that layer attestation + signing.
+- **Next Planned Actions:**
+  1. Draft partner-facing attestation endpoint profiles (payload/response contracts, retry guidance, SLA expectations).
+  2. Expand telemetry provider samples to combine request signing middleware with attestation metadata.
+  3. Continue wiring the consent/compliance Playwright smoke lane into CI alongside new license checks.
+
+## 2025-10-19 – Session 13
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Package remote license attestation endpoints into reusable profiles for commercialization teams (B-13 follow-up).
+  - Expose profile registration/apply APIs through the telemetry harness and Adaptive SDK surface.
+  - Refresh documentation, types, and planning artifacts to capture the new profile catalog workflow.
+- **Actions Taken:**
+  1. Authored `LicenseAttestationProfileRegistry` and wired it into `ProductTelemetryHarness` and `AdaptiveInterfaceEngine` with audit trails for profile registration, defaults, and applications.
+  2. Extended `createAdaptiveSDK` to accept/register attestation profiles during bootstrap, expose new helper APIs, and updated Vitest suites plus a dedicated registry test.
+  3. Updated README, architecture/core assessments, SDK boundary proposal, telemetry privacy guide, tracker, and type definitions to document the profile registry milestone and partner packaging expectations.
+- **Decisions:**
+  - Treat license attestation profiles as first-class SDK assets so partner teams can ship curated endpoint/SLA bundles without forking the attestor implementation.
+  - Log profile registration/application events in the telemetry audit trail to maintain compliance visibility across deployments.
+- **Risks/Issues Raised:**
+  - Partner-facing documentation for profile schemas, SLA defaults, and retry guidance is still pending.
+  - Need to coordinate monetization catalog persistence so profile metadata aligns with entitlement packaging.
+- **Next Planned Actions:**
+  1. Draft external documentation for attestation profiles (payload templates, SLA expectations, segmentation guidance).
+  2. Bundle sample profile packs for early adopter partners and integrate them into onboarding collateral.
+  3. Continue wiring signed telemetry provider examples that consume both request middleware and attestation profile metadata.
+
+## 2025-10-20 – Session 14
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Package attestation profiles into reusable packs with SDK/bootstrap helpers and partner-facing documentation.
+  - Extend telemetry harness + Adaptive SDK surfaces so packs can be registered/audited alongside individual profiles.
+  - Update commercialization artifacts (README, planning docs, privacy guide) to reflect the new catalog milestone.
+- **Actions Taken:**
+  1. Authored `LicenseAttestationProfileCatalog` with enterprise/studio/indie builders, registration helpers, and documentation plus Vitest coverage.
+  2. Extended `ProductTelemetryHarness`, `AdaptiveInterfaceEngine`, and `createAdaptiveSDK` with pack registration APIs, bootstrap options, and audit events while updating type definitions.
+  3. Added Vitest suites for pack bootstrap/runtime flows, introduced a catalog-focused doc, refreshed SDK/telemetry docs, tracker, and session log.
+- **Decisions:**
+  - Default pack registration applies the pack's default profile unless integrators opt out with `applyDefault: false`.
+  - Catalog defaults favor descriptive SLA metadata (`responseTargetMs`, `availability`, `breachWindowMs`) to simplify compliance dashboards.
+- **Risks/Issues Raised:**
+  - Need partner feedback on whether the initial enterprise/studio/indie packs cover region/tier granularity; healthcare/education packs remain outstanding.
+  - Catalog metadata isn't yet wired into commercialization analytics dashboards.
+- **Next Planned Actions:**
+  1. Gather partner feedback on catalog coverage and prioritize additional packs (healthcare, education, government).
+  2. Connect pack metadata to commercialization dashboards/reporting to visualize entitlement coverage.
+  3. Continue exploring signed provider examples that combine request middleware with pack-driven SLA metadata.
+
+## 2025-10-21 – Session 15
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Translate attestation pack metadata into commercial coverage analytics and surface it through SDK APIs.
+  - Update wearable demo to visualise commercialization coverage for stakeholders.
+  - Refresh documentation, tracker, and planning artifacts with the new analytics bridge.
+- **Actions Taken:**
+  1. Implemented `LicenseCommercializationReporter`, wired it into `ProductTelemetryHarness`/`AdaptiveSDK`, and exposed commercialization summary getters.
+  2. Added commercialization coverage panel to `wearable-designer.html` driven by the new summaries, registering enterprise/studio packs at bootstrap.
+  3. Authored commercialization analytics documentation, updated README/plan/tracker entries, and expanded Vitest coverage (`license-commercialization-reporter.test.js`, harness updates).
+- **Decisions:**
+  - Treat commercialization summaries as first-class telemetry output so partner dashboards avoid duplicating attestation audit logic.
+  - Use SDK callbacks (`telemetry.commercialization.onUpdate`) for live UI updates while persisting follow-up work for long-term storage.
+- **Risks/Issues Raised:**
+  - Need to persist commercialization summaries for longitudinal KPI reporting before exposing them to enterprise portals.
+  - Additional attestation packs (healthcare/education) will require new segment metadata and analytics baselines.
+- **Next Planned Actions:**
+  1. Define persistence strategy (daily snapshots, BI export integration) for commercialization summaries.
+  2. Expand catalog coverage to healthcare/education segments with accompanying analytics metadata.
+  3. Wire commercialization feed into partner dashboards/portal concepts and gather stakeholder feedback.
+
+## 2025-10-22 – Session 16
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Persist commercialization KPI snapshots and expose BI-friendly exports through the SDK.
+  - Upgrade wearable demo UX so stakeholders can capture/export commercialization metrics without code.
+  - Backfill documentation, tracker, and tests to reflect the new commercialization persistence workflow.
+- **Actions Taken:**
+  1. Implemented `LicenseCommercializationSnapshotStore`, integrated it with `ProductTelemetryHarness`/`AdaptiveInterfaceEngine`/`createAdaptiveSDK`, and added scheduling helpers.
+  2. Enhanced `wearable-designer.html` with snapshot controls, KPI delta rendering, and export downloads driven by the new SDK APIs.
+  3. Authored snapshot store Vitest suites, expanded harness/reporter coverage, refreshed commercialization analytics docs, and logged tracker/session updates.
+- **Decisions:**
+  - Enable snapshot capture by default (unless `commercialization.snapshotStore === false`) so telemetry consumers automatically build KPI history.
+  - Surface exports in JSON and CSV formats to support both API-driven dashboards and spreadsheet-driven stakeholder reviews.
+- **Risks/Issues Raised:**
+  - External persistence (vault/S3) still needs to be wired before enterprise rollout; follow-up scheduled under B-13.
+  - KPI exports currently omit healthcare/education pack metadata pending catalog expansion.
+- **Next Planned Actions:**
+  1. Prototype durable storage adapters for commercialization snapshots alongside compliance vault exports.
+  2. Extend attestation pack catalog with healthcare/education metadata wired into KPI summaries.
+  3. Draft partner-facing dashboard examples leveraging the new CSV/JSON exports.
+
+## 2025-10-23 – Session 17
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Ship commercialization remote persistence adapters and async hydration support for partner dashboards.
+  - Demonstrate the remote upload workflow inside the wearable designer experience with KPI-ready logging.
+  - Backfill docs, types, and tests so SDK consumers can rely on the new storage builders.
+- **Actions Taken:**
+  1. Extended `LicenseCommercializationSnapshotStore` with async storage support, `whenReady()`, and storage append/clear hooks; published commercialization snapshot storage adapters (generic + signed S3).
+  2. Wired the wearable designer demo to the new remote storage adapter, added a persistence log UI, redacted license data before uploads, and waited on `whenReady()` for KPI hydration.
+  3. Added Vitest coverage for async storage and S3 adapters, refreshed commercialization analytics/SDK boundary docs, updated README/tracker/session records, and exposed new helpers in the type definitions.
+- **Decisions:**
+  - Default remote commercialization uploads to omit summaries and redact `licenseKey` while allowing partners to opt back in via adapter options.
+  - Promote `whenReady()` as the handshake for dashboards so UI surfaces only render once remote hydration completes.
+- **Risks/Issues Raised:**
+  - Remote adapters still need retry/backoff policies and error telemetry before production rollout.
+  - Nightly export scheduling is documented but the demo uses a shorter cadence; alignment with partner SLAs remains.
+- **Next Planned Actions:**
+  1. Add retry/backoff and failure instrumentation to commercialization remote storage adapters.
+  2. Connect scheduled snapshot exports to downstream partner BI pipelines (S3/log broker destinations).
+  3. Draft partner dashboard examples that consume the remote persistence payloads and highlight KPI trend deltas.
+
+
+## 2025-10-24 – Session 18
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Deliver an adaptive blueprint renderer that visualizes layout synthesis output on the wearable demo canvases.
+  - Expose blueprint exports/metrics in the wearable designer UI so partners can inspect adaptive surfaces without digging into raw layout payloads.
+  - Backfill SDK types/tests/documentation to make the blueprint workflow part of the supported surface.
+- **Actions Taken:**
+  1. Authored `LayoutBlueprintRenderer` with layered canvas rendering, focus highlighting, and monetization-aware component overlays plus the `buildLayoutBlueprint` helper for export payloads.
+  2. Updated `wearable-designer.html` with a dedicated blueprint panel (metrics + zone list), download control, and runtime wiring to the new renderer while instrumenting adaptive update hooks.
+  3. Added Vitest coverage for `buildLayoutBlueprint`, extended SDK type definitions, refreshed README/architecture/product plan docs, and logged tracker/session updates to capture the visualization milestone.
+- **Decisions:**
+  - Treat the blueprint export as a first-class SDK artifact (types + helper) so partner tooling can consume adaptive layouts without instantiating the renderer.
+  - Keep the renderer observing container resize events to stay in sync with future modular demo shells (follow-up under B-05).
+- **Risks/Issues Raised:**
+  - Wearable demo remains a monolithic HTML file; the renderer needs to be packaged as reusable components during the modularization effort.
+  - Blueprint exports currently focus on zone/component summaries; future partner requests may require richer animation timelines or asset references.
+- **Next Planned Actions:**
+  1. Break the blueprint panel into reusable UI modules as part of B-05 (demo modularization).
+  2. Document blueprint payload usage guidelines for partner SDK consumers and design-tool integrations.
+  3. Explore syncing blueprint exports with commercialization analytics so adoption dashboards can correlate layout decisions with monetization KPIs.
+
+## 2025-10-24 – Session 19
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Extend the adaptive visualization stack with a reusable 4D projection-field composer and scenario simulator for wearables.
+  - Instrument the wearable designer with a projection panel, metrics, and scenario controls so stakeholders can compare realtime vs. scripted gesture/attention flows.
+  - Update SDK boundaries, types, docs, and Vitest suites to expose the new projection APIs alongside layout blueprint helpers.
+- **Actions Taken:**
+  1. Implemented `ProjectionFieldComposer` + `ProjectionScenarioSimulator`, wired them into `AdaptiveInterfaceEngine`/`AdaptiveSDK`, and exposed helper APIs for composing/stepping projection frames.
+  2. Refreshed `wearable-designer.html` with a projection canvas stack, metrics, scenario dropdown, and simulation trigger while sharing the composer instance with the SDK.
+  3. Added Vitest coverage for the composer/simulator, documented the new surface across README, architecture review, product plan, tracker, SDK boundary proposal, and types, and logged the milestone.
+- **Decisions:**
+  - Treat projection composition/simulation as first-class SDK exports to unblock partner tooling beyond the demo shell.
+  - Keep realtime rendering as the default view while allowing scenarios to override via `setActiveProjectionScenario` without interfering with adaptive updates.
+- **Risks/Issues Raised:**
+  - Scenario registry still lives in the monolithic demo; modularization (B-05) must break it into reusable UI kits.
+  - Projection context relies on synthesized data until real sensor adapters provide richer metadata.
+- **Next Planned Actions:**
+  1. Author a projection scenario authoring guide and link it from the SDK boundary documentation.
+  2. Package the projection panel into modular UI components during the wearable designer modularization effort (B-05).
+  3. Benchmark projection composer performance on lower-powered wearable hardware targets once adapters become available.
+
+## 2025-10-25 – Session 20
+- **Who:** Core Team Lead (agent)
+- **Focus Areas:**
+  - Harden engine/bootstrap code so automated tests and headless partners can initialize the SDK without browser canvas dependencies.
+  - Guard gallery/preview utilities against missing rendering contexts while keeping wearable demo behaviour intact.
+  - Extend SDK configuration, type definitions, and documentation to surface the new environment options alongside coverage updates.
+- **Actions Taken:**
+  1. Added environment normalization to `VIB34DIntegratedEngine`, gating canvas/UI bootstrapping, gallery/export wiring, and status messaging in headless mode.
+  2. Shielded `GallerySystem` preview rendering from missing `getContext` implementations and tightened `ExportManager` setup for non-DOM environments.
+  3. Plumbed `environment` through `createAdaptiveSDK`, updated type definitions/docs, and expanded Vitest coverage with a headless bootstrap regression case.
+- **Decisions:**
+  - Default to browser mode to preserve current demo behaviour while requiring explicit `environment.mode = 'headless'` for test/server usage to avoid silent feature gaps.
+  - Keep gallery/export facades logging informative warnings when disabled so partner tooling can detect unsupported operations without hard failures.
+- **Risks/Issues Raised:**
+  - Headless mode currently bypasses visualization/export flows entirely; future modular UI work must offer injectable mock visualizers if partners need deterministic renders in CI.
+  - RequestAnimationFrame remains a soft prerequisite for preview loops; additional polyfills may be required for strictly server-side rendering scenarios.
+- **Next Planned Actions:**
+  1. Update wearable demo modularization backlog (B-05) to account for injectable visualizer facades compatible with headless mode.
+  2. Evaluate lightweight canvas polyfills for Node-based regression suites without dragging heavy dependencies into partner builds.
+  3. Document environment configuration guidelines in the README headless/testing section for upcoming partner preview drops.

--- a/PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md
+++ b/PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Wearable Designer Migration Checklist
+
+## Objective
+Transition `wearable-designer.html` from a monolithic prototype into an integration sample that consumes the modular adaptive SDK
+interfaces.
+
+## Pre-Migration Prerequisites
+- [ ] SDK boundary finalized and exported via `createAdaptiveRuntime` factory.
+- [ ] Layout strategies and telemetry providers injectable (Phase 2 deliverables).
+- [ ] Baseline Vitest coverage in place for layout + telemetry modules.
+- [ ] Partner design team reviews migration scope and UI dependencies.
+
+## Migration Tasks
+1. **Bootstrap Integration Layer**
+   - [ ] Replace direct imports with `createAdaptiveRuntime` + dependency map.
+   - [ ] Introduce configuration file for pattern packs and sensor channel wiring.
+2. **Componentize UI Shell**
+   - [ ] Break sections (hero, monetization banners, telemetry console) into reusable Web Components or templated modules.
+   - [ ] Ensure styling tokens map to `DesignLanguageManager` outputs.
+3. **Telemetry & Licensing Hooks**
+   - [ ] Wire consent + license prompts to `ProductTelemetryHarness` provider injection.
+   - [ ] Verify flushing/analytics toggles respect disabled state.
+4. **Testing & Validation**
+   - [ ] Author Vitest integration tests for the new adapter layer (mock sensors + telemetry).
+   - [ ] Schedule manual wearable experience review against the monetization checklist.
+
+## Post-Migration Follow-ups
+- [ ] Update README Quick Start to reference the new modular entry point.
+- [ ] Capture learnings + UI deltas in the development tracker.
+- [ ] Plan product marketing assets demonstrating plug-in pathway.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,72 @@
-# VIB34D Holographic Visualization Engine
+# VIB34D Adaptive Interface Platform (Prototype)
 
-A WebGL-based 4D mathematics visualization system with 4 different rendering engines.
+The VIB34D visualization engine now includes an experimental adaptive layer aimed at wearable, ambient, and projection-first interfaces. The current codebase demonstrates the concept but still requires significant engineering work before it can be marketed as a supported SDK. Start here to understand the available pieces and how we plan to evolve them.
 
-## 🚀 Quick Start
+## 🚀 Quick Start (Concept Demo)
 
 ```bash
 # Clone and navigate
-cd v2-refactored-mobile-fix
+cd vib34d-ultimate-viewer
 
-# Start local server
+# Start local server (no build tooling required)
 python3 -m http.server 8080
 
-# Open in browser
-http://localhost:8080/index-clean.html
+# Open the wearable/ambient demo shell
+http://localhost:8080/wearable-designer.html
 ```
 
-## 🎮 The 4 Systems
+> **Note:** `wearable-designer.html` is a prototype experience that wires the adaptive engine into a marketing-oriented UI. It is not yet packaged as a reusable toolkit.
 
-**🔷 FACETED** - Simple 2D geometric patterns  
-**🌌 QUANTUM** - Complex 3D lattice effects  
-**✨ HOLOGRAPHIC** - Audio-reactive visualizations  
-**🔮 POLYCHORA** - True 4D polytope mathematics  
+> **New:** The demo shell now ships with the reusable `createConsentPanel` experience, downloadable compliance exports powered by `ComplianceVaultTelemetryProvider`, the remote license attestation status feed, a commercialization coverage dashboard powered by the commercialization analytics stack, an adaptive layout blueprint renderer/exporter, **and a 4D projection-field composer**. Use it to trial consent toggles, review the audit stream, monitor attestation outcomes, capture commercialization KPI snapshots, export BI feeds, visualize pack coverage/adoption, preview/download the layout blueprint, and inspect the real-time projection field or scenario simulations that govern gesture/attention holograms before embedding the SDK elsewhere.
 
-Switch between systems using the top navigation buttons. All systems share the same 11-parameter control system.
+## 🧠 Adaptive Architecture Overview
 
-## 📱 Mobile Support
+| Layer | Purpose | Key Files |
+|-------|---------|-----------|
+| Core Runtime | Extends the legacy `VIB34DIntegratedEngine` with adaptive hooks while preserving existing visualizers. | `src/core/AdaptiveInterfaceEngine.js` |
+| Sensory Input | Normalizes gaze, neural, biometric, and ambient signals into semantic channels with schema validation. | `src/ui/adaptive/SensoryInputBridge.js`, `src/ui/adaptive/sensors/SensorSchemaRegistry.js` |
+| Layout Synthesis | Generates intent-driven layout descriptors, motion cues, and color adaptation guidance using pluggable strategies/annotations. | `src/ui/adaptive/SpatialLayoutSynthesizer.js`, `src/ui/adaptive/strategies/*`, `src/ui/adaptive/annotations/*` |
+| Design Language | Maps engine variations to monetizable interface patterns and integration metadata. | `src/features/DesignLanguageManager.js`, `src/ui/adaptive/InterfacePatternRegistry.js` |
+| Telemetry | Classifies events, gates analytics/biometrics behind consent, enforces license activation before dispatch, routes through provider interfaces (console, HTTP, partner, compliance vault), streams audit trails into remote stores, records remote attestation/licensing events with profile-driven attestor orchestration, and now synthesizes commercialization coverage summaries with snapshot persistence/export helpers plus remote KPI storage builders. | `src/product/ProductTelemetryHarness.js`, `src/product/telemetry/*`, `src/product/licensing/LicenseManager.js`, `src/product/licensing/LicenseAttestationProfileRegistry.js`, `src/product/licensing/LicenseAttestationProfileCatalog.js`, `src/product/licensing/LicenseCommercializationReporter.js`, `src/product/licensing/LicenseCommercializationSnapshotStore.js`, `src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js`, `src/product/telemetry/storage/RemoteStorageAdapters.js` |
+| Licensing & Monetization | Centralizes license validation, feature gating, remote attestation, profile registries, curated attestation packs, commercialization analytics, async snapshot hydration helpers, and SDK monetization metadata for downstream integrations. | `src/product/licensing/LicenseManager.js`, `src/product/licensing/RemoteLicenseAttestor.js`, `src/product/licensing/LicenseAttestationProfileRegistry.js`, `src/product/licensing/LicenseAttestationProfileCatalog.js`, `src/product/licensing/LicenseCommercializationReporter.js`, `src/product/licensing/LicenseCommercializationSnapshotStore.js`, `src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js`, `src/core/AdaptiveSDK.js`, `types/adaptive-sdk.d.ts` |
+| SDK Composition | Lightweight factory for DI-based integration into partner shells (includes `createConsentPanel` helper). | `src/core/AdaptiveSDK.js` |
+| Experience Shell | Demonstration UI highlighting adaptive behaviours and commercialization hooks (now composed with `createConsentPanel`, the commercialization coverage panel, the live Layout Blueprint renderer/export workflow, and the 4D projection field composer + scenario simulator). | `wearable-designer.html`, `src/ui/components/ConsentPanel.js`, `src/ui/adaptive/renderers/LayoutBlueprintRenderer.js`, `src/ui/adaptive/renderers/ProjectionFieldComposer.js`, `src/ui/adaptive/simulators/ProjectionScenarioSimulator.js` |
 
-Mobile performance is optimized. The system loads quickly on phones and runs at 45-60 FPS on most devices.
+Read the [Adaptive Engine Architecture Review](DOCS/ADAPTIVE_ENGINE_ARCHITECTURE_REVIEW.md) for an in-depth assessment of the current implementation, strengths, and risks.
 
-## 🎨 Features
+## 📈 Roadmap & Tracking
 
-- **Real-time 4D mathematics** with WebGL rendering
-- **11 parameter control system** with live updates  
-- **Gallery system** for saving/loading configurations
-- **Trading card export** in multiple formats
-- **Audio reactivity** in holographic system
-- **Cross-system compatibility** - parameters work across all engines
+- [Adaptive Engine Development Tracker](PLANNING/ADAPTIVE_ENGINE_TRACKER.md) – Source of truth for backlog, sprint focus, and environment readiness.
+- [Adaptive Engine Core Viability Assessment](DOCS/ADAPTIVE_ENGINE_CORE_ASSESSMENT.md) – Deep-dive on whether the current stack can graduate to a commercial SDK and what refactors are required.
+- [Adaptive Engine Testing Stack Evaluation](DOCS/TESTING_STACK_EVALUATION.md) – Recommendation to adopt Vitest + jsdom for Phase 1 coverage while keeping Playwright optional.
+- [Environment Automation Plan](PLANNING/ENVIRONMENT_AUTOMATION_PLAN.md) – Defines Vitest vs. Playwright lanes, container commands, and CI caching guidance.
+- [Layout & Telemetry Modularization Brief](DOCS/LAYOUT_TELEMETRY_MODULARIZATION_BRIEF.md) – Target interfaces and acceptance criteria for strategy/provider refactors.
+- [Adaptive SDK Boundary Proposal](DOCS/SDK_BOUNDARY_PROPOSAL.md) – Proposed public API surface, dependency injection model, and packaging plan for commercialization.
+- [Telemetry Privacy & Consent Guide](DOCS/TELEMETRY_PRIVACY_AND_CONSENT_GUIDE.md) – Default classifications, consent lifecycle mechanics, and adapter lifecycle telemetry expectations.
+- [License Attestation Profile Catalog](DOCS/LICENSE_ATTESTATION_PROFILE_CATALOG.md) – Commercialization-ready attestation packs, SLA defaults, and registration patterns.
+- [Remote Storage Encryption Templates](DOCS/REMOTE_STORAGE_ENCRYPTION_TEMPLATES.md) – AES-GCM/KMS and envelope-encryption examples for compliance exports.
+- [License Commercialization Analytics Bridge](DOCS/LICENSE_COMMERCIALIZATION_ANALYTICS.md) – How commercialization summaries feed dashboards via the telemetry harness and Adaptive SDK.
+- `DOCS/ADAPTIVE_UI_PRODUCT_PLAN.md` – Strategic objectives and go-to-market framing from the previous refactor.
+- `DOCS/PARTNER_INTEGRATION_STRATEGY.md` – High-level integration opportunities for tooling ecosystems.
+- [Wearable Designer Migration Checklist](PLANNING/WEARABLE_DESIGNER_MIGRATION_CHECKLIST.md) – Tasks for porting the demo shell onto the modular runtime once interfaces stabilize.
 
-## 🔧 Development
+Phase 1 now delivers runtime-pluggable layout strategies, annotations, telemetry providers, sensor payload schema validation, consent-aware and license-gated telemetry, a reusable consent panel component, downloadable audit exports with remote storage adapters (retention metadata + encryption hooks), request signing middleware, a centralized license manager with remote attestation/entitlement sync, a curated license attestation profile catalog with SDK registration helpers, and a reusable license attestation profile registry surfaced through the `AdaptiveSDK` alongside the first Playwright consent/compliance smoke spec. Upcoming focus areas include wiring the smoke lane into CI, deepening hardware adapter lifecycle coverage, and porting experience shells onto the new factory. Progress on these tasks is recorded in the tracker above.
 
-Main files:
-- `index-clean.html` - Main interface (427 lines)
-- `js/core/app.js` - System controller  
-- `js/controls/ui-handlers.js` - Parameter controls
-- `src/` - Engine implementations
+## 🎨 Engine Heritage
 
-CSS is modularized in `styles/` directory. All JavaScript uses ES6 modules with graceful fallbacks.
+All four holographic subsystems remain available for creative workflows and continue to share the unified parameter controls described in `SYSTEM_STATUS.md`. The adaptive layer currently sits on top of this proven rendering core.
 
-## 📊 Status
+## 🔧 Development Notes
 
-✅ All systems operational  
-✅ Mobile optimized  
-✅ No critical issues  
-✅ Ready for use  
+- The adaptive modules are delivered as native ES modules; a static HTTP server is sufficient for local prototyping.
+- Legacy gallery/test harnesses remain in the repository to preserve historical functionality while refactoring proceeds.
+- Automated testing for the adaptive pipeline now uses Vitest + jsdom (`npm test`). Playwright smoke suites (e.g., `npm run test:e2e:smoke`) remain optional and require a one-time `npx playwright install` to pull Chromium locally.
+- Headless CI or server-side integrations can initialize `createAdaptiveSDK({ environment: { mode: 'headless' } })` to bypass canvas/DOM bootstrapping while still exercising sensory, telemetry, licensing, commercialization, and projection APIs.
 
-See `CLAUDE.md` for detailed documentation and `SYSTEM_STATUS.md` for current technical status.
+## 📊 Reality Check
+
+- ⚠️ Prototype status – Suitable for demonstrations, not production deployments.
+- ⚠️ Documentation gap – API contracts, adapter lifecycles, and telemetry providers still need formal specs.
+- ✅ Visualization core – Legacy systems remain stable and documented (see `SYSTEM_STATUS.md`).
+
+Contributions should reference the architecture review and tracker documents to stay aligned with the evolving roadmap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,562 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.55.0",
-        "playwright": "^1.55.0"
+        "jsdom": "^23.2.0",
+        "playwright": "^1.55.0",
+        "vitest": "^1.6.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
@@ -29,6 +583,843 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -43,6 +1434,549 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.55.0",
@@ -74,6 +2008,676 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "1.0.0",
   "description": "**Revolutionary transformation: 20+ WebGL contexts → 1 unified context**",
   "main": "index.js",
+  "types": "types/adaptive-sdk.d.ts",
   "scripts": {
-    "test": "npx playwright test",
-    "test:headed": "npx playwright test --headed",
-    "test:debug": "npx playwright test --debug",
-    "test:report": "npx playwright show-report",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed",
+    "test:e2e:debug": "npx playwright test --debug",
+    "test:e2e:smoke": "npx playwright test --project=chromium --grep @smoke",
+    "test:e2e:report": "npx playwright show-report",
     "dev": "python3 -m http.server 8145"
   },
   "repository": {
@@ -24,6 +28,8 @@
   "homepage": "https://github.com/Domusgpt/v2-refactored#readme",
   "devDependencies": {
     "@playwright/test": "^1.55.0",
-    "playwright": "^1.55.0"
+    "jsdom": "^23.2.0",
+    "playwright": "^1.55.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/core/AdaptiveInterfaceEngine.js
+++ b/src/core/AdaptiveInterfaceEngine.js
@@ -1,0 +1,377 @@
+import { VIB34DIntegratedEngine } from './Engine.js';
+import { SensoryInputBridge } from '../ui/adaptive/SensoryInputBridge.js';
+import { SpatialLayoutSynthesizer } from '../ui/adaptive/SpatialLayoutSynthesizer.js';
+import { DesignLanguageManager } from '../features/DesignLanguageManager.js';
+import { ProductTelemetryHarness } from '../product/ProductTelemetryHarness.js';
+import { buildLayoutBlueprint } from '../ui/adaptive/renderers/LayoutBlueprintRenderer.js';
+import { ProjectionFieldComposer } from '../ui/adaptive/renderers/ProjectionFieldComposer.js';
+import { ProjectionScenarioSimulator } from '../ui/adaptive/simulators/ProjectionScenarioSimulator.js';
+
+/**
+ * AdaptiveInterfaceEngine
+ * ------------------------------------------------------------
+ * Productized variant of the VIB34D engine tailored for wearable and ambient
+ * UI design. Introduces adaptive sensory input, layout synthesis, and
+ * monetization scaffolding.
+ */
+export class AdaptiveInterfaceEngine extends VIB34DIntegratedEngine {
+    constructor(options = {}) {
+        const environmentOptions = options.environment || {};
+        super(environmentOptions);
+
+        this.sensoryBridge = new SensoryInputBridge(options.sensory);
+        this.layoutSynthesizer = new SpatialLayoutSynthesizer(options.layout);
+        this.designLanguageManager = new DesignLanguageManager(this, options.design);
+        this.telemetry = new ProductTelemetryHarness(options.telemetry);
+        this.marketplaceHooks = options.marketplaceHooks || {};
+        this.projectionComposer = new ProjectionFieldComposer(options.projection?.composer);
+        this.projectionSimulator = new ProjectionScenarioSimulator({
+            ...(options.projection?.simulator || {}),
+            composer: this.projectionComposer
+        });
+
+        if (typeof this.sensoryBridge.setValidationReporter === 'function') {
+            this.sensoryBridge.setValidationReporter(issue => {
+                this.telemetry.recordSchemaIssue(issue);
+            });
+        }
+
+        this.activeLayout = null;
+        this.activeDesignSpec = null;
+        this.activeBlueprint = null;
+        this.activeProjectionField = null;
+        this.adaptiveUpdateNeeded = true;
+
+        this.initializeAdaptivePipeline();
+    }
+
+    initializeAdaptivePipeline() {
+        const markDirty = () => {
+            this.adaptiveUpdateNeeded = true;
+        };
+
+        ['focus', 'intention', 'biometrics', 'environment', 'gesture'].forEach(channel => {
+            this.sensoryBridge.subscribe(channel, markDirty);
+        });
+
+        this.sensoryBridge.subscribe('focus', vector => {
+            this.telemetry.track('adaptive.focus', { x: vector.x, y: vector.y, depth: vector.depth });
+        });
+
+        this.sensoryBridge.subscribe('gesture', gesture => {
+            if (gesture?.intent) {
+                this.telemetry.track('adaptive.gesture', { intent: gesture.intent });
+            }
+        });
+
+        this.telemetry.start();
+        this.sensoryBridge.start();
+        this.syncDesignSpec();
+    }
+
+    registerLayoutStrategy(strategy) {
+        this.layoutSynthesizer.registerStrategy(strategy);
+        this.telemetry.track('design.layout.strategy_registered', { id: strategy.id });
+        return this;
+    }
+
+    registerLayoutAnnotation(annotation) {
+        this.layoutSynthesizer.registerAnnotation(annotation);
+        this.telemetry.track('design.layout.annotation_registered', { id: annotation.id });
+        return this;
+    }
+
+    registerSensorSchema(type, schema) {
+        this.sensoryBridge.registerSchema(type, schema);
+        this.telemetry.track('sensors.schema_registered', { type });
+        return this;
+    }
+
+    registerTelemetryProvider(provider) {
+        this.telemetry.registerProvider(provider);
+        this.telemetry.track('design.telemetry.provider_registered', { id: provider.id });
+        return this;
+    }
+
+    registerTelemetryRequestMiddleware(middleware) {
+        this.telemetry.registerRequestMiddleware(middleware);
+        return this;
+    }
+
+    clearTelemetryRequestMiddleware() {
+        this.telemetry.clearRequestMiddleware();
+        return this;
+    }
+
+    registerLicenseAttestationProfile(profileOrId, maybeProfile) {
+        return this.telemetry.registerLicenseAttestationProfile(profileOrId, maybeProfile);
+    }
+
+    registerLicenseAttestationProfilePack(packOrId, options = {}) {
+        return this.telemetry.registerLicenseAttestationProfilePack(packOrId, options);
+    }
+
+    setDefaultLicenseAttestationProfile(id) {
+        this.telemetry.setDefaultLicenseAttestationProfile(id);
+        return this;
+    }
+
+    applyLicenseAttestationProfile(id, overrides = {}) {
+        return this.telemetry.setLicenseAttestorFromProfile(id, overrides);
+    }
+
+    removeTelemetryProvider(id) {
+        this.telemetry.removeProvider(id);
+        this.telemetry.track('design.telemetry.provider_removed', { id });
+        return this;
+    }
+
+    getTelemetryAuditTrail() {
+        return this.telemetry.getAuditTrail();
+    }
+
+    getLicenseCommercializationSummary() {
+        return this.telemetry.getCommercializationSummary();
+    }
+
+    getLicenseCommercializationReporter() {
+        return this.telemetry.getCommercializationReporter();
+    }
+
+    getLicenseCommercializationSnapshotStore() {
+        return this.telemetry.getCommercializationSnapshotStore();
+    }
+
+    captureLicenseCommercializationSnapshot(context = {}) {
+        return this.telemetry.captureCommercializationSnapshot(context);
+    }
+
+    getLicenseCommercializationSnapshots(options = {}) {
+        return this.telemetry.getCommercializationSnapshots(options);
+    }
+
+    getLicenseCommercializationKpiReport(options = {}) {
+        return this.telemetry.getCommercializationKpiReport(options);
+    }
+
+    exportLicenseCommercializationSnapshots(options = {}) {
+        return this.telemetry.exportCommercializationSnapshots(options);
+    }
+
+    startLicenseCommercializationSnapshotSchedule(intervalMs, context = {}) {
+        return this.telemetry.startCommercializationSnapshotSchedule(intervalMs, context);
+    }
+
+    stopLicenseCommercializationSnapshotSchedule() {
+        this.telemetry.stopCommercializationSnapshotSchedule();
+        return this;
+    }
+
+    registerSensorAdapter(type, adapter, options = {}) {
+        this.sensoryBridge.registerAdapter(type, adapter);
+        this.telemetry.track('sensors.adapter.registered', {
+            type,
+            lifecycle: {
+                connect: typeof adapter.connect === 'function',
+                disconnect: typeof adapter.disconnect === 'function',
+                test: typeof adapter.test === 'function'
+            }
+        });
+
+        if (options.autoConnect ?? true) {
+            this.connectSensorAdapter(type).catch(error => {
+                this.telemetry.track('sensors.adapter.connect_failed', {
+                    type,
+                    message: error?.message || 'Unknown error'
+                }, { classification: 'compliance' });
+            });
+        }
+        return this;
+    }
+
+    async connectSensorAdapter(type) {
+        try {
+            await this.sensoryBridge.connectAdapter(type);
+            this.telemetry.track('sensors.adapter.connected', { type });
+        } catch (error) {
+            this.telemetry.track('sensors.adapter.connect_failed', {
+                type,
+                message: error?.message || 'Unknown error'
+            }, { classification: 'compliance' });
+            throw error;
+        }
+    }
+
+    async disconnectSensorAdapter(type) {
+        try {
+            await this.sensoryBridge.disconnectAdapter(type);
+            this.telemetry.track('sensors.adapter.disconnected', { type });
+        } catch (error) {
+            this.telemetry.track('sensors.adapter.disconnect_failed', {
+                type,
+                message: error?.message || 'Unknown error'
+            }, { classification: 'compliance' });
+            throw error;
+        }
+    }
+
+    async testSensorAdapter(type) {
+        const result = await this.sensoryBridge.testAdapter(type);
+        this.telemetry.track('sensors.adapter.tested', { type, result: result ?? null });
+        return result;
+    }
+
+    updateVisualizers() {
+        if (this.adaptiveUpdateNeeded) {
+            const context = this.sensoryBridge.getSnapshot();
+            this.activeLayout = this.layoutSynthesizer.generateLayout(context);
+            this.applyLayoutToParameters(this.activeLayout);
+            this.activeBlueprint = buildLayoutBlueprint(this.activeLayout, this.activeDesignSpec, context);
+            this.activeProjectionField = this.projectionComposer.render(this.activeBlueprint, {
+                gazeVelocity: context?.eyeTracking?.velocity ?? context?.focus?.velocity ?? 0.35,
+                neuralCoherence: context?.neural?.coherence ?? context?.intention?.confidence ?? 0.4,
+                hapticFeedback: context?.gesture?.haptic ?? 0.35,
+                ambientVariance: context?.environment?.motion ?? 0.3,
+                gestureIntent: {
+                    intensity: context?.gesture?.intensity ?? 0.3,
+                    vector: {
+                        x: context?.gesture?.vector?.x ?? context?.focus?.x ?? 0.5,
+                        y: context?.gesture?.vector?.y ?? context?.focus?.y ?? 0.5,
+                        z: context?.gesture?.vector?.z ?? context?.focus?.depth ?? 0.4
+                    }
+                }
+            });
+            this.projectionSimulator.observeAdaptiveState({
+                layout: this.activeLayout,
+                blueprint: this.activeBlueprint,
+                context: {
+                    gazeVelocity: context?.eyeTracking?.velocity ?? 0.35,
+                    neuralCoherence: context?.intention?.confidence ?? 0.4,
+                    hapticFeedback: context?.gesture?.haptic ?? 0.35,
+                    ambientVariance: context?.environment?.motion ?? 0.3,
+                    gestureIntent: {
+                        intensity: context?.gesture?.intensity ?? 0.3,
+                        vector: {
+                            x: context?.gesture?.vector?.x ?? context?.focus?.x ?? 0.5,
+                            y: context?.gesture?.vector?.y ?? context?.focus?.y ?? 0.5,
+                            z: context?.gesture?.vector?.z ?? context?.focus?.depth ?? 0.4
+                        }
+                    }
+                }
+            });
+            this.emitAdaptiveUpdate(context, this.activeLayout);
+            this.adaptiveUpdateNeeded = false;
+        }
+
+        super.updateVisualizers();
+    }
+
+    applyLayoutToParameters(layout) {
+        if (!layout) return;
+        this.parameterManager.setParameter('intensity', layout.intensity);
+        this.parameterManager.setParameter('speed', 0.5 + layout.motion.velocity * 1.5);
+        this.parameterManager.setParameter('hue', layout.colorAdaptation.hueShift);
+        this.parameterManager.setParameter('saturation', layout.colorAdaptation.saturation / 100);
+
+        const geometryBias = layout.zones.find(zone => zone.id === 'primary')?.occupancy || 0.6;
+        const geometryIndex = Math.round(geometryBias * 7);
+        this.parameterManager.setParameter('geometry', geometryIndex);
+    }
+
+    emitAdaptiveUpdate(context, layout) {
+        if (typeof this.marketplaceHooks.onAdaptiveUpdate === 'function') {
+            this.marketplaceHooks.onAdaptiveUpdate({ context, layout, design: this.activeDesignSpec });
+        }
+        if (typeof this.marketplaceHooks.onProjectionUpdate === 'function') {
+            this.marketplaceHooks.onProjectionUpdate({
+                context,
+                layout,
+                design: this.activeDesignSpec,
+                blueprint: this.activeBlueprint,
+                projection: this.activeProjectionField
+            });
+        }
+    }
+
+    setVariation(index) {
+        super.setVariation(index);
+        this.syncDesignSpec();
+    }
+
+    syncDesignSpec() {
+        const variationName = this.variationManager.getVariationName(this.currentVariation);
+        this.activeDesignSpec = this.designLanguageManager.getDesignSpec(variationName);
+        this.telemetry.track('design.spec.activated', {
+            variation: variationName,
+            pattern: this.activeDesignSpec.pattern?.id,
+            tier: this.activeDesignSpec.monetization.tier
+        });
+
+        if (typeof this.marketplaceHooks.onPatternChange === 'function') {
+            this.marketplaceHooks.onPatternChange(this.activeDesignSpec);
+        }
+    }
+
+    exportMarketplaceCatalog() {
+        return this.designLanguageManager.exportMarketplaceCatalog();
+    }
+
+    composeProjectionField(blueprintOrLayout, design = this.activeDesignSpec, context = {}, options = {}) {
+        const blueprint = blueprintOrLayout?.zones
+            ? buildLayoutBlueprint(blueprintOrLayout, design || this.activeDesignSpec, context)
+            : blueprintOrLayout || this.activeBlueprint;
+        if (!blueprint) {
+            return null;
+        }
+        return this.projectionComposer.compose(blueprint, context, options);
+    }
+
+    getProjectionFrame() {
+        return this.projectionSimulator.getLastResult() || (this.activeProjectionField
+            ? {
+                id: 'realtime',
+                name: 'Realtime Adaptive',
+                progress: 1,
+                cycleMs: 0,
+                blueprint: this.activeBlueprint,
+                context: null,
+                composition: this.activeProjectionField,
+                anchors: []
+            }
+            : null);
+    }
+
+    stepProjectionSimulation(options = {}) {
+        return this.projectionSimulator.step(options);
+    }
+
+    registerProjectionScenario(descriptor) {
+        return this.projectionSimulator.registerScenario(descriptor);
+    }
+
+    removeProjectionScenario(id) {
+        return this.projectionSimulator.removeScenario(id);
+    }
+
+    listProjectionScenarios() {
+        return this.projectionSimulator.listScenarios();
+    }
+
+    getProjectionScenario(id) {
+        return this.projectionSimulator.getScenario(id);
+    }
+
+    setActiveProjectionScenario(id) {
+        return this.projectionSimulator.setActiveScenario(id);
+    }
+
+    getActiveProjectionScenario() {
+        return this.projectionSimulator.getActiveScenario();
+    }
+
+    dispose() {
+        this.telemetry.stop();
+        this.sensoryBridge.stop();
+    }
+}
+

--- a/src/core/AdaptiveSDK.js
+++ b/src/core/AdaptiveSDK.js
@@ -1,0 +1,325 @@
+import { AdaptiveInterfaceEngine } from './AdaptiveInterfaceEngine.js';
+import { createConsentPanel as baseCreateConsentPanel } from '../ui/components/ConsentPanel.js';
+import { LicenseManager } from '../product/licensing/LicenseManager.js';
+import { RemoteLicenseAttestor } from '../product/licensing/RemoteLicenseAttestor.js';
+
+export function createAdaptiveSDK(config = {}) {
+    const telemetryOptions = { ...(config.telemetry || {}) };
+    if (config.replaceDefaultProviders) {
+        telemetryOptions.useDefaultProvider = false;
+    }
+
+    if (Array.isArray(config.licenseAttestationProfilePacks)) {
+        telemetryOptions.licenseAttestationProfilePacks = config.licenseAttestationProfilePacks;
+    }
+    if (config.licenseAttestationProfilePackId) {
+        telemetryOptions.licenseAttestationProfilePackId = config.licenseAttestationProfilePackId;
+    }
+    if (config.licenseAttestationProfilePackOptions) {
+        telemetryOptions.licenseAttestationProfilePackOptions = config.licenseAttestationProfilePackOptions;
+    }
+
+    if (config.commercialization) {
+        telemetryOptions.commercialization = config.commercialization;
+    }
+
+    if (config.commercializationReporter) {
+        telemetryOptions.commercializationReporter = config.commercializationReporter;
+    }
+
+    if (Array.isArray(config.licenseAttestationProfiles)) {
+        telemetryOptions.licenseAttestationProfiles = config.licenseAttestationProfiles;
+    }
+    if (config.defaultLicenseAttestationProfileId) {
+        telemetryOptions.defaultLicenseAttestationProfileId = config.defaultLicenseAttestationProfileId;
+    }
+
+    let pendingLicenseAttestorProfileId = config.licenseAttestorProfileId || null;
+    let pendingLicenseAttestorProfileOverrides = { ...(config.licenseAttestorProfileOverrides || {}) };
+
+    let licenseManager = config.licenseManager || null;
+    let licenseAttestor = null;
+    let licenseAttestorBindingOptions = {};
+    if (!licenseManager && config.license) {
+        const {
+            validators,
+            autoValidate = true,
+            managerOptions = {},
+            attestor,
+            attestorBinding = {},
+            attestorProfileId,
+            attestorProfileOverrides = {},
+            ...licenseDetails
+        } = config.license;
+
+        const options = { ...managerOptions };
+        if (Array.isArray(validators)) {
+            options.validators = validators;
+        }
+        licenseManager = new LicenseManager(options);
+        if (licenseDetails.key) {
+            licenseManager.setLicense(licenseDetails);
+        }
+
+        if (autoValidate !== false && licenseDetails.key) {
+            licenseManager.validate().catch(error => {
+                console.warn('[AdaptiveSDK] License validation failed', error);
+            });
+        }
+
+        if (attestor) {
+            if (typeof attestor.createValidator === 'function') {
+                licenseAttestor = attestor;
+            } else {
+                licenseAttestor = new RemoteLicenseAttestor(attestor);
+            }
+            licenseAttestorBindingOptions = attestorBinding || {};
+        } else if (attestorProfileId) {
+            pendingLicenseAttestorProfileId = attestorProfileId;
+            pendingLicenseAttestorProfileOverrides = {
+                ...pendingLicenseAttestorProfileOverrides,
+                ...(attestorProfileOverrides || {})
+            };
+        }
+    }
+
+    if (licenseManager) {
+        telemetryOptions.licenseManager = licenseManager;
+        if (!telemetryOptions.licenseKey && licenseManager.getLicense()?.key) {
+            telemetryOptions.licenseKey = licenseManager.getLicense().key;
+        }
+    }
+
+    if (!licenseAttestor && config.licenseAttestor) {
+        if (typeof config.licenseAttestor.createValidator === 'function') {
+            licenseAttestor = config.licenseAttestor;
+        } else {
+            licenseAttestor = new RemoteLicenseAttestor(config.licenseAttestor);
+        }
+        licenseAttestorBindingOptions = config.licenseAttestorBinding || {};
+    } else if (!licenseAttestor && config.licenseAttestorProfileId) {
+        pendingLicenseAttestorProfileId = config.licenseAttestorProfileId;
+        pendingLicenseAttestorProfileOverrides = {
+            ...pendingLicenseAttestorProfileOverrides,
+            ...(config.licenseAttestorProfileOverrides || {})
+        };
+    }
+
+    if (licenseAttestor) {
+        telemetryOptions.licenseAttestor = licenseAttestor;
+        telemetryOptions.licenseAttestorBinding = licenseAttestorBindingOptions;
+    }
+
+    const engine = new AdaptiveInterfaceEngine({
+        sensory: config.sensory,
+        layout: config.layout,
+        design: config.design,
+        telemetry: telemetryOptions,
+        marketplaceHooks: config.marketplaceHooks,
+        projection: config.projection,
+        environment: config.environment
+    });
+
+    if (licenseManager) {
+        engine.telemetry.setLicenseManager(licenseManager);
+    }
+
+    if (licenseAttestor) {
+        engine.telemetry.setLicenseAttestor(licenseAttestor, licenseAttestorBindingOptions);
+    } else if (pendingLicenseAttestorProfileId) {
+        const profileResult = engine.telemetry.setLicenseAttestorFromProfile(
+            pendingLicenseAttestorProfileId,
+            pendingLicenseAttestorProfileOverrides
+        );
+        if (profileResult?.attestor) {
+            licenseAttestor = profileResult.attestor;
+            licenseAttestorBindingOptions = profileResult.binding || {};
+        }
+    }
+
+    if (Array.isArray(config.layoutStrategies)) {
+        engine.layoutSynthesizer.clearStrategies();
+        for (const strategy of config.layoutStrategies) {
+            engine.registerLayoutStrategy(strategy);
+        }
+    }
+
+    if (Array.isArray(config.layoutAnnotations)) {
+        engine.layoutSynthesizer.clearAnnotations();
+        for (const annotation of config.layoutAnnotations) {
+            engine.registerLayoutAnnotation(annotation);
+        }
+    }
+
+    if (Array.isArray(config.telemetryProviders)) {
+        if (config.replaceDefaultProviders ?? false) {
+            engine.telemetry.providers = new Map();
+        }
+        for (const provider of config.telemetryProviders) {
+            engine.registerTelemetryProvider(provider);
+        }
+    }
+
+    if (config.sensorSchemas) {
+        if (Array.isArray(config.sensorSchemas)) {
+            for (const entry of config.sensorSchemas) {
+                if (entry && typeof entry === 'object' && entry.type && entry.schema) {
+                    engine.registerSensorSchema(entry.type, entry.schema);
+                }
+            }
+        } else if (typeof config.sensorSchemas === 'object') {
+            for (const [type, schema] of Object.entries(config.sensorSchemas)) {
+                engine.registerSensorSchema(type, schema);
+            }
+        }
+    }
+
+    if (Array.isArray(config.sensorAdapters)) {
+        for (const adapter of config.sensorAdapters) {
+            if (adapter && adapter.type && adapter.instance) {
+                engine.registerSensorAdapter(adapter.type, adapter.instance, { autoConnect: adapter.autoConnect });
+            }
+        }
+    }
+
+    if (config.telemetryConsent) {
+        engine.telemetry.updateConsent(config.telemetryConsent, { source: 'sdk-bootstrap' });
+    }
+
+    const defaultConsentOptions = Array.isArray(config.consentOptions) ? config.consentOptions : undefined;
+
+    return {
+        engine,
+        sensoryBridge: engine.sensoryBridge,
+        layoutSynthesizer: engine.layoutSynthesizer,
+        telemetry: engine.telemetry,
+        projectionComposer: engine.projectionComposer,
+        projectionSimulator: engine.projectionSimulator,
+        licenseManager,
+        licenseAttestor,
+        registerLayoutStrategy: engine.registerLayoutStrategy.bind(engine),
+        registerLayoutAnnotation: engine.registerLayoutAnnotation.bind(engine),
+        registerTelemetryProvider: engine.registerTelemetryProvider.bind(engine),
+        registerTelemetryRequestMiddleware: engine.registerTelemetryRequestMiddleware.bind(engine),
+        clearTelemetryRequestMiddleware: engine.clearTelemetryRequestMiddleware.bind(engine),
+        registerLicenseAttestationProfile: engine.registerLicenseAttestationProfile.bind(engine),
+        registerLicenseAttestationProfilePack: engine.registerLicenseAttestationProfilePack.bind(engine),
+        getLicenseAttestationProfiles: engine.telemetry.getLicenseAttestationProfiles.bind(engine.telemetry),
+        getLicenseAttestationProfile: engine.telemetry.getLicenseAttestationProfile.bind(engine.telemetry),
+        setDefaultLicenseAttestationProfile: engine.setDefaultLicenseAttestationProfile.bind(engine),
+        setLicenseAttestorFromProfile(profileId, overrides = {}) {
+            const result = engine.applyLicenseAttestationProfile(profileId, overrides);
+            if (result?.attestor) {
+                licenseAttestor = result.attestor;
+                licenseAttestorBindingOptions = result.binding || {};
+                this.licenseAttestor = licenseAttestor;
+            }
+            return result;
+        },
+        registerSensorSchema: engine.registerSensorSchema.bind(engine),
+        registerSensorAdapter: engine.registerSensorAdapter.bind(engine),
+        connectSensorAdapter: engine.connectSensorAdapter.bind(engine),
+        disconnectSensorAdapter: engine.disconnectSensorAdapter.bind(engine),
+        testSensorAdapter: engine.testSensorAdapter.bind(engine),
+        updateTelemetryConsent: engine.telemetry.updateConsent.bind(engine.telemetry),
+        getTelemetryConsent: engine.telemetry.getConsentSnapshot.bind(engine.telemetry),
+        getTelemetryAuditTrail: engine.getTelemetryAuditTrail.bind(engine),
+        getLicenseCommercializationSummary: engine.getLicenseCommercializationSummary.bind(engine),
+        getLicenseCommercializationReporter: engine.getLicenseCommercializationReporter.bind(engine),
+        getLicenseCommercializationSnapshotStore: engine.getLicenseCommercializationSnapshotStore.bind(engine),
+        captureLicenseCommercializationSnapshot: engine.captureLicenseCommercializationSnapshot.bind(engine),
+        getLicenseCommercializationSnapshots: engine.getLicenseCommercializationSnapshots.bind(engine),
+        getLicenseCommercializationKpiReport: engine.getLicenseCommercializationKpiReport.bind(engine),
+        exportLicenseCommercializationSnapshots: engine.exportLicenseCommercializationSnapshots.bind(engine),
+        startLicenseCommercializationSnapshotSchedule: engine.startLicenseCommercializationSnapshotSchedule.bind(engine),
+        stopLicenseCommercializationSnapshotSchedule: engine.stopLicenseCommercializationSnapshotSchedule.bind(engine),
+        setLicense(license) {
+            if (!licenseManager) {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            licenseManager.setLicense(license);
+        },
+        validateLicense(context) {
+            if (!licenseManager) {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            return licenseManager.validate(context);
+        },
+        getLicenseStatus() {
+            if (!licenseManager) {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            return licenseManager.getStatus();
+        },
+        getLicenseHistory() {
+            if (!licenseManager) {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            return licenseManager.getValidationHistory();
+        },
+        getLicenseAttestationHistory() {
+            if (!licenseAttestor || typeof licenseAttestor.getHistory !== 'function') {
+                return [];
+            }
+            return licenseAttestor.getHistory();
+        },
+        composeProjectionField(blueprintOrLayout, design, context, options) {
+            return engine.composeProjectionField(blueprintOrLayout, design, context, options);
+        },
+        getProjectionFrame() {
+            return engine.getProjectionFrame();
+        },
+        stepProjectionSimulation(options) {
+            return engine.stepProjectionSimulation(options);
+        },
+        registerProjectionScenario(descriptor) {
+            return engine.registerProjectionScenario(descriptor);
+        },
+        removeProjectionScenario(id) {
+            return engine.removeProjectionScenario(id);
+        },
+        listProjectionScenarios() {
+            return engine.listProjectionScenarios();
+        },
+        getProjectionScenario(id) {
+            return engine.getProjectionScenario(id);
+        },
+        setActiveProjectionScenario(id) {
+            return engine.setActiveProjectionScenario(id);
+        },
+        getActiveProjectionScenario() {
+            return engine.getActiveProjectionScenario();
+        },
+        setLicenseAttestor(attestor, options = {}) {
+            if (attestor && typeof attestor.createValidator !== 'function' && typeof attestor.bindToLicenseManager !== 'function') {
+                throw new Error('Invalid license attestor provided.');
+            }
+            if (attestor && typeof attestor.createValidator !== 'function') {
+                attestor = new RemoteLicenseAttestor(attestor);
+            }
+            licenseAttestor = attestor;
+            licenseAttestorBindingOptions = options;
+            engine.telemetry.setLicenseAttestor(licenseAttestor, licenseAttestorBindingOptions);
+            this.licenseAttestor = licenseAttestor;
+        },
+        requestLicenseAttestation(context = {}) {
+            if (!licenseManager) {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            return licenseManager.validate({ ...context, trigger: 'manual-attestation' });
+        },
+        onLicenseStatusChange(listener) {
+            if (!licenseManager || typeof licenseManager.onStatusChange !== 'function') {
+                throw new Error('No license manager configured for this SDK instance.');
+            }
+            return licenseManager.onStatusChange(listener);
+        },
+        createConsentPanel(options = {}) {
+            const consentOptions = options.consentOptions ?? defaultConsentOptions;
+            return baseCreateConsentPanel({
+                ...options,
+                consentOptions
+            });
+        }
+    };
+}

--- a/src/export/ExportManager.js
+++ b/src/export/ExportManager.js
@@ -4,8 +4,16 @@
  */
 
 export class ExportManager {
-    constructor(engine) {
+    constructor(engine, options = {}) {
         this.engine = engine;
+        this.options = options;
+        this.environment = options.environment || {};
+        if (typeof document === 'undefined') {
+            return;
+        }
+        if (this.environment.skipUiBindings) {
+            return;
+        }
         this.setupFileInputs();
     }
     

--- a/src/features/DesignLanguageManager.js
+++ b/src/features/DesignLanguageManager.js
@@ -1,0 +1,85 @@
+import { InterfacePatternRegistry } from '../ui/adaptive/InterfacePatternRegistry.js';
+
+/**
+ * DesignLanguageManager
+ * ------------------------------------------------------------
+ * Binds the holographic variation system to adaptive interface patterns,
+ * enabling UI-first workflows while preserving the expressive geometry core.
+ */
+export class DesignLanguageManager {
+    constructor(engine, options = {}) {
+        this.engine = engine;
+        this.registry = new InterfacePatternRegistry(options.patterns);
+        this.languages = new Map();
+        this.activeLanguage = options.defaultLanguage || 'default';
+
+        this.registerLanguage('default', {
+            name: 'Default Adaptive UI',
+            description: 'Base wearable-ready interface mapping built on VIB34D polytopes.',
+            mappings: new Map([
+                ['TETRAHEDRON LATTICE 1', 'neuro-glance-feed'],
+                ['HYPERCUBE LATTICE 2', 'holo-command-ring'],
+                ['SPHERE LATTICE 3', 'biometric-rituals']
+            ])
+        });
+    }
+
+    registerLanguage(id, descriptor) {
+        this.languages.set(id, {
+            name: descriptor.name,
+            description: descriptor.description,
+            mappings: descriptor.mappings instanceof Map ? descriptor.mappings : new Map(Object.entries(descriptor.mappings || {}))
+        });
+    }
+
+    setActiveLanguage(id) {
+        if (this.languages.has(id)) {
+            this.activeLanguage = id;
+        } else {
+            throw new Error(`Design language ${id} not registered`);
+        }
+    }
+
+    getActiveLanguage() {
+        return this.languages.get(this.activeLanguage);
+    }
+
+    getDesignSpec(variationName) {
+        const language = this.getActiveLanguage();
+        const patternId = language?.mappings.get(variationName) || 'neuro-glance-feed';
+        const pattern = this.registry.getPattern(patternId);
+        return {
+            pattern,
+            monetization: this.buildMonetizationDescriptor(patternId),
+            integration: this.buildIntegrationDescriptor(patternId)
+        };
+    }
+
+    buildMonetizationDescriptor(patternId) {
+        const pattern = this.registry.getPattern(patternId);
+        if (!pattern) return { tier: 'starter', license: 'community' };
+        return {
+            tier: pattern.subscriptionTier,
+            license: pattern.subscriptionTier === 'enterprise' ? 'floating-enterprise' : 'seat-based',
+            upsell: pattern.subscriptionTier === 'starter' ? 'pro-upgrade' : null
+        };
+    }
+
+    buildIntegrationDescriptor(patternId) {
+        const pattern = this.registry.getPattern(patternId);
+        const designTokens = {
+            color: pattern?.components?.includes('glanceable-card') ? 'glance' : 'ambient',
+            motion: pattern?.components?.includes('adaptive-controls') ? 'command' : 'flow'
+        };
+        return {
+            figmaPlugin: `vib34d-${patternId}`,
+            webflowPackage: `@vib34d/${patternId}`,
+            designTokens
+        };
+    }
+
+    exportMarketplaceCatalog() {
+        return this.registry.exportForMarketplace();
+    }
+}
+

--- a/src/product/ProductTelemetryHarness.js
+++ b/src/product/ProductTelemetryHarness.js
@@ -1,0 +1,785 @@
+import { ConsoleTelemetryProvider } from './telemetry/ConsoleTelemetryProvider.js';
+import { LicenseAttestationProfileRegistry } from './licensing/LicenseAttestationProfileRegistry.js';
+import { resolveLicenseAttestationProfilePack } from './licensing/LicenseAttestationProfileCatalog.js';
+import { LicenseCommercializationReporter } from './licensing/LicenseCommercializationReporter.js';
+import { LicenseCommercializationSnapshotStore } from './licensing/LicenseCommercializationSnapshotStore.js';
+
+const DEFAULT_CLASSIFICATION_RULES = [
+    { prefix: 'adaptive.', classification: 'interaction' },
+    { prefix: 'design.layout.', classification: 'analytics' },
+    { prefix: 'design.spec.', classification: 'analytics' },
+    { prefix: 'design.telemetry.', classification: 'system' },
+    { prefix: 'sensors.adapter.', classification: 'system' },
+    { prefix: 'sensors.schema', classification: 'compliance' },
+    { prefix: 'compliance.', classification: 'compliance' },
+    { prefix: 'privacy.', classification: 'compliance' },
+    { prefix: 'biometric.', classification: 'biometric' }
+];
+
+export class ProductTelemetryHarness {
+    constructor(options = {}) {
+        this.enabled = options.enabled ?? true;
+        this.licenseKey = options.licenseKey || null;
+        this.flushInterval = options.flushInterval || 10000;
+        this.flushHandle = null;
+        this.buffer = [];
+        this.licenseManager = options.licenseManager || null;
+        this.licenseAttestor = null;
+        this.licenseAttestorSubscriptions = [];
+        this.licenseAttestorDetach = null;
+        this.licenseAttestorBindingOptions = {
+            bindToLicenseManager: true,
+            attestorOptions: undefined
+        };
+
+        this.licenseAttestationProfiles = new LicenseAttestationProfileRegistry({
+            defaultProfileId: options.defaultLicenseAttestationProfileId
+        });
+
+        if (options.commercializationReporter instanceof LicenseCommercializationReporter) {
+            this.commercializationReporter = options.commercializationReporter;
+        } else if (options.commercialization?.enabled === false) {
+            this.commercializationReporter = null;
+        } else {
+            const commercializationOptions = options.commercialization || {};
+            this.commercializationReporter = new LicenseCommercializationReporter(commercializationOptions);
+        }
+
+        this.commercializationSnapshotStore = null;
+        this.commercializationSnapshotScheduleHandle = null;
+        this.commercializationSnapshotScheduleContext = null;
+        this.commercializationUpdateUnsubscribe = null;
+
+        if (this.commercializationReporter) {
+            const commercializationOptions = options.commercialization || {};
+            const snapshotConfig = commercializationOptions.snapshotStore;
+            if (snapshotConfig instanceof LicenseCommercializationSnapshotStore) {
+                this.commercializationSnapshotStore = snapshotConfig;
+            } else if (snapshotConfig !== false) {
+                const snapshotOptions = snapshotConfig && typeof snapshotConfig === 'object'
+                    ? snapshotConfig
+                    : (commercializationOptions.snapshotStoreOptions || {});
+                this.commercializationSnapshotStore = new LicenseCommercializationSnapshotStore(snapshotOptions);
+            }
+
+            if (this.commercializationSnapshotStore) {
+                this.commercializationUpdateUnsubscribe = this.commercializationReporter.addUpdateListener(summary => {
+                    this.commercializationSnapshotStore.recordSnapshot(summary, { trigger: 'reporter-update' });
+                });
+
+                if (commercializationOptions.captureInitialSnapshot !== false) {
+                    this.captureCommercializationSnapshot({ trigger: 'telemetry-bootstrap' });
+                }
+
+                if (Number.isFinite(commercializationOptions.snapshotIntervalMs)) {
+                    this.startCommercializationSnapshotSchedule(
+                        commercializationOptions.snapshotIntervalMs,
+                        { trigger: 'scheduled-capture' }
+                    );
+                }
+            }
+        }
+
+        this.dataMinimization = {
+            omitLicense: options.dataMinimization?.omitLicense ?? false,
+            allowedFields: options.dataMinimization?.allowedFields,
+            anonymize: options.dataMinimization?.anonymize ?? false
+        };
+
+        this.defaultClassification = options.defaultClassification || 'analytics';
+        this.classificationRules = (options.classificationRules || DEFAULT_CLASSIFICATION_RULES)
+            .map(rule => this.createClassificationRule(rule))
+            .filter(Boolean);
+
+        const defaultConsent = {
+            system: true,
+            compliance: true,
+            interaction: true,
+            analytics: false,
+            biometric: false,
+            ...(options.defaultConsent || {})
+        };
+
+        this.consent = new Map(Object.entries(defaultConsent));
+        this.auditLog = [];
+        this.auditLogLimit = options.auditLogLimit || 200;
+        this.onConsentDecision = typeof options.onConsentDecision === 'function' ? options.onConsentDecision : null;
+
+        this.providers = new Map();
+
+        this.requestMiddleware = [];
+
+        if (this.licenseManager) {
+            this.attachLicenseFromManager(this.licenseManager.getLicense());
+            this.licenseManagerSubscription = this.licenseManager.onStatusChange?.(status => {
+                if (status?.state === 'valid') {
+                    this.attachLicenseFromManager(this.licenseManager.getLicense());
+                } else if (status?.state === 'unregistered') {
+                    this.attachLicense(null);
+                }
+            });
+        }
+
+        if (Array.isArray(options.requestMiddleware)) {
+            for (const middleware of options.requestMiddleware) {
+                if (typeof middleware === 'function') {
+                    this.registerRequestMiddleware(middleware);
+                }
+            }
+        }
+
+        if (options.useDefaultProvider !== false) {
+            this.registerProvider(new ConsoleTelemetryProvider(options.consoleProvider || {}));
+        }
+
+        (options.providers || []).forEach(provider => this.registerProvider(provider));
+
+        this.bootstrapLicenseAttestationPacks(options);
+
+        if (Array.isArray(options.licenseAttestationProfiles)) {
+            for (const profile of options.licenseAttestationProfiles) {
+                this.registerLicenseAttestationProfile(profile);
+            }
+            if (options.defaultLicenseAttestationProfileId) {
+                this.licenseAttestationProfiles.setDefaultProfile(options.defaultLicenseAttestationProfileId);
+            }
+        }
+
+        if (options.licenseAttestor) {
+            this.setLicenseAttestor(options.licenseAttestor, options.licenseAttestorBinding);
+        }
+    }
+
+    createClassificationRule(rule) {
+        if (!rule) return null;
+
+        if (typeof rule === 'function') {
+            return { test: rule, classification: this.defaultClassification };
+        }
+
+        if (rule instanceof RegExp) {
+            return { test: event => rule.test(event), classification: this.defaultClassification };
+        }
+
+        if (typeof rule === 'object') {
+            if (typeof rule.test === 'function') {
+                return { test: rule.test, classification: rule.classification || this.defaultClassification };
+            }
+
+            if (typeof rule.prefix === 'string') {
+                return { test: event => event.startsWith(rule.prefix), classification: rule.classification || this.defaultClassification };
+            }
+
+            if (rule.match instanceof RegExp) {
+                return { test: event => rule.match.test(event), classification: rule.classification || this.defaultClassification };
+            }
+        }
+
+        throw new Error('Invalid classification rule supplied to ProductTelemetryHarness');
+    }
+
+    registerProvider(provider) {
+        this.providers.set(provider.id, provider);
+        if (this.requestMiddleware.length > 0 && typeof provider.registerRequestMiddleware === 'function') {
+            for (const middleware of this.requestMiddleware) {
+                provider.registerRequestMiddleware(middleware);
+            }
+        }
+    }
+
+    removeProvider(id) {
+        this.providers.delete(id);
+    }
+
+    registerRequestMiddleware(middleware) {
+        if (typeof middleware !== 'function') {
+            throw new Error('Telemetry request middleware must be a function.');
+        }
+
+        this.requestMiddleware.push(middleware);
+
+        for (const provider of this.providers.values()) {
+            if (typeof provider.registerRequestMiddleware === 'function') {
+                provider.registerRequestMiddleware(middleware);
+            }
+        }
+    }
+
+    clearRequestMiddleware() {
+        this.requestMiddleware = [];
+        for (const provider of this.providers.values()) {
+            if (typeof provider.clearRequestMiddleware === 'function') {
+                provider.clearRequestMiddleware();
+            }
+        }
+    }
+
+    registerLicenseAttestationProfile(profileOrId, maybeProfile, context = {}) {
+        const profile = this.licenseAttestationProfiles.registerProfile(profileOrId, maybeProfile);
+        this.recordAudit('system.license.attestation_profile_registered', {
+            profileId: profile.id,
+            sla: profile.sla || null
+        }, 'system');
+        if (this.commercializationReporter) {
+            this.commercializationReporter.recordProfileRegistration(profile, {
+                ...context,
+                packId: context.packId || this.commercializationReporter.getPackIdForProfile(profile.id) || null,
+                setAsDefault: context.setAsDefault || false
+            });
+        }
+        return profile;
+    }
+
+    registerLicenseAttestationProfilePack(packOrId, options = {}) {
+        const pack = resolveLicenseAttestationProfilePack(packOrId, options);
+        const registeredProfileIds = [];
+        const previousDefaultId = this.licenseAttestationProfiles.getDefaultProfileId();
+
+        for (const profile of pack.profiles) {
+            const result = this.registerLicenseAttestationProfile(profile, undefined, {
+                packId: pack.id,
+                source: 'catalog-pack',
+                metadata: pack.metadata,
+                setAsDefault: false
+            });
+            registeredProfileIds.push(result.id);
+        }
+
+        let defaultProfileId = this.licenseAttestationProfiles.getDefaultProfileId();
+        if (pack.defaultProfileId && options.applyDefault !== false) {
+            this.setDefaultLicenseAttestationProfile(pack.defaultProfileId);
+            defaultProfileId = pack.defaultProfileId;
+        } else if (options.applyDefault === false) {
+            if (previousDefaultId) {
+                this.licenseAttestationProfiles.setDefaultProfile(previousDefaultId);
+                defaultProfileId = previousDefaultId;
+            } else if (typeof this.licenseAttestationProfiles.clearDefaultProfile === 'function') {
+                this.licenseAttestationProfiles.clearDefaultProfile();
+                defaultProfileId = null;
+            }
+        }
+
+        this.recordAudit('system.license.attestation_profile_pack_registered', {
+            packId: pack.id,
+            profileIds: registeredProfileIds,
+            defaultProfileId,
+            metadata: pack.metadata || null
+        }, 'system');
+
+        if (this.commercializationReporter) {
+            this.commercializationReporter.recordPackRegistration(pack, {
+                registeredProfileIds,
+                defaultProfileId,
+                appliedDefault: defaultProfileId === pack.defaultProfileId,
+                options,
+                applyDefault: options.applyDefault
+            });
+            if (defaultProfileId) {
+                this.commercializationReporter.recordDefaultProfileChange(defaultProfileId, {
+                    packId: pack.id
+                });
+            } else {
+                this.commercializationReporter.recordDefaultProfileChange(null, {
+                    packId: pack.id
+                });
+            }
+        }
+
+        return {
+            id: pack.id,
+            name: pack.name,
+            description: pack.description,
+            defaultProfileId,
+            profileIds: registeredProfileIds,
+            metadata: pack.metadata || null
+        };
+    }
+
+    getLicenseAttestationProfiles() {
+        return this.licenseAttestationProfiles.getProfiles();
+    }
+
+    getLicenseAttestationProfile(id) {
+        return this.licenseAttestationProfiles.getProfile(id);
+    }
+
+    setDefaultLicenseAttestationProfile(id) {
+        const previousDefault = this.licenseAttestationProfiles.getDefaultProfileId();
+        this.licenseAttestationProfiles.setDefaultProfile(id);
+        this.recordAudit('system.license.attestation_profile_default', { profileId: id }, 'system');
+        if (this.commercializationReporter) {
+            this.commercializationReporter.recordDefaultProfileChange(id, {
+                previousDefaultId: previousDefault
+            });
+        }
+    }
+
+    setLicenseAttestorFromProfile(profileId, overrides = {}) {
+        const result = this.licenseAttestationProfiles.createAttestor(profileId, overrides);
+        this.setLicenseAttestor(result.attestor, result.binding);
+        this.recordAudit('system.license.attestation_profile_applied', {
+            profileId: result.profile.id,
+            sla: result.profile.sla || null
+        }, 'system');
+        if (this.commercializationReporter) {
+            this.commercializationReporter.recordProfileApplied(result.profile, {
+                packId: this.commercializationReporter.getPackIdForProfile(result.profile.id),
+                context: overrides
+            });
+        }
+        return result;
+    }
+
+    bootstrapLicenseAttestationPacks(options) {
+        const packs = options.licenseAttestationProfilePacks;
+        if (Array.isArray(packs)) {
+            for (const entry of packs) {
+                if (!entry) continue;
+                if (typeof entry === 'string') {
+                    this.registerLicenseAttestationProfilePack(entry, options.licenseAttestationProfilePackOptions || {});
+                } else if (typeof entry === 'object') {
+                    if (typeof entry.id === 'string' && entry.options) {
+                        this.registerLicenseAttestationProfilePack(entry.id, entry.options);
+                    } else {
+                        this.registerLicenseAttestationProfilePack(entry);
+                    }
+                }
+            }
+            return;
+        }
+
+        if (options.licenseAttestationProfilePackId) {
+            this.registerLicenseAttestationProfilePack(
+                options.licenseAttestationProfilePackId,
+                options.licenseAttestationProfilePackOptions || {}
+            );
+        }
+    }
+
+    registerClassificationRule(rule) {
+        const normalized = this.createClassificationRule(rule);
+        this.classificationRules.unshift(normalized);
+    }
+
+    identify(identity, traits = {}, options = {}) {
+        if (!this.enabled) return;
+        if (!this.isLicensePermitted('identify')) {
+            return;
+        }
+
+        const classification = options.classification || 'system';
+        if (!this.isConsentGranted(classification)) {
+            this.recordAudit('privacy.identity.blocked', { identity, classification });
+            return;
+        }
+
+        const sanitizedTraits = this.sanitizePayload(traits);
+        for (const provider of this.providers.values()) {
+            provider.identify?.(identity, sanitizedTraits, { classification });
+        }
+    }
+
+    track(event, payload = {}, options = {}) {
+        if (!this.enabled) return;
+        if (!this.isLicensePermitted('track', event)) {
+            return;
+        }
+
+        const sanitizedPayload = this.sanitizePayload(payload);
+        const classification = options.classification || this.classifyEvent(event, sanitizedPayload);
+
+        if (!this.isConsentGranted(classification)) {
+            this.recordAudit('privacy.event.blocked', { event, classification });
+            return;
+        }
+
+        const record = {
+            event,
+            payload: sanitizedPayload,
+            classification,
+            licenseKey: this.dataMinimization.omitLicense ? undefined : this.licenseKey,
+            timestamp: new Date().toISOString()
+        };
+
+        this.buffer.push(record);
+        for (const provider of this.providers.values()) {
+            provider.track?.(event, record, { classification });
+        }
+    }
+
+    sanitizePayload(payload) {
+        if (!payload || typeof payload !== 'object') return payload;
+        const clone = { ...payload };
+
+        if (this.dataMinimization.allowedFields) {
+            const filtered = {};
+            for (const key of this.dataMinimization.allowedFields) {
+                if (key in clone) {
+                    filtered[key] = clone[key];
+                }
+            }
+            return filtered;
+        }
+
+        if (this.dataMinimization.anonymize) {
+            delete clone.userId;
+            delete clone.identity;
+            delete clone.email;
+        }
+
+        return clone;
+    }
+
+    classifyEvent(event, payload) {
+        for (const rule of this.classificationRules) {
+            try {
+                if (rule.test(event, payload)) {
+                    return rule.classification;
+                }
+            } catch (error) {
+                this.recordAudit('privacy.classification.error', { event, error: error.message });
+            }
+        }
+        return this.defaultClassification;
+    }
+
+    isConsentGranted(classification) {
+        if (!classification) return true;
+        if (!this.consent.has(classification)) {
+            return false;
+        }
+        return Boolean(this.consent.get(classification));
+    }
+
+    updateConsent(consentUpdates = {}, metadata = {}) {
+        const applied = {};
+        for (const [classification, value] of Object.entries(consentUpdates)) {
+            this.consent.set(classification, Boolean(value));
+            applied[classification] = Boolean(value);
+        }
+
+        const snapshot = this.getConsentSnapshot();
+        this.recordAudit('privacy.consent.updated', { applied, metadata, snapshot });
+        this.onConsentDecision?.(snapshot, metadata);
+    }
+
+    getConsentSnapshot() {
+        return Object.fromEntries(this.consent.entries());
+    }
+
+    pushAuditEntry(entry) {
+        this.auditLog.push(entry);
+        if (this.auditLog.length > this.auditLogLimit) {
+            this.auditLog.shift();
+        }
+    }
+
+    recordAudit(event, payload = {}, classification = 'compliance') {
+        const entry = {
+            event,
+            payload,
+            classification,
+            timestamp: new Date().toISOString()
+        };
+
+        this.pushAuditEntry(entry);
+
+        for (const provider of this.providers.values()) {
+            if (typeof provider.recordAudit === 'function') {
+                try {
+                    provider.recordAudit(entry);
+                } catch (error) {
+                    this.pushAuditEntry({
+                        event: 'privacy.audit.provider_error',
+                        payload: {
+                            provider: provider.id,
+                            sourceEvent: event,
+                            message: error?.message || 'Unknown error'
+                        },
+                        classification: 'system',
+                        timestamp: new Date().toISOString()
+                    });
+                }
+            }
+        }
+
+        return entry;
+    }
+
+    getAuditTrail() {
+        return [...this.auditLog];
+    }
+
+    getCommercializationSummary() {
+        return this.commercializationReporter ? this.commercializationReporter.getSummary() : {
+            packs: [],
+            profiles: [],
+            segments: {},
+            regions: {},
+            sla: {
+                responseTargetMs: null,
+                availabilityPercent: null,
+                breachWindowMs: null
+            },
+            defaultProfileId: null,
+            lastUpdated: null
+        };
+    }
+
+    getCommercializationReporter() {
+        return this.commercializationReporter || null;
+    }
+
+    getCommercializationSnapshotStore() {
+        return this.commercializationSnapshotStore || null;
+    }
+
+    captureCommercializationSnapshot(context = {}) {
+        if (!this.commercializationReporter || !this.commercializationSnapshotStore) {
+            return null;
+        }
+        const summary = this.commercializationReporter.getSummary();
+        const metadata = {
+            ...context,
+            trigger: context.trigger || 'manual-capture',
+            capturedBy: context.capturedBy || 'telemetry-harness'
+        };
+        if (!this.dataMinimization?.omitLicense && this.licenseKey) {
+            metadata.licenseKey = this.licenseKey;
+        }
+        return this.commercializationSnapshotStore.recordSnapshot(summary, metadata);
+    }
+
+    getCommercializationSnapshots(options = {}) {
+        if (!this.commercializationSnapshotStore) {
+            return [];
+        }
+        return this.commercializationSnapshotStore.getSnapshots(options);
+    }
+
+    getCommercializationKpiReport(options = {}) {
+        if (!this.commercializationSnapshotStore) {
+            return { latest: null, previous: null, deltas: {} };
+        }
+        return this.commercializationSnapshotStore.getKpiReport(options);
+    }
+
+    exportCommercializationSnapshots(options = {}) {
+        if (!this.commercializationSnapshotStore) {
+            return null;
+        }
+        return this.commercializationSnapshotStore.exportForBi(options);
+    }
+
+    startCommercializationSnapshotSchedule(intervalMs = 3600000, context = {}) {
+        if (!this.commercializationReporter || !this.commercializationSnapshotStore) {
+            return null;
+        }
+        const interval = Number(intervalMs);
+        if (!Number.isFinite(interval) || interval <= 0) {
+            throw new Error('Commercialization snapshot interval must be a positive number.');
+        }
+        this.stopCommercializationSnapshotSchedule();
+        this.commercializationSnapshotScheduleContext = { ...context };
+        this.commercializationSnapshotScheduleHandle = setInterval(() => {
+            const scheduleContext = this.commercializationSnapshotScheduleContext || {};
+            this.captureCommercializationSnapshot({
+                ...scheduleContext,
+                trigger: scheduleContext.trigger || 'scheduled-capture',
+                scheduledAt: new Date().toISOString()
+            });
+        }, interval);
+        return () => this.stopCommercializationSnapshotSchedule();
+    }
+
+    stopCommercializationSnapshotSchedule() {
+        if (this.commercializationSnapshotScheduleHandle) {
+            clearInterval(this.commercializationSnapshotScheduleHandle);
+            this.commercializationSnapshotScheduleHandle = null;
+            this.commercializationSnapshotScheduleContext = null;
+        }
+    }
+
+    recordSchemaIssue({ type, issues, payload }) {
+        this.recordAudit('compliance.schema.issue', { type, issues, payload });
+        this.track('sensors.schema_issue', { type, issues, payload }, { classification: 'compliance' });
+    }
+
+    attachLicense(licenseKey) {
+        this.licenseKey = licenseKey;
+    }
+
+    attachLicenseFromManager(license) {
+        if (!license || !license.key) {
+            this.attachLicense(null);
+            return;
+        }
+        this.attachLicense(license.key);
+    }
+
+    setLicenseManager(manager) {
+        if (this.licenseManagerSubscription) {
+            this.licenseManagerSubscription();
+            this.licenseManagerSubscription = null;
+        }
+
+        if (this.licenseAttestorDetach) {
+            try {
+                this.licenseAttestorDetach();
+            } catch (error) {
+                console?.warn?.('Failed to detach license attestor', error);
+            }
+            this.licenseAttestorDetach = null;
+        }
+
+        this.licenseManager = manager || null;
+        if (!this.licenseManager) {
+            this.licenseKey = null;
+            if (this.licenseAttestor && typeof this.licenseAttestor.detach === 'function') {
+                this.licenseAttestor.detach();
+            }
+            return;
+        }
+
+        this.attachLicenseFromManager(this.licenseManager.getLicense());
+        if (typeof this.licenseManager.onStatusChange === 'function') {
+            this.licenseManagerSubscription = this.licenseManager.onStatusChange(status => {
+                if (status?.state === 'valid') {
+                    this.attachLicenseFromManager(this.licenseManager.getLicense());
+                } else if (status?.state === 'unregistered') {
+                    this.attachLicense(null);
+                }
+            });
+        }
+
+        this.bindLicenseAttestor();
+    }
+
+    isLicensePermitted(action, event) {
+        if (!this.licenseManager) return true;
+        const status = this.licenseManager.getStatus();
+        if (status.state === 'valid') return true;
+
+        this.recordAudit('compliance.license.blocked', {
+            action,
+            event,
+            status
+        });
+        return false;
+    }
+
+    start() {
+        if (!this.enabled || this.flushHandle) return;
+        this.flushHandle = setInterval(() => this.flush(), this.flushInterval);
+    }
+
+    stop() {
+        if (this.flushHandle) {
+            clearInterval(this.flushHandle);
+            this.flushHandle = null;
+        }
+        if (this.licenseManagerSubscription) {
+            this.licenseManagerSubscription();
+            this.licenseManagerSubscription = null;
+        }
+        if (this.licenseAttestorDetach) {
+            try {
+                this.licenseAttestorDetach();
+            } catch (error) {
+                console?.warn?.('Failed to detach license attestor during stop', error);
+            }
+            this.licenseAttestorDetach = null;
+        }
+    }
+
+    async flush() {
+        if (!this.enabled) return;
+        const pending = [];
+        for (const provider of this.providers.values()) {
+            const result = provider.flush?.();
+            if (result instanceof Promise) {
+                pending.push(result);
+            }
+        }
+        this.buffer = [];
+        if (pending.length) {
+            await Promise.allSettled(pending);
+        }
+    }
+
+    bindLicenseAttestor() {
+        if (!this.licenseAttestor || this.licenseAttestorBindingOptions.bindToLicenseManager === false) {
+            return;
+        }
+        if (!this.licenseManager || typeof this.licenseAttestor.bindToLicenseManager !== 'function') {
+            return;
+        }
+        try {
+            this.licenseAttestorDetach = this.licenseAttestor.bindToLicenseManager(
+                this.licenseManager,
+                this.licenseAttestorBindingOptions.attestorOptions || {}
+            );
+        } catch (error) {
+            console?.warn?.('Failed to bind license attestor to manager', error);
+        }
+    }
+
+    detachLicenseAttestorListeners() {
+        if (Array.isArray(this.licenseAttestorSubscriptions)) {
+            for (const unsubscribe of this.licenseAttestorSubscriptions) {
+                try {
+                    unsubscribe?.();
+                } catch (error) {
+                    console?.warn?.('Failed to unsubscribe attestor listener', error);
+                }
+            }
+        }
+        this.licenseAttestorSubscriptions = [];
+    }
+
+    setLicenseAttestor(attestor, bindingOptions = {}) {
+        this.detachLicenseAttestorListeners();
+        if (this.licenseAttestorDetach) {
+            try {
+                this.licenseAttestorDetach();
+            } catch (error) {
+                console?.warn?.('Failed to detach existing license attestor', error);
+            }
+        }
+        this.licenseAttestorDetach = null;
+
+        this.licenseAttestor = attestor || null;
+        this.licenseAttestorBindingOptions = {
+            bindToLicenseManager: bindingOptions.bindToLicenseManager ?? true,
+            attestorOptions: bindingOptions.attestorOptions
+        };
+
+        if (!this.licenseAttestor) {
+            return;
+        }
+
+        if (typeof this.licenseAttestor.on === 'function') {
+            const subscribe = (event, handler) => {
+                try {
+                    const unsubscribe = this.licenseAttestor.on(event, handler);
+                    if (typeof unsubscribe === 'function') {
+                        this.licenseAttestorSubscriptions.push(unsubscribe);
+                    } else if (typeof this.licenseAttestor.off === 'function') {
+                        this.licenseAttestorSubscriptions.push(() => this.licenseAttestor.off(event, handler));
+                    }
+                } catch (error) {
+                    console?.warn?.('Failed to subscribe to license attestor event', event, error);
+                }
+            };
+
+            subscribe('attestation', payload => this.recordAudit('compliance.license.attestation', payload));
+            subscribe('revocation', payload => this.recordAudit('compliance.license.revocation', payload));
+            subscribe('entitlements', payload => this.recordAudit('compliance.license.entitlements', payload));
+            subscribe('validation', payload => this.recordAudit('compliance.license.validation', payload));
+            subscribe('schedule', payload => this.recordAudit('system.license.attestation_scheduled', payload, 'system'));
+            subscribe('error', payload => this.recordAudit('compliance.license.attestor_error', payload, 'system'));
+        }
+
+        this.bindLicenseAttestor();
+    }
+}

--- a/src/product/licensing/LicenseAttestationProfileCatalog.js
+++ b/src/product/licensing/LicenseAttestationProfileCatalog.js
@@ -1,0 +1,309 @@
+import { RemoteLicenseAttestor } from './RemoteLicenseAttestor.js';
+
+function ensureArray(value, fallback) {
+    if (Array.isArray(value) && value.length > 0) {
+        return value;
+    }
+    return Array.isArray(fallback) ? [...fallback] : [];
+}
+
+function trimTrailingSlash(value) {
+    if (typeof value !== 'string') return '';
+    return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function normalizeRegion(region) {
+    if (!region) return 'global';
+    return String(region).toLowerCase();
+}
+
+function toDisplayRegion(region) {
+    if (!region) return 'Global';
+    return region.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+}
+
+function cloneProfile(profile) {
+    return {
+        ...profile,
+        attestor: profile.attestor ? { ...profile.attestor } : undefined,
+        binding: profile.binding ? { ...profile.binding } : undefined,
+        sla: profile.sla ? { ...profile.sla } : undefined,
+        metadata: profile.metadata ? { ...profile.metadata } : undefined
+    };
+}
+
+const ENTERPRISE_SAAS_PACK = {
+    id: 'enterprise-saas',
+    name: 'Enterprise SaaS Compliance Pack',
+    description: 'Hardened attestation endpoints for regulated enterprise customers with multi-region redundancy.',
+    defaults: {
+        baseUrl: 'https://licensing.enterprise.example.com',
+        regions: ['global', 'na', 'eu'],
+        pollIntervalMs: 15 * 60 * 1000,
+        minimumPollIntervalMs: 5 * 60 * 1000,
+        failOpen: false,
+        headers: {
+            'x-sdk-product': 'adaptive-interface-engine',
+            'x-sdk-tier': 'enterprise'
+        },
+        sla: {
+            responseTargetMs: 900,
+            availability: '99.9%',
+            breachWindowMs: 5 * 60 * 1000
+        }
+    },
+    buildProfiles(options = {}) {
+        const regions = ensureArray(options.regions, this.defaults.regions);
+        const baseUrl = trimTrailingSlash(options.baseUrl || this.defaults.baseUrl);
+        return regions.map(region => {
+            const normalized = normalizeRegion(region);
+            const displayRegion = toDisplayRegion(normalized);
+            const regionPath = normalized === 'global' ? 'global' : normalized;
+            const attestationBase = `${baseUrl}/${regionPath}`;
+
+            return {
+                id: `enterprise-saas/${normalized}`,
+                name: `Enterprise SaaS (${displayRegion})`,
+                description: `Managed compliance endpoints for ${displayRegion} deployments.`,
+                attestor: {
+                    attestationUrl: `${attestationBase}/attest`,
+                    revocationUrl: `${attestationBase}/revoke`,
+                    entitlementsUrl: `${attestationBase}/entitlements`,
+                    pollIntervalMs: options.pollIntervalMs ?? this.defaults.pollIntervalMs,
+                    minimumPollIntervalMs: options.minimumPollIntervalMs ?? this.defaults.minimumPollIntervalMs,
+                    failOpen: options.failOpen ?? this.defaults.failOpen,
+                    headers: { ...this.defaults.headers, ...(options.headers || {}) }
+                },
+                binding: {
+                    attestorOptions: {
+                        context: {
+                            region: normalized,
+                            tier: 'enterprise'
+                        }
+                    }
+                },
+                sla: {
+                    responseTargetMs: options.sla?.responseTargetMs ?? this.defaults.sla.responseTargetMs,
+                    availability: options.sla?.availability ?? this.defaults.sla.availability,
+                    breachWindowMs: options.sla?.breachWindowMs ?? this.defaults.sla.breachWindowMs
+                },
+                metadata: {
+                    segment: 'enterprise',
+                    region: normalized,
+                    complianceTier: 'regulated'
+                }
+            };
+        });
+    }
+};
+
+const STUDIO_COLLAB_PACK = {
+    id: 'studio-collab',
+    name: 'Studio Collaboration Pack',
+    description: 'Right-sized attestation endpoints for design studios collaborating across wearable projects.',
+    defaults: {
+        baseUrl: 'https://licensing.studiohub.example.com',
+        regions: ['global', 'latam'],
+        pollIntervalMs: 30 * 60 * 1000,
+        minimumPollIntervalMs: 10 * 60 * 1000,
+        failOpen: true,
+        headers: {
+            'x-sdk-product': 'adaptive-interface-engine',
+            'x-sdk-tier': 'studio'
+        },
+        sla: {
+            responseTargetMs: 1500,
+            availability: '99.5%',
+            breachWindowMs: 15 * 60 * 1000
+        }
+    },
+    buildProfiles(options = {}) {
+        const regions = ensureArray(options.regions, this.defaults.regions);
+        const baseUrl = trimTrailingSlash(options.baseUrl || this.defaults.baseUrl);
+        const collaborationId = options.collaborationId || 'default';
+
+        return regions.map(region => {
+            const normalized = normalizeRegion(region);
+            const displayRegion = toDisplayRegion(normalized);
+            const regionPath = normalized === 'global' ? 'global' : normalized;
+            const attestationBase = `${baseUrl}/${collaborationId}/${regionPath}`;
+
+            return {
+                id: `studio-collab/${collaborationId}/${normalized}`,
+                name: `Studio Collaboration (${displayRegion})`,
+                description: `Shared entitlement attestation for ${displayRegion} studio pods (${collaborationId}).`,
+                attestor: {
+                    attestationUrl: `${attestationBase}/attest`,
+                    revocationUrl: `${attestationBase}/revoke`,
+                    entitlementsUrl: `${attestationBase}/entitlements`,
+                    pollIntervalMs: options.pollIntervalMs ?? this.defaults.pollIntervalMs,
+                    minimumPollIntervalMs: options.minimumPollIntervalMs ?? this.defaults.minimumPollIntervalMs,
+                    failOpen: options.failOpen ?? this.defaults.failOpen,
+                    headers: { ...this.defaults.headers, ...(options.headers || {}), 'x-collaboration-id': collaborationId }
+                },
+                binding: {
+                    attestorOptions: {
+                        context: {
+                            region: normalized,
+                            collaborationId,
+                            tier: 'studio'
+                        }
+                    }
+                },
+                sla: {
+                    responseTargetMs: options.sla?.responseTargetMs ?? this.defaults.sla.responseTargetMs,
+                    availability: options.sla?.availability ?? this.defaults.sla.availability,
+                    breachWindowMs: options.sla?.breachWindowMs ?? this.defaults.sla.breachWindowMs
+                },
+                metadata: {
+                    segment: 'studio',
+                    region: normalized,
+                    collaborationId,
+                    complianceTier: 'managed'
+                }
+            };
+        });
+    }
+};
+
+const INDIE_LAB_PACK = {
+    id: 'indie-lab',
+    name: 'Indie Lab Starter Pack',
+    description: 'Lightweight attestation endpoints for independent wearable labs and prototyping collectives.',
+    defaults: {
+        baseUrl: 'https://licensing.indielab.example.com',
+        regions: ['global'],
+        pollIntervalMs: 60 * 60 * 1000,
+        minimumPollIntervalMs: 30 * 60 * 1000,
+        failOpen: true,
+        headers: {
+            'x-sdk-product': 'adaptive-interface-engine',
+            'x-sdk-tier': 'indie'
+        },
+        sla: {
+            responseTargetMs: 2500,
+            availability: '99.0%',
+            breachWindowMs: 30 * 60 * 1000
+        }
+    },
+    buildProfiles(options = {}) {
+        const regions = ensureArray(options.regions, this.defaults.regions);
+        const baseUrl = trimTrailingSlash(options.baseUrl || this.defaults.baseUrl);
+        const projectCode = options.projectCode || 'prototype';
+
+        return regions.map(region => {
+            const normalized = normalizeRegion(region);
+            const displayRegion = toDisplayRegion(normalized);
+            const regionPath = normalized === 'global' ? 'global' : normalized;
+            const attestationBase = `${baseUrl}/${projectCode}/${regionPath}`;
+
+            return {
+                id: `indie-lab/${projectCode}/${normalized}`,
+                name: `Indie Lab (${displayRegion})`,
+                description: `Low-friction attestation endpoints for ${projectCode} experiments in ${displayRegion}.`,
+                attestor: {
+                    attestationUrl: `${attestationBase}/attest`,
+                    revocationUrl: `${attestationBase}/revoke`,
+                    entitlementsUrl: `${attestationBase}/entitlements`,
+                    pollIntervalMs: options.pollIntervalMs ?? this.defaults.pollIntervalMs,
+                    minimumPollIntervalMs: options.minimumPollIntervalMs ?? this.defaults.minimumPollIntervalMs,
+                    failOpen: options.failOpen ?? this.defaults.failOpen,
+                    headers: { ...this.defaults.headers, ...(options.headers || {}), 'x-project-code': projectCode }
+                },
+                binding: {
+                    attestorOptions: {
+                        context: {
+                            region: normalized,
+                            projectCode,
+                            tier: 'indie'
+                        }
+                    }
+                },
+                sla: {
+                    responseTargetMs: options.sla?.responseTargetMs ?? this.defaults.sla.responseTargetMs,
+                    availability: options.sla?.availability ?? this.defaults.sla.availability,
+                    breachWindowMs: options.sla?.breachWindowMs ?? this.defaults.sla.breachWindowMs
+                },
+                metadata: {
+                    segment: 'indie',
+                    region: normalized,
+                    projectCode,
+                    complianceTier: 'experimental'
+                }
+            };
+        });
+    }
+};
+
+export const DEFAULT_LICENSE_ATTESTATION_PROFILE_PACKS = [
+    ENTERPRISE_SAAS_PACK,
+    STUDIO_COLLAB_PACK,
+    INDIE_LAB_PACK
+];
+
+export function instantiateLicenseAttestationProfilePack(packDescriptor, options = {}) {
+    if (!packDescriptor) {
+        throw new Error('A license attestation profile pack descriptor is required.');
+    }
+
+    const packOptions = {
+        ...(packDescriptor.defaults || {}),
+        ...(options || {})
+    };
+
+    let profiles;
+    if (typeof packDescriptor.buildProfiles === 'function') {
+        profiles = packDescriptor.buildProfiles(packOptions) || [];
+    } else if (Array.isArray(packDescriptor.profiles)) {
+        profiles = packDescriptor.profiles.map(profile => cloneProfile(profile));
+    } else {
+        profiles = [];
+    }
+
+    profiles = profiles.map(profile => {
+        if (profile.attestor && !(profile.attestor instanceof RemoteLicenseAttestor) && typeof profile.attestor === 'object') {
+            return cloneProfile({
+                ...profile,
+                attestor: { ...profile.attestor }
+            });
+        }
+        return cloneProfile(profile);
+    });
+
+    const defaultProfileId = packOptions.defaultProfileId
+        || packDescriptor.defaultProfileId
+        || (profiles[0] ? profiles[0].id : null);
+
+    return {
+        id: packDescriptor.id || options.id || 'custom-pack',
+        name: packDescriptor.name || options.name || packDescriptor.id || 'Custom Pack',
+        description: packDescriptor.description || options.description || '',
+        metadata: packDescriptor.metadata ? { ...packDescriptor.metadata } : (options.metadata ? { ...options.metadata } : undefined),
+        profiles,
+        defaultProfileId
+    };
+}
+
+export function resolveLicenseAttestationProfilePack(packOrId, options = {}) {
+    if (typeof packOrId === 'string') {
+        const descriptor = DEFAULT_LICENSE_ATTESTATION_PROFILE_PACKS.find(pack => pack.id === packOrId);
+        if (!descriptor) {
+            throw new Error(`Unknown license attestation profile pack: ${packOrId}`);
+        }
+        return instantiateLicenseAttestationProfilePack(descriptor, options);
+    }
+
+    if (packOrId && typeof packOrId === 'object') {
+        if (typeof packOrId.buildProfiles === 'function' || Array.isArray(packOrId.profiles)) {
+            return instantiateLicenseAttestationProfilePack(packOrId, options);
+        }
+        if (Array.isArray(packOrId.packages)) {
+            throw new Error('Nested license attestation profile packs are not supported.');
+        }
+        if (Array.isArray(packOrId.regions) || packOrId.baseUrl) {
+            return instantiateLicenseAttestationProfilePack({ ...ENTERPRISE_SAAS_PACK, ...packOrId }, options);
+        }
+    }
+
+    throw new Error('Invalid license attestation profile pack supplied.');
+}

--- a/src/product/licensing/LicenseAttestationProfileRegistry.js
+++ b/src/product/licensing/LicenseAttestationProfileRegistry.js
@@ -1,0 +1,189 @@
+import { RemoteLicenseAttestor } from './RemoteLicenseAttestor.js';
+
+function isObject(value) {
+    return value !== null && typeof value === 'object';
+}
+
+function cloneShallow(value) {
+    if (Array.isArray(value)) {
+        return value.map(item => (isObject(item) ? { ...item } : item));
+    }
+    if (isObject(value)) {
+        return { ...value };
+    }
+    return value;
+}
+
+export class LicenseAttestationProfileRegistry {
+    constructor(options = {}) {
+        this.profiles = new Map();
+        this.defaultProfileId = options.defaultProfileId || null;
+    }
+
+    hasProfile(id) {
+        return this.profiles.has(id);
+    }
+
+    registerProfile(profileOrId, maybeProfile) {
+        const profile = this.normalizeProfile(profileOrId, maybeProfile);
+        this.profiles.set(profile.id, profile);
+        if (!this.defaultProfileId) {
+            this.defaultProfileId = profile.id;
+        }
+        return this.getProfile(profile.id);
+    }
+
+    registerProfiles(profiles) {
+        if (!Array.isArray(profiles)) return [];
+        return profiles.map(profile => this.registerProfile(profile));
+    }
+
+    setDefaultProfile(id) {
+        if (!this.profiles.has(id)) {
+            throw new Error(`Unknown license attestation profile: ${id}`);
+        }
+        this.defaultProfileId = id;
+    }
+
+    getDefaultProfileId() {
+        return this.defaultProfileId;
+    }
+
+    clearDefaultProfile() {
+        this.defaultProfileId = null;
+    }
+
+    getProfile(id) {
+        if (!this.profiles.has(id)) {
+            return null;
+        }
+        const stored = this.profiles.get(id);
+        return {
+            id: stored.id,
+            name: stored.name,
+            description: stored.description,
+            attestor: stored.attestor,
+            createAttestor: stored.createAttestor,
+            binding: stored.binding ? { ...stored.binding } : undefined,
+            sla: stored.sla ? { ...stored.sla } : undefined,
+            metadata: stored.metadata ? { ...stored.metadata } : undefined
+        };
+    }
+
+    getProfiles() {
+        return Array.from(this.profiles.keys()).map(id => this.getProfile(id));
+    }
+
+    removeProfile(id) {
+        this.profiles.delete(id);
+        if (this.defaultProfileId === id) {
+            this.defaultProfileId = this.profiles.size > 0 ? this.profiles.keys().next().value : null;
+        }
+    }
+
+    normalizeProfile(profileOrId, maybeProfile) {
+        let profile;
+        if (typeof profileOrId === 'string') {
+            if (!maybeProfile || !isObject(maybeProfile)) {
+                throw new Error('License attestation profile options are required.');
+            }
+            profile = { id: profileOrId, ...maybeProfile };
+        } else if (isObject(profileOrId)) {
+            profile = { ...profileOrId };
+        } else {
+            throw new Error('Invalid license attestation profile.');
+        }
+
+        if (!profile.id || typeof profile.id !== 'string') {
+            throw new Error('License attestation profile must include an id.');
+        }
+
+        const normalized = {
+            id: profile.id,
+            name: typeof profile.name === 'string' ? profile.name : profile.id,
+            description: typeof profile.description === 'string' ? profile.description : '',
+            attestor: profile.attestor || null,
+            createAttestor: typeof profile.createAttestor === 'function' ? profile.createAttestor : null,
+            binding: profile.binding ? { ...profile.binding } : undefined,
+            sla: profile.sla ? { ...profile.sla } : undefined,
+            metadata: profile.metadata ? { ...profile.metadata } : undefined
+        };
+
+        if (!normalized.attestor && !normalized.createAttestor) {
+            throw new Error(`License attestation profile "${normalized.id}" requires an attestor definition.`);
+        }
+
+        return normalized;
+    }
+
+    resolveProfileId(profileId) {
+        const targetId = profileId || this.defaultProfileId;
+        if (!targetId) {
+            throw new Error('No license attestation profile id provided and no default set.');
+        }
+        if (!this.profiles.has(targetId)) {
+            throw new Error(`Unknown license attestation profile: ${targetId}`);
+        }
+        return targetId;
+    }
+
+    createAttestor(profileId, overrides = {}) {
+        const resolvedId = this.resolveProfileId(profileId);
+        const stored = this.profiles.get(resolvedId);
+
+        let attestorInstance = overrides.attestor || null;
+        const attestorOptionsOverride = overrides.attestorOptions || {};
+
+        if (!attestorInstance) {
+            if (stored.createAttestor) {
+                const result = stored.createAttestor({
+                    profile: this.getProfile(resolvedId),
+                    attestorOptions: attestorOptionsOverride,
+                    overrides
+                });
+                if (!result) {
+                    throw new Error(`createAttestor for profile "${resolvedId}" returned no attestor.`);
+                }
+                attestorInstance = result;
+            } else if (stored.attestor && (typeof stored.attestor.createValidator === 'function' || typeof stored.attestor.bindToLicenseManager === 'function')) {
+                attestorInstance = stored.attestor;
+            } else if (stored.attestor && isObject(stored.attestor)) {
+                const attestorConfig = { ...stored.attestor, ...attestorOptionsOverride };
+                attestorInstance = new RemoteLicenseAttestor(attestorConfig);
+            } else {
+                throw new Error(`Profile "${resolvedId}" does not include a valid attestor configuration.`);
+            }
+        }
+
+        const bindingOverrides = overrides.binding || {};
+        const binding = stored.binding ? { ...stored.binding } : {};
+
+        if (binding.attestorOptions || bindingOverrides.attestorOptions) {
+            binding.attestorOptions = {
+                ...(binding.attestorOptions ? cloneShallow(binding.attestorOptions) : {}),
+                ...(bindingOverrides.attestorOptions ? cloneShallow(bindingOverrides.attestorOptions) : {})
+            };
+        }
+
+        for (const [key, value] of Object.entries(bindingOverrides)) {
+            if (key === 'attestorOptions') continue;
+            binding[key] = value;
+        }
+
+        let metadata = stored.metadata ? { ...stored.metadata } : undefined;
+        if (overrides.metadata) {
+            metadata = { ...(metadata || {}), ...overrides.metadata };
+        }
+
+        const profile = this.getProfile(resolvedId);
+        if (metadata) {
+            profile.metadata = metadata;
+        }
+
+        return {
+            attestor: attestorInstance,
+            binding,
+            profile
+        };
+    }
+}

--- a/src/product/licensing/LicenseCommercializationReporter.js
+++ b/src/product/licensing/LicenseCommercializationReporter.js
@@ -1,0 +1,290 @@
+function cloneMetadata(value) {
+    if (!value || typeof value !== 'object') {
+        return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeProfile(profile) {
+    if (!profile) return null;
+    return {
+        id: profile.id,
+        name: profile.name,
+        description: profile.description,
+        metadata: cloneMetadata(profile.metadata),
+        sla: profile.sla ? { ...profile.sla } : undefined
+    };
+}
+
+function extractProfilesFromPack(pack) {
+    if (!pack || !Array.isArray(pack.profiles)) {
+        return [];
+    }
+    return pack.profiles.map(normalizeProfile).filter(Boolean);
+}
+
+function toIso(timestamp) {
+    return timestamp ? new Date(timestamp).toISOString() : null;
+}
+
+function parseAvailability(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value !== 'string') return null;
+    const numeric = parseFloat(value.replace(/%/g, ''));
+    return Number.isFinite(numeric) ? numeric : null;
+}
+
+function aggregateMetric(values) {
+    const filtered = values.filter(value => typeof value === 'number' && !Number.isNaN(value));
+    if (filtered.length === 0) return null;
+    const min = Math.min(...filtered);
+    const max = Math.max(...filtered);
+    const average = filtered.reduce((sum, value) => sum + value, 0) / filtered.length;
+    return { min, max, average };
+}
+
+function ensureSet(map, key) {
+    if (!map.has(key)) {
+        map.set(key, new Set());
+    }
+    return map.get(key);
+}
+
+export class LicenseCommercializationReporter {
+    constructor(options = {}) {
+        this.packs = new Map();
+        this.profiles = new Map();
+        this.profileToPack = new Map();
+        this.adoption = new Map();
+        this.defaultProfileId = null;
+        this.lastUpdated = null;
+        this.updateListeners = [];
+        if (typeof options.onUpdate === 'function') {
+            this.addUpdateListener(options.onUpdate);
+        }
+        this.emitProfileDetails = options.emitProfileDetails ?? true;
+    }
+
+    touch() {
+        this.lastUpdated = new Date();
+        const summary = this.getSummary();
+        for (const listener of this.updateListeners) {
+            try {
+                listener(summary);
+            } catch (error) {
+                console?.warn?.('LicenseCommercializationReporter onUpdate failed', error);
+            }
+        }
+    }
+
+    addUpdateListener(listener) {
+        if (typeof listener !== 'function') {
+            throw new Error('LicenseCommercializationReporter update listener must be a function.');
+        }
+        this.updateListeners.push(listener);
+        return () => this.removeUpdateListener(listener);
+    }
+
+    removeUpdateListener(listener) {
+        const index = this.updateListeners.indexOf(listener);
+        if (index >= 0) {
+            this.updateListeners.splice(index, 1);
+        }
+    }
+
+    recordPackRegistration(pack, context = {}) {
+        if (!pack) return;
+        const profiles = extractProfilesFromPack(pack);
+        const entry = {
+            id: pack.id,
+            name: pack.name,
+            description: pack.description,
+            metadata: cloneMetadata(pack.metadata),
+            profileIds: new Set(profiles.map(profile => profile.id)),
+            registeredAt: new Date(),
+            appliedDefault: context.appliedDefault ?? (pack.defaultProfileId ? context.applyDefault !== false : false),
+            defaultProfileId: context.defaultProfileId ?? pack.defaultProfileId ?? null,
+            options: cloneMetadata(context.options)
+        };
+        this.packs.set(entry.id, entry);
+        if (entry.defaultProfileId) {
+            this.defaultProfileId = entry.defaultProfileId;
+        }
+        for (const profile of profiles) {
+            this.profileToPack.set(profile.id, entry.id);
+        }
+        if (Array.isArray(context.registeredProfileIds)) {
+            for (const profileId of context.registeredProfileIds) {
+                this.profileToPack.set(profileId, entry.id);
+            }
+        }
+        this.touch();
+    }
+
+    recordProfileRegistration(profile, context = {}) {
+        const normalized = normalizeProfile(profile);
+        if (!normalized) return;
+        const packId = context.packId || this.profileToPack.get(normalized.id) || null;
+        const details = {
+            profile: normalized,
+            packId,
+            registeredAt: new Date(),
+            source: context.source || (packId ? 'catalog-pack' : 'direct'),
+            metadata: cloneMetadata(context.metadata)
+        };
+        this.profiles.set(normalized.id, details);
+        if (packId) {
+            this.profileToPack.set(normalized.id, packId);
+        }
+        if (context.setAsDefault) {
+            this.defaultProfileId = normalized.id;
+        }
+        this.touch();
+    }
+
+    recordProfileApplied(profile, context = {}) {
+        const normalized = normalizeProfile(profile);
+        if (!normalized) return;
+        const packId = context.packId || this.profileToPack.get(normalized.id) || null;
+        const adoption = this.adoption.get(normalized.id) || {
+            count: 0,
+            lastAppliedAt: null,
+            history: []
+        };
+        adoption.count += 1;
+        const appliedAt = new Date();
+        adoption.lastAppliedAt = appliedAt;
+        if (this.emitProfileDetails !== false) {
+            adoption.history.push({
+                at: appliedAt.toISOString(),
+                packId,
+                context: cloneMetadata(context.context)
+            });
+        }
+        this.adoption.set(normalized.id, adoption);
+        this.touch();
+    }
+
+    recordDefaultProfileChange(profileId, context = {}) {
+        if (profileId) {
+            this.defaultProfileId = profileId;
+        } else {
+            this.defaultProfileId = null;
+        }
+        const packId = profileId ? this.profileToPack.get(profileId) : null;
+        if (packId && this.packs.has(packId)) {
+            const pack = this.packs.get(packId);
+            pack.defaultProfileId = profileId;
+            this.packs.set(packId, pack);
+        }
+        if (context.packId && this.packs.has(context.packId)) {
+            const pack = this.packs.get(context.packId);
+            pack.defaultProfileId = profileId;
+            this.packs.set(context.packId, pack);
+        }
+        this.touch();
+    }
+
+    getPackIdForProfile(profileId) {
+        return this.profileToPack.get(profileId) || null;
+    }
+
+    getSummary() {
+        const packs = [];
+        for (const entry of this.packs.values()) {
+            const adoptionCount = Array.from(entry.profileIds.values())
+                .reduce((sum, profileId) => sum + (this.adoption.get(profileId)?.count || 0), 0);
+            packs.push({
+                id: entry.id,
+                name: entry.name,
+                description: entry.description,
+                metadata: cloneMetadata(entry.metadata),
+                profileIds: Array.from(entry.profileIds.values()),
+                registeredAt: toIso(entry.registeredAt),
+                appliedDefault: entry.appliedDefault,
+                defaultProfileId: entry.defaultProfileId || null,
+                adoptionCount,
+                options: cloneMetadata(entry.options)
+            });
+        }
+
+        const profiles = [];
+        for (const [id, record] of this.profiles.entries()) {
+            const adoption = this.adoption.get(id);
+            profiles.push({
+                id,
+                name: record.profile.name,
+                description: record.profile.description,
+                metadata: cloneMetadata(record.profile.metadata),
+                sla: record.profile.sla ? { ...record.profile.sla } : undefined,
+                packId: record.packId || null,
+                registeredAt: toIso(record.registeredAt),
+                source: record.source,
+                adoptionCount: adoption?.count || 0,
+                lastAppliedAt: adoption?.lastAppliedAt ? adoption.lastAppliedAt.toISOString() : null
+            });
+        }
+
+        const segments = new Map();
+        const regions = new Map();
+        const responseTargets = [];
+        const availabilities = [];
+        const breachWindows = [];
+
+        for (const profile of profiles) {
+            const metadata = profile.metadata || {};
+            const segment = metadata.segment || 'unspecified';
+            const region = metadata.region || 'global';
+            const segmentEntry = ensureSet(segments, segment);
+            segmentEntry.add(profile.id);
+            const regionEntry = ensureSet(regions, region);
+            regionEntry.add(profile.id);
+
+            if (profile.sla) {
+                if (typeof profile.sla.responseTargetMs === 'number') {
+                    responseTargets.push(profile.sla.responseTargetMs);
+                }
+                if (typeof profile.sla.breachWindowMs === 'number') {
+                    breachWindows.push(profile.sla.breachWindowMs);
+                }
+                const availability = parseAvailability(profile.sla.availability);
+                if (availability !== null) {
+                    availabilities.push(availability);
+                }
+            }
+        }
+
+        const segmentSummary = {};
+        for (const [segment, ids] of segments.entries()) {
+            segmentSummary[segment] = {
+                profileCount: ids.size,
+                packIds: Array.from(new Set(Array.from(ids.values()).map(id => this.profileToPack.get(id) || null).filter(Boolean))),
+                adoptionCount: Array.from(ids.values()).reduce((sum, id) => sum + (this.adoption.get(id)?.count || 0), 0)
+            };
+        }
+
+        const regionSummary = {};
+        for (const [region, ids] of regions.entries()) {
+            regionSummary[region] = {
+                profileCount: ids.size,
+                adoptionCount: Array.from(ids.values()).reduce((sum, id) => sum + (this.adoption.get(id)?.count || 0), 0)
+            };
+        }
+
+        const sla = {
+            responseTargetMs: aggregateMetric(responseTargets),
+            availabilityPercent: aggregateMetric(availabilities),
+            breachWindowMs: aggregateMetric(breachWindows)
+        };
+
+        return {
+            packs,
+            profiles,
+            segments: segmentSummary,
+            regions: regionSummary,
+            sla,
+            defaultProfileId: this.defaultProfileId,
+            lastUpdated: this.lastUpdated ? this.lastUpdated.toISOString() : null
+        };
+    }
+}

--- a/src/product/licensing/LicenseCommercializationSnapshotStore.js
+++ b/src/product/licensing/LicenseCommercializationSnapshotStore.js
@@ -1,0 +1,308 @@
+import { LicenseCommercializationReporter } from './LicenseCommercializationReporter.js';
+
+function clone(value) {
+    if (value === undefined || value === null) return value;
+    if (typeof value !== 'object') return value;
+    return JSON.parse(JSON.stringify(value));
+}
+
+function isPromise(value) {
+    return Boolean(value) && typeof value.then === 'function';
+}
+
+function guardAsync(result, message) {
+    if (isPromise(result)) {
+        result.catch(error => {
+            console?.warn?.(message, error);
+        });
+    }
+}
+
+function computeKpis(summary = {}) {
+    const packs = Array.isArray(summary.packs) ? summary.packs : [];
+    const profiles = Array.isArray(summary.profiles) ? summary.profiles : [];
+    const segments = summary.segments && typeof summary.segments === 'object' ? summary.segments : {};
+    const regions = summary.regions && typeof summary.regions === 'object' ? summary.regions : {};
+
+    const totalAdoption = profiles.reduce((sum, profile) => sum + (profile?.adoptionCount || 0), 0);
+    const activePacks = packs.filter(pack => (pack?.adoptionCount || 0) > 0).length;
+    const activeProfiles = profiles.filter(profile => (profile?.adoptionCount || 0) > 0).length;
+
+    const adoptionPerPack = packs.length > 0 ? totalAdoption / packs.length : 0;
+    const adoptionPerProfile = profiles.length > 0 ? totalAdoption / profiles.length : 0;
+
+    const topSegments = Object.entries(segments)
+        .map(([key, data]) => ({ key, adoption: data?.adoptionCount || 0, profiles: data?.profileCount || 0 }))
+        .sort((a, b) => b.adoption - a.adoption)
+        .slice(0, 3);
+
+    const topRegions = Object.entries(regions)
+        .map(([key, data]) => ({ key, adoption: data?.adoptionCount || 0, profiles: data?.profileCount || 0 }))
+        .sort((a, b) => b.adoption - a.adoption)
+        .slice(0, 3);
+
+    return {
+        totalPacks: packs.length,
+        totalProfiles: profiles.length,
+        totalAdoption,
+        activePacks,
+        activeProfiles,
+        adoptionPerPack,
+        adoptionPerProfile,
+        segmentCount: Object.keys(segments).length,
+        regionCount: Object.keys(regions).length,
+        defaultProfileId: summary.defaultProfileId || null,
+        lastUpdated: summary.lastUpdated || null,
+        topSegments,
+        topRegions
+    };
+}
+
+function normalizeSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') return null;
+    const capturedAt = snapshot.capturedAt ? new Date(snapshot.capturedAt).toISOString() : new Date().toISOString();
+    const summary = clone(snapshot.summary);
+    const context = snapshot.context && typeof snapshot.context === 'object' ? clone(snapshot.context) : {};
+    const kpis = snapshot.kpis && typeof snapshot.kpis === 'object' ? { ...snapshot.kpis } : computeKpis(summary);
+
+    return {
+        id: snapshot.id || capturedAt,
+        capturedAt,
+        summary,
+        context,
+        kpis
+    };
+}
+
+export class LicenseCommercializationSnapshotStore {
+    constructor(options = {}) {
+        this.maxSnapshots = Number.isFinite(options.maxSnapshots) ? Math.max(1, options.maxSnapshots) : 120;
+        this.snapshots = [];
+        this.storage = options.storage || null;
+        this.onChange = typeof options.onChange === 'function' ? options.onChange : null;
+
+        this.readyPromise = Promise.resolve(this.getSnapshots());
+        this.initializeFromStorage();
+    }
+
+    persist() {
+        if (this.storage && typeof this.storage.saveSnapshots === 'function') {
+            try {
+                const result = this.storage.saveSnapshots(this.snapshots.map(snapshot => clone(snapshot)));
+                guardAsync(result, 'LicenseCommercializationSnapshotStore persist failed');
+            } catch (error) {
+                console?.warn?.('LicenseCommercializationSnapshotStore persist failed', error);
+            }
+        }
+    }
+
+    notifyChange() {
+        if (this.onChange) {
+            try {
+                this.onChange(this.getSnapshots());
+            } catch (error) {
+                console?.warn?.('LicenseCommercializationSnapshotStore onChange failed', error);
+            }
+        }
+    }
+
+    recordSnapshot(summary, context = {}) {
+        const normalizedSummary = summary instanceof LicenseCommercializationReporter ? summary.getSummary() : summary;
+        const snapshot = normalizeSnapshot({
+            summary: clone(normalizedSummary),
+            context: clone(context),
+            capturedAt: new Date().toISOString()
+        });
+
+        this.snapshots.unshift(snapshot);
+        if (this.snapshots.length > this.maxSnapshots) {
+            this.snapshots.length = this.maxSnapshots;
+        }
+        this.persist();
+        if (this.storage && typeof this.storage.appendSnapshot === 'function') {
+            try {
+                const result = this.storage.appendSnapshot(clone(snapshot));
+                guardAsync(result, 'LicenseCommercializationSnapshotStore append failed');
+            } catch (error) {
+                console?.warn?.('LicenseCommercializationSnapshotStore append failed', error);
+            }
+        }
+        this.notifyChange();
+        return clone(snapshot);
+    }
+
+    getSnapshots(options = {}) {
+        const limit = Number.isFinite(options.limit) ? Math.max(1, options.limit) : this.snapshots.length;
+        const results = this.snapshots.slice(0, limit).map(snapshot => clone(snapshot));
+        if (options.withSummary === false) {
+            return results.map(snapshot => ({
+                id: snapshot.id,
+                capturedAt: snapshot.capturedAt,
+                context: snapshot.context,
+                kpis: snapshot.kpis
+            }));
+        }
+        return results;
+    }
+
+    getLatestSnapshot() {
+        if (this.snapshots.length === 0) return null;
+        return clone(this.snapshots[0]);
+    }
+
+    getKpiReport(options = {}) {
+        const snapshots = this.getSnapshots({ limit: options.limit ?? 2 });
+        const latest = snapshots[0] || null;
+        const previous = snapshots[1] || null;
+        const deltas = {};
+
+        if (latest && previous) {
+            for (const key of Object.keys(latest.kpis || {})) {
+                if (typeof latest.kpis[key] === 'number' && typeof previous.kpis?.[key] === 'number') {
+                    deltas[key] = latest.kpis[key] - previous.kpis[key];
+                }
+            }
+        }
+
+        return {
+            latest,
+            previous,
+            deltas
+        };
+    }
+
+    exportForBi(options = {}) {
+        const format = options.format || 'object';
+        const includeSummary = options.includeSummary ?? true;
+        const payload = {
+            generatedAt: new Date().toISOString(),
+            snapshotCount: this.snapshots.length,
+            snapshots: this.snapshots.map(snapshot => {
+                const entry = {
+                    id: snapshot.id,
+                    capturedAt: snapshot.capturedAt,
+                    context: clone(snapshot.context),
+                    kpis: { ...snapshot.kpis }
+                };
+                if (includeSummary) {
+                    entry.summary = clone(snapshot.summary);
+                }
+                return entry;
+            })
+        };
+
+        if (format === 'json') {
+            return JSON.stringify(payload, null, options.pretty === false ? 0 : 2);
+        }
+
+        if (format === 'csv') {
+            const headers = [
+                'id',
+                'capturedAt',
+                'totalPacks',
+                'totalProfiles',
+                'totalAdoption',
+                'activePacks',
+                'activeProfiles',
+                'adoptionPerPack',
+                'adoptionPerProfile',
+                'segmentCount',
+                'regionCount',
+                'defaultProfileId'
+            ];
+            const rows = [headers.join(',')];
+            for (const snapshot of payload.snapshots) {
+                const { kpis } = snapshot;
+                rows.push([
+                    snapshot.id,
+                    snapshot.capturedAt,
+                    kpis.totalPacks ?? '',
+                    kpis.totalProfiles ?? '',
+                    kpis.totalAdoption ?? '',
+                    kpis.activePacks ?? '',
+                    kpis.activeProfiles ?? '',
+                    kpis.adoptionPerPack ?? '',
+                    kpis.adoptionPerProfile ?? '',
+                    kpis.segmentCount ?? '',
+                    kpis.regionCount ?? '',
+                    kpis.defaultProfileId ?? ''
+                ].join(','));
+            }
+            return rows.join('\n');
+        }
+
+        return payload;
+    }
+
+    clearSnapshots() {
+        this.snapshots = [];
+        this.persist();
+        if (this.storage && typeof this.storage.clearSnapshots === 'function') {
+            try {
+                const result = this.storage.clearSnapshots();
+                guardAsync(result, 'LicenseCommercializationSnapshotStore clear failed');
+            } catch (error) {
+                console?.warn?.('LicenseCommercializationSnapshotStore clear failed', error);
+            }
+        }
+        this.notifyChange();
+    }
+
+    whenReady() {
+        return this.readyPromise;
+    }
+
+    initializeFromStorage() {
+        if (!this.storage || typeof this.storage.loadSnapshots !== 'function') {
+            this.readyPromise = Promise.resolve(this.getSnapshots());
+            return;
+        }
+
+        try {
+            const loaded = this.storage.loadSnapshots();
+            if (isPromise(loaded)) {
+                this.readyPromise = loaded
+                    .then(data => {
+                        this.applyLoadedSnapshots(data);
+                        return this.getSnapshots();
+                    })
+                    .catch(error => {
+                        console?.warn?.('LicenseCommercializationSnapshotStore load failed', error);
+                        this.snapshots = [];
+                        return this.getSnapshots();
+                    });
+            } else {
+                this.applyLoadedSnapshots(loaded);
+                this.readyPromise = Promise.resolve(this.getSnapshots());
+            }
+        } catch (error) {
+            console?.warn?.('LicenseCommercializationSnapshotStore load failed', error);
+            this.snapshots = [];
+            this.readyPromise = Promise.resolve(this.getSnapshots());
+        }
+    }
+
+    applyLoadedSnapshots(loaded) {
+        if (!Array.isArray(loaded)) {
+            return;
+        }
+
+        this.snapshots = loaded
+            .map(normalizeSnapshot)
+            .filter(Boolean)
+            .sort((a, b) => new Date(b.capturedAt).getTime() - new Date(a.capturedAt).getTime())
+            .slice(0, this.maxSnapshots);
+    }
+}
+
+export function createInMemoryCommercializationSnapshotStorage(initial = []) {
+    let data = Array.isArray(initial) ? initial.slice() : [];
+    return {
+        loadSnapshots() {
+            return data.slice();
+        },
+        saveSnapshots(snapshots) {
+            data = Array.isArray(snapshots) ? snapshots.slice() : [];
+        }
+    };
+}

--- a/src/product/licensing/LicenseManager.js
+++ b/src/product/licensing/LicenseManager.js
@@ -1,0 +1,281 @@
+const DEFAULT_STATUS = {
+    state: 'unregistered',
+    reason: 'NO_LICENSE',
+    validatedAt: null
+};
+
+function clone(obj) {
+    if (!obj || typeof obj !== 'object') return obj;
+    return JSON.parse(JSON.stringify(obj));
+}
+
+export class LicenseManager {
+    constructor(options = {}) {
+        this.clock = typeof options.clock === 'function' ? options.clock : () => new Date();
+        this.logger = options.logger || console;
+        this.validators = [];
+        this.listeners = new Set();
+        this.status = { ...DEFAULT_STATUS };
+        this.currentLicense = null;
+        this.validationHistory = [];
+
+        if (Array.isArray(options.validators)) {
+            for (const validator of options.validators) {
+                this.registerValidator(validator);
+            }
+        }
+    }
+
+    onStatusChange(listener) {
+        if (typeof listener !== 'function') {
+            throw new TypeError('LicenseManager.onStatusChange requires a function listener');
+        }
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    notify(status) {
+        for (const listener of this.listeners) {
+            try {
+                listener(clone(status));
+            } catch (error) {
+                this.logger?.warn?.('LicenseManager listener failed', error);
+            }
+        }
+    }
+
+    getLicense() {
+        return clone(this.currentLicense);
+    }
+
+    setLicense(license = null) {
+        if (license === null) {
+            this.clearLicense();
+            return { ...this.status };
+        }
+
+        if (typeof license !== 'object' || !license.key) {
+            throw new TypeError('LicenseManager.setLicense requires a license object with a key');
+        }
+
+        this.currentLicense = {
+            key: license.key,
+            tenantId: license.tenantId || null,
+            features: Array.isArray(license.features) ? [...new Set(license.features)] : [],
+            expiresAt: license.expiresAt || null,
+            issuedAt: license.issuedAt || null,
+            signature: license.signature || null,
+            metadata: license.metadata ? { ...license.metadata } : {}
+        };
+
+        this.status = {
+            state: 'pending',
+            reason: 'PENDING_VALIDATION',
+            validatedAt: null
+        };
+
+        this.notify(this.status);
+        return { ...this.status };
+    }
+
+    clearLicense() {
+        this.currentLicense = null;
+        this.status = { ...DEFAULT_STATUS };
+        this.notify(this.status);
+        return { ...this.status };
+    }
+
+    registerValidator(validator) {
+        if (typeof validator !== 'function') {
+            throw new TypeError('LicenseManager validator must be a function');
+        }
+        this.validators.push(validator);
+        return () => {
+            const index = this.validators.indexOf(validator);
+            if (index >= 0) {
+                this.validators.splice(index, 1);
+            }
+        };
+    }
+
+    async validate(context = {}) {
+        if (!this.currentLicense) {
+            this.status = { ...DEFAULT_STATUS };
+            this.recordHistory(this.status);
+            this.notify(this.status);
+            return { ...this.status };
+        }
+
+        const now = this.clock();
+        const nowTime = now instanceof Date ? now.getTime() : new Date(now).getTime();
+
+        if (!this.currentLicense.key) {
+            this.status = {
+                state: 'invalid',
+                reason: 'MISSING_KEY',
+                validatedAt: this.toIsoString(nowTime)
+            };
+            this.recordHistory(this.status);
+            this.notify(this.status);
+            return { ...this.status };
+        }
+
+        if (this.currentLicense.expiresAt) {
+            const expiresTime = new Date(this.currentLicense.expiresAt).getTime();
+            if (Number.isNaN(expiresTime)) {
+                this.status = {
+                    state: 'invalid',
+                    reason: 'INVALID_EXPIRY',
+                    validatedAt: this.toIsoString(nowTime)
+                };
+                this.recordHistory(this.status);
+                this.notify(this.status);
+                return { ...this.status };
+            }
+            if (nowTime >= expiresTime) {
+                this.status = {
+                    state: 'expired',
+                    reason: 'LICENSE_EXPIRED',
+                    validatedAt: this.toIsoString(nowTime)
+                };
+                this.recordHistory(this.status);
+                this.notify(this.status);
+                return { ...this.status };
+            }
+        }
+
+        let mergedMetadata = {};
+        for (const validator of this.validators) {
+            try {
+                const result = await validator({ ...this.currentLicense }, { ...context });
+                if (result === false) {
+                    this.status = {
+                        state: 'invalid',
+                        reason: 'VALIDATOR_REJECTED',
+                        validatedAt: this.toIsoString(nowTime)
+                    };
+                    this.recordHistory(this.status);
+                    this.notify(this.status);
+                    return { ...this.status };
+                }
+                if (result && typeof result === 'object') {
+                    if (result.valid === false) {
+                        this.status = {
+                            state: 'invalid',
+                            reason: result.reason || 'VALIDATOR_REJECTED',
+                            validatedAt: this.toIsoString(nowTime)
+                        };
+                        this.recordHistory(this.status);
+                        this.notify(this.status);
+                        return { ...this.status };
+                    }
+                    if (result.metadata && typeof result.metadata === 'object') {
+                        mergedMetadata = { ...mergedMetadata, ...result.metadata };
+                    }
+                }
+            } catch (error) {
+                this.logger?.warn?.('License validator threw error', error);
+                this.status = {
+                    state: 'invalid',
+                    reason: 'VALIDATOR_ERROR',
+                    error: error?.message || 'Unknown validator error',
+                    validatedAt: this.toIsoString(nowTime)
+                };
+                this.recordHistory(this.status);
+                this.notify(this.status);
+                return { ...this.status };
+            }
+        }
+
+        this.status = {
+            state: 'valid',
+            reason: 'VALID',
+            metadata: undefined,
+            validatedAt: this.toIsoString(nowTime)
+        };
+
+        if (Object.keys(mergedMetadata).length) {
+            if (this.currentLicense) {
+                if (Array.isArray(mergedMetadata.entitlements)) {
+                    const featureSet = new Set(this.currentLicense.features || []);
+                    for (const feature of mergedMetadata.entitlements) {
+                        if (typeof feature === 'string' && feature) {
+                            featureSet.add(feature);
+                        }
+                    }
+                    this.currentLicense.features = [...featureSet];
+                }
+
+                if (mergedMetadata.remote && mergedMetadata.remote.entitlements?.entitlements) {
+                    const featureSet = new Set(this.currentLicense.features || []);
+                    for (const feature of mergedMetadata.remote.entitlements.entitlements) {
+                        if (typeof feature === 'string' && feature) {
+                            featureSet.add(feature);
+                        }
+                    }
+                    this.currentLicense.features = [...featureSet];
+                }
+
+                const existingMetadata = this.currentLicense.metadata && typeof this.currentLicense.metadata === 'object'
+                    ? { ...this.currentLicense.metadata }
+                    : {};
+
+                this.currentLicense.metadata = { ...existingMetadata, ...mergedMetadata };
+            }
+
+            this.status.metadata = mergedMetadata;
+        }
+        this.recordHistory(this.status);
+        this.notify(this.status);
+        return { ...this.status };
+    }
+
+    recordHistory(status) {
+        this.validationHistory.push({
+            status: { ...status },
+            timestamp: this.toIsoString(this.clock())
+        });
+        if (this.validationHistory.length > 50) {
+            this.validationHistory.shift();
+        }
+    }
+
+    toIsoString(value) {
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+        const time = typeof value === 'number' ? value : new Date(value).getTime();
+        if (Number.isNaN(time)) {
+            return new Date().toISOString();
+        }
+        return new Date(time).toISOString();
+    }
+
+    getStatus() {
+        return { ...this.status };
+    }
+
+    getValidationHistory() {
+        return this.validationHistory.map(entry => ({
+            status: { ...entry.status },
+            timestamp: entry.timestamp
+        }));
+    }
+
+    hasFeature(feature) {
+        if (!feature) return false;
+        return Array.isArray(this.currentLicense?.features) && this.currentLicense.features.includes(feature);
+    }
+
+    requireFeature(feature) {
+        if (!this.hasFeature(feature)) {
+            const error = new Error(`License does not grant required feature: ${feature}`);
+            error.code = 'LICENSE_FEATURE_MISSING';
+            throw error;
+        }
+    }
+
+    isActive() {
+        return this.status.state === 'valid';
+    }
+}

--- a/src/product/licensing/RemoteLicenseAttestor.js
+++ b/src/product/licensing/RemoteLicenseAttestor.js
@@ -1,0 +1,421 @@
+const DEFAULT_HEADERS = {
+    'content-type': 'application/json'
+};
+
+function toIsoString(clock, fallback = new Date()) {
+    try {
+        const value = typeof clock === 'function' ? clock() : clock;
+        if (!value) {
+            return new Date(fallback).toISOString();
+        }
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+        const time = typeof value === 'number' ? value : new Date(value).getTime();
+        if (Number.isNaN(time)) {
+            return new Date(fallback).toISOString();
+        }
+        return new Date(time).toISOString();
+    } catch (error) {
+        return new Date(fallback).toISOString();
+    }
+}
+
+function ensureFetch(fetchImpl) {
+    if (typeof fetchImpl === 'function') {
+        return fetchImpl;
+    }
+    if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
+        return globalThis.fetch.bind(globalThis);
+    }
+    throw new Error('RemoteLicenseAttestor requires a fetch implementation');
+}
+
+function isFunction(value) {
+    return typeof value === 'function';
+}
+
+function safeJsonParse(text) {
+    if (!text) return {};
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        return { raw: text };
+    }
+}
+
+function normalizeHeaders(headers = {}) {
+    const result = { ...DEFAULT_HEADERS };
+    for (const [key, value] of Object.entries(headers)) {
+        if (typeof value === 'undefined') continue;
+        result[key.toLowerCase()] = value;
+    }
+    return result;
+}
+
+export class RemoteLicenseAttestor {
+    constructor(options = {}) {
+        this.attestationUrl = options.attestationUrl || null;
+        this.revocationUrl = options.revocationUrl || null;
+        this.entitlementsUrl = options.entitlementsUrl || null;
+        this.fetch = ensureFetch(options.fetch);
+        this.logger = options.logger || console;
+        this.clock = isFunction(options.clock) ? options.clock : () => new Date();
+        this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? options.pollIntervalMs : 60 * 60 * 1000;
+        this.minimumPollIntervalMs = typeof options.minimumPollIntervalMs === 'number' ? options.minimumPollIntervalMs : 5 * 60 * 1000;
+        this.failOpen = options.failOpen ?? false;
+        this.requestHeaders = normalizeHeaders(options.headers);
+        this.transformRequest = isFunction(options.transformRequest) ? options.transformRequest : null;
+        this.transformResponse = isFunction(options.transformResponse) ? options.transformResponse : null;
+        this.historyLimit = typeof options.historyLimit === 'number' ? options.historyLimit : 50;
+
+        this.listeners = new Map();
+        this.history = [];
+        this.lastResult = null;
+        this.attestationTimer = null;
+        this.boundLicenseManager = null;
+        this.unregisterValidator = null;
+        this.unsubscribeStatus = null;
+    }
+
+    on(event, listener) {
+        if (!isFunction(listener)) {
+            throw new TypeError('RemoteLicenseAttestor.on requires a function listener');
+        }
+        if (!this.listeners.has(event)) {
+            this.listeners.set(event, new Set());
+        }
+        const listeners = this.listeners.get(event);
+        listeners.add(listener);
+        return () => this.off(event, listener);
+    }
+
+    off(event, listener) {
+        const listeners = this.listeners.get(event);
+        if (!listeners) return;
+        listeners.delete(listener);
+        if (listeners.size === 0) {
+            this.listeners.delete(event);
+        }
+    }
+
+    emit(event, payload) {
+        const listeners = this.listeners.get(event);
+        if (!listeners) return;
+        for (const listener of listeners) {
+            try {
+                listener(payload);
+            } catch (error) {
+                this.logger?.warn?.('RemoteLicenseAttestor listener error', error);
+            }
+        }
+    }
+
+    recordHistory(entry) {
+        this.history.push({
+            timestamp: toIsoString(this.clock),
+            entry
+        });
+        if (this.history.length > this.historyLimit) {
+            this.history.shift();
+        }
+    }
+
+    getHistory() {
+        return this.history.map(item => ({
+            timestamp: item.timestamp,
+            entry: item.entry
+        }));
+    }
+
+    getLastResult() {
+        return this.lastResult ? { ...this.lastResult } : null;
+    }
+
+    createRequestPayload(type, license, context) {
+        const basePayload = {
+            license: {
+                key: license.key,
+                tenantId: license.tenantId || null,
+                signature: license.signature || null,
+                features: Array.isArray(license.features) ? license.features : [],
+                expiresAt: license.expiresAt || null,
+                issuedAt: license.issuedAt || null,
+                metadata: license.metadata || null
+            },
+            context: context || {},
+            timestamp: toIsoString(this.clock)
+        };
+
+        if (this.transformRequest) {
+            return this.transformRequest({ type, payload: basePayload }) || basePayload;
+        }
+        return basePayload;
+    }
+
+    async performFetch(url, payload, type) {
+        const requestInit = {
+            method: 'POST',
+            headers: { ...this.requestHeaders },
+            body: JSON.stringify(payload)
+        };
+
+        let request = requestInit;
+        if (this.transformRequest) {
+            const transformed = this.transformRequest({ type, payload, request: requestInit }) || requestInit;
+            request = { ...requestInit, ...transformed };
+            if (transformed?.headers) {
+                request.headers = normalizeHeaders(transformed.headers);
+            }
+        }
+
+        const response = await this.fetch(url, request);
+        const text = typeof response.text === 'function' ? await response.text() : '';
+        const data = this.transformResponse ? this.transformResponse({ type, response, text }) : safeJsonParse(text);
+
+        if (!response.ok) {
+            const error = new Error(`Remote attestation request failed with status ${response.status}`);
+            error.status = response.status;
+            error.response = data;
+            throw error;
+        }
+
+        return data || {};
+    }
+
+    async attest(license, context = {}) {
+        if (!this.attestationUrl) {
+            return { skipped: true };
+        }
+
+        const payload = this.createRequestPayload('attestation', license, context);
+        const data = await this.performFetch(this.attestationUrl, payload, 'attestation');
+        const attestedAt = data.attestedAt || data.timestamp || toIsoString(this.clock);
+
+        return {
+            valid: data.valid !== false,
+            reason: data.reason || (data.valid === false ? 'REMOTE_INVALID' : 'REMOTE_VALID'),
+            attestedAt,
+            nextCheckAt: data.nextCheckAt || null,
+            nextCheckInMs: typeof data.nextCheckInMs === 'number' ? data.nextCheckInMs : null,
+            metadata: data.metadata || null,
+            raw: data
+        };
+    }
+
+    async checkRevocation(license, context = {}) {
+        if (!this.revocationUrl) {
+            return { skipped: true };
+        }
+        const payload = this.createRequestPayload('revocation', license, context);
+        const data = await this.performFetch(this.revocationUrl, payload, 'revocation');
+        return {
+            revoked: data.revoked === true,
+            reason: data.reason || (data.revoked ? 'REMOTE_REVOKED' : 'REMOTE_ACTIVE'),
+            checkedAt: data.checkedAt || data.timestamp || toIsoString(this.clock),
+            metadata: data.metadata || null,
+            raw: data
+        };
+    }
+
+    async syncEntitlements(license, context = {}) {
+        if (!this.entitlementsUrl) {
+            return { skipped: true };
+        }
+        const payload = this.createRequestPayload('entitlements', license, context);
+        const data = await this.performFetch(this.entitlementsUrl, payload, 'entitlements');
+        const entitlements = Array.isArray(data.entitlements) ? data.entitlements : [];
+        return {
+            entitlements,
+            updatedAt: data.updatedAt || data.timestamp || toIsoString(this.clock),
+            ttlMs: typeof data.ttlMs === 'number' ? data.ttlMs : null,
+            metadata: data.metadata || null,
+            raw: data
+        };
+    }
+
+    async runAttestation(license, context = {}) {
+        const result = {};
+        try {
+            const attestation = await this.attest(license, context);
+            result.attestation = attestation;
+            this.emit('attestation', { license, context, attestation });
+            if (attestation.valid === false) {
+                this.recordHistory(result);
+                this.lastResult = result;
+                return result;
+            }
+        } catch (error) {
+            this.emit('error', { type: 'attestation', license, context, error });
+            throw error;
+        }
+
+        try {
+            const revocation = await this.checkRevocation(license, context);
+            result.revocation = revocation;
+            this.emit('revocation', { license, context, revocation });
+            if (revocation.revoked) {
+                this.recordHistory(result);
+                this.lastResult = result;
+                return result;
+            }
+        } catch (error) {
+            this.emit('error', { type: 'revocation', license, context, error });
+            throw error;
+        }
+
+        try {
+            const entitlements = await this.syncEntitlements(license, context);
+            result.entitlements = entitlements;
+            this.emit('entitlements', { license, context, entitlements });
+        } catch (error) {
+            this.emit('error', { type: 'entitlements', license, context, error });
+            if (!this.failOpen) {
+                throw error;
+            }
+        }
+
+        this.recordHistory(result);
+        this.lastResult = result;
+        return result;
+    }
+
+    createValidator() {
+        return async (license, context = {}) => {
+            try {
+                const result = await this.runAttestation(license, context);
+                this.emit('validation', { license, context, result });
+
+                if (result.attestation && result.attestation.valid === false) {
+                    return {
+                        valid: false,
+                        reason: result.attestation.reason || 'REMOTE_INVALID',
+                        metadata: { remote: result }
+                    };
+                }
+
+                if (result.revocation && result.revocation.revoked) {
+                    return {
+                        valid: false,
+                        reason: result.revocation.reason || 'REMOTE_REVOKED',
+                        metadata: { remote: result }
+                    };
+                }
+
+                const metadata = { remote: result };
+                if (Array.isArray(result.entitlements?.entitlements) && result.entitlements.entitlements.length > 0) {
+                    metadata.entitlements = result.entitlements.entitlements;
+                }
+
+                return { valid: true, metadata };
+            } catch (error) {
+                this.emit('error', { type: 'validation', license, context, error });
+                if (this.failOpen) {
+                    return {
+                        valid: true,
+                        metadata: {
+                            remote: {
+                                error: error?.message || 'Remote attestation failed',
+                                failOpen: true
+                            }
+                        }
+                    };
+                }
+                return {
+                    valid: false,
+                    reason: 'REMOTE_ATTESTATION_ERROR',
+                    metadata: {
+                        remote: {
+                            error: error?.message || 'Remote attestation failed'
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    detach() {
+        if (this.attestationTimer) {
+            clearTimeout(this.attestationTimer);
+            this.attestationTimer = null;
+        }
+        if (this.unregisterValidator) {
+            this.unregisterValidator();
+            this.unregisterValidator = null;
+        }
+        if (this.unsubscribeStatus) {
+            this.unsubscribeStatus();
+            this.unsubscribeStatus = null;
+        }
+        this.boundLicenseManager = null;
+    }
+
+    scheduleNext(delayMs, context = {}) {
+        if (this.attestationTimer) {
+            clearTimeout(this.attestationTimer);
+            this.attestationTimer = null;
+        }
+
+        if (!delayMs || delayMs <= 0) {
+            delayMs = this.pollIntervalMs;
+        }
+
+        const safeDelay = Math.max(delayMs, this.minimumPollIntervalMs);
+        this.attestationTimer = setTimeout(() => {
+            this.attestationTimer = null;
+            if (!this.boundLicenseManager) return;
+            this.boundLicenseManager.validate({ ...context, trigger: 'remote-attestor' }).catch(error => {
+                this.emit('error', { type: 'scheduled-validation', error, context });
+            });
+        }, safeDelay);
+
+        this.emit('schedule', { delayMs: safeDelay, context });
+    }
+
+    bindToLicenseManager(manager, options = {}) {
+        this.detach();
+
+        if (!manager) {
+            return () => {};
+        }
+
+        this.boundLicenseManager = manager;
+        this.unregisterValidator = manager.registerValidator(this.createValidator());
+
+        if (typeof manager.onStatusChange === 'function') {
+            this.unsubscribeStatus = manager.onStatusChange(status => {
+                if (!status || status.state !== 'valid') {
+                    if (status?.state === 'unregistered') {
+                        this.detach();
+                    }
+                    return;
+                }
+
+                const remoteMeta = status.metadata?.remote || status.metadata?.remoteAttestation;
+                let delayMs = null;
+                if (remoteMeta?.attestation?.nextCheckInMs) {
+                    delayMs = remoteMeta.attestation.nextCheckInMs;
+                } else if (remoteMeta?.attestation?.nextCheckAt) {
+                    delayMs = new Date(remoteMeta.attestation.nextCheckAt).getTime() - Date.now();
+                } else if (remoteMeta?.entitlements?.ttlMs) {
+                    delayMs = remoteMeta.entitlements.ttlMs;
+                }
+
+                this.scheduleNext(delayMs, { trigger: 'status-change' });
+            });
+        }
+
+        const license = manager.getLicense();
+        if (license?.key) {
+            if (options.immediate !== false) {
+                manager.validate({ ...options.initialContext, trigger: 'remote-attestor-initial' }).catch(error => {
+                    this.emit('error', { type: 'initial-validation', error, context: options.initialContext });
+                });
+            } else {
+                this.scheduleNext(options.initialDelayMs || this.pollIntervalMs, { trigger: 'initial-schedule' });
+            }
+        }
+
+        return () => this.detach();
+    }
+}

--- a/src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js
+++ b/src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js
@@ -1,0 +1,188 @@
+import { createSignedS3StorageAdapter, createLogBrokerStorageAdapter } from '../../telemetry/storage/RemoteStorageAdapters.js';
+
+function clone(value) {
+    if (value === undefined || value === null) return value;
+    if (typeof value !== 'object') return value;
+    return JSON.parse(JSON.stringify(value));
+}
+
+function createSnapshotTransformer({ includeSummary = true, redactContextKeys = [] } = {}) {
+    const redactions = new Set(redactContextKeys);
+    return snapshot => {
+        if (!snapshot || typeof snapshot !== 'object') {
+            return null;
+        }
+
+        const capturedAt = snapshot.capturedAt ? new Date(snapshot.capturedAt).toISOString() : new Date().toISOString();
+        const id = typeof snapshot.id === 'string' && snapshot.id.trim().length > 0
+            ? snapshot.id
+            : snapshot.capturedAt || capturedAt;
+
+        const normalized = {
+            id,
+            capturedAt,
+            context: {},
+            kpis: {}
+        };
+
+        if (snapshot.context && typeof snapshot.context === 'object') {
+            const context = {};
+            for (const [key, value] of Object.entries(snapshot.context)) {
+                if (!redactions.has(key)) {
+                    context[key] = clone(value);
+                }
+            }
+            normalized.context = context;
+        }
+
+        if (snapshot.kpis && typeof snapshot.kpis === 'object') {
+            normalized.kpis = clone(snapshot.kpis);
+        }
+
+        if (includeSummary && snapshot.summary && typeof snapshot.summary === 'object') {
+            normalized.summary = clone(snapshot.summary);
+        }
+
+        return normalized;
+    };
+}
+
+function toArray(value) {
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+}
+
+function ensureSnapshotsArray(value, transform) {
+    const snapshots = toArray(value);
+    const normalized = [];
+    for (const snapshot of snapshots) {
+        const transformed = transform(snapshot);
+        if (transformed) {
+            normalized.push(transformed);
+        }
+    }
+    return normalized;
+}
+
+function defaultSerializePayload(snapshots = [], { retentionPolicy } = {}) {
+    return {
+        exportedAt: new Date().toISOString(),
+        snapshotCount: Array.isArray(snapshots) ? snapshots.length : 0,
+        ...(retentionPolicy ? { retentionPolicy } : {}),
+        snapshots
+    };
+}
+
+export function createCommercializationSnapshotRemoteStorage(options = {}) {
+    const {
+        adapter,
+        includeSummary = true,
+        redactContextKeys = [],
+        transformSnapshot,
+        transformIncoming,
+        onError
+    } = options;
+
+    if (!adapter || typeof adapter.write !== 'function') {
+        throw new Error('[createCommercializationSnapshotRemoteStorage] `adapter` with a write method is required.');
+    }
+
+    const outgoingTransform = typeof transformSnapshot === 'function'
+        ? snapshot => transformSnapshot(snapshot, { includeSummary, redactContextKeys: [...redactContextKeys] })
+        : createSnapshotTransformer({ includeSummary, redactContextKeys });
+
+    const incomingTransform = typeof transformIncoming === 'function'
+        ? records => transformIncoming(records, { includeSummary, redactContextKeys: [...redactContextKeys] })
+        : records => ensureSnapshotsArray(records, outgoingTransform);
+
+    async function safelyInvoke(method, ...args) {
+        if (typeof method !== 'function') {
+            return undefined;
+        }
+        try {
+            return await method(...args);
+        } catch (error) {
+            onError?.(error);
+            console?.warn?.('[createCommercializationSnapshotRemoteStorage] operation failed', error);
+            return undefined;
+        }
+    }
+
+    return {
+        async loadSnapshots() {
+            const records = await safelyInvoke(adapter.read?.bind(adapter));
+            return incomingTransform(records || []);
+        },
+        async saveSnapshots(snapshots) {
+            const payload = ensureSnapshotsArray(snapshots, outgoingTransform);
+            if (payload.length === 0) {
+                return;
+            }
+            await safelyInvoke(adapter.write.bind(adapter), payload);
+        },
+        async appendSnapshot(snapshot) {
+            const payload = ensureSnapshotsArray([snapshot], outgoingTransform);
+            if (payload.length === 0) {
+                return;
+            }
+            await safelyInvoke(adapter.write.bind(adapter), payload);
+        },
+        async clearSnapshots() {
+            await safelyInvoke(adapter.clear?.bind(adapter));
+        }
+    };
+}
+
+export function createSignedS3CommercializationSnapshotStorage(options = {}) {
+    const {
+        includeSummary,
+        redactContextKeys,
+        transformSnapshot,
+        transformIncoming,
+        onError,
+        serialize = defaultSerializePayload,
+        ...adapterOptions
+    } = options;
+
+    const adapter = createSignedS3StorageAdapter({
+        ...adapterOptions,
+        serialize
+    });
+
+    return createCommercializationSnapshotRemoteStorage({
+        adapter,
+        includeSummary,
+        redactContextKeys,
+        transformSnapshot,
+        transformIncoming,
+        onError
+    });
+}
+
+export function createLogBrokerCommercializationSnapshotStorage(options = {}) {
+    const {
+        includeSummary,
+        redactContextKeys,
+        transformSnapshot,
+        transformIncoming,
+        onError,
+        serialize = defaultSerializePayload,
+        ...adapterOptions
+    } = options;
+
+    const adapter = createLogBrokerStorageAdapter({
+        ...adapterOptions,
+        serialize
+    });
+
+    return createCommercializationSnapshotRemoteStorage({
+        adapter,
+        includeSummary,
+        redactContextKeys,
+        transformSnapshot,
+        transformIncoming,
+        onError
+    });
+}
+
+export { defaultSerializePayload as createCommercializationSnapshotPayload };

--- a/src/product/telemetry/ComplianceVaultTelemetryProvider.js
+++ b/src/product/telemetry/ComplianceVaultTelemetryProvider.js
@@ -1,0 +1,159 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+function createDefaultStorageAdapter(storageKey) {
+    if (typeof window !== 'undefined' && window?.localStorage) {
+        return {
+            read() {
+                try {
+                    const raw = window.localStorage.getItem(storageKey);
+                    return raw ? JSON.parse(raw) : [];
+                } catch (error) {
+                    console.warn('[ComplianceVaultTelemetryProvider] Failed to read localStorage', error);
+                    return [];
+                }
+            },
+            write(records) {
+                try {
+                    window.localStorage.setItem(storageKey, JSON.stringify(records));
+                } catch (error) {
+                    console.warn('[ComplianceVaultTelemetryProvider] Failed to write localStorage', error);
+                }
+            },
+            clear() {
+                try {
+                    window.localStorage.removeItem(storageKey);
+                } catch (error) {
+                    console.warn('[ComplianceVaultTelemetryProvider] Failed to clear localStorage', error);
+                }
+            }
+        };
+    }
+
+    let memoryRecords = [];
+    return {
+        read() {
+            return [...memoryRecords];
+        },
+        write(records) {
+            memoryRecords = [...records];
+        },
+        clear() {
+            memoryRecords = [];
+        }
+    };
+}
+
+function sanitizeRecord(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    const base = {
+        event: entry.event,
+        classification: entry.classification,
+        timestamp: entry.timestamp || new Date().toISOString(),
+        payload: entry.payload ?? null
+    };
+
+    if ('licenseKey' in entry) {
+        base.licenseKey = entry.licenseKey;
+    }
+    if (entry.source) {
+        base.source = entry.source;
+    }
+
+    return base;
+}
+
+export class ComplianceVaultTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: options.id || 'compliance-vault', metadata: options.metadata });
+
+        this.storageKey = options.storageKey || 'vib34d:compliance-vault';
+        this.maxRecords = options.maxRecords || 500;
+        this.includeClassifications = new Set(options.includeClassifications || ['compliance']);
+        this.storageAdapter = options.storageAdapter || createDefaultStorageAdapter(this.storageKey);
+
+        const existing = this.storageAdapter.read?.();
+        this.records = Array.isArray(existing) ? [...existing] : [];
+        this.initializationPromise = Promise.resolve(existing)
+            .then((records) => {
+                if (Array.isArray(records)) {
+                    this.records = [...records];
+                }
+                return this.records;
+            })
+            .catch((error) => {
+                console.warn('[ComplianceVaultTelemetryProvider] Failed to initialize from storage', error);
+                return this.records;
+            });
+    }
+
+    shouldCapture(classification) {
+        return this.includeClassifications.has(classification);
+    }
+
+    store(entry) {
+        const normalized = sanitizeRecord(entry);
+        if (!normalized) return;
+
+        this.records.push(normalized);
+        if (this.records.length > this.maxRecords) {
+            this.records.splice(0, this.records.length - this.maxRecords);
+        }
+
+        const result = this.storageAdapter.write?.(this.records);
+        if (result && typeof result.then === 'function') {
+            result.catch((error) => {
+                console.warn('[ComplianceVaultTelemetryProvider] Failed to persist compliance record', error);
+            });
+        }
+    }
+
+    track(event, record = {}, context = {}) {
+        const classification = context.classification || record.classification;
+        if (!this.shouldCapture(classification)) {
+            return;
+        }
+
+        this.store({
+            event,
+            classification: classification || 'compliance',
+            timestamp: record.timestamp,
+            payload: record.payload,
+            licenseKey: record.licenseKey
+        });
+    }
+
+    recordAudit(entry) {
+        if (!this.shouldCapture(entry?.classification)) {
+            return;
+        }
+        this.store({ ...entry, source: 'audit-log' });
+    }
+
+    getRecords() {
+        return [...this.records];
+    }
+
+    clear() {
+        this.records = [];
+        const result = this.storageAdapter.clear?.();
+        if (result && typeof result.then === 'function') {
+            result.catch((error) => {
+                console.warn('[ComplianceVaultTelemetryProvider] Failed to clear compliance vault', error);
+            });
+        }
+    }
+
+    flush() {
+        const result = this.storageAdapter.write?.(this.records);
+        if (result && typeof result.then === 'function') {
+            result.catch((error) => {
+                console.warn('[ComplianceVaultTelemetryProvider] Failed to flush compliance vault', error);
+            });
+        }
+    }
+
+    async whenReady() {
+        await this.initializationPromise;
+        return this.getRecords();
+    }
+}

--- a/src/product/telemetry/ConsoleTelemetryProvider.js
+++ b/src/product/telemetry/ConsoleTelemetryProvider.js
@@ -1,0 +1,33 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class ConsoleTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: 'console', metadata: { storage: 'memory', ...options.metadata } });
+        this.events = [];
+        this.identities = [];
+        this.log = options.log ?? false;
+    }
+
+    identify(identity, traits = {}) {
+        const record = { identity, traits, timestamp: Date.now() };
+        this.identities.push(record);
+        if (this.log) {
+            console.info('[ConsoleTelemetryProvider] identify', record);
+        }
+    }
+
+    track(event, payload) {
+        const record = { event, payload, timestamp: Date.now() };
+        this.events.push(record);
+        if (this.log) {
+            console.info('[ConsoleTelemetryProvider] track', record);
+        }
+    }
+
+    flush() {
+        if (this.log && this.events.length) {
+            console.table(this.events);
+        }
+        this.events = [];
+    }
+}

--- a/src/product/telemetry/HttpTelemetryProvider.js
+++ b/src/product/telemetry/HttpTelemetryProvider.js
@@ -1,0 +1,109 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class HttpTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: 'http', metadata: { storage: 'remote', ...options.metadata } });
+        this.endpoint = options.endpoint;
+        this.headers = options.headers || { 'Content-Type': 'application/json' };
+        this.queue = [];
+
+        this.requestMiddleware = [];
+        if (Array.isArray(options.requestMiddleware)) {
+            for (const middleware of options.requestMiddleware) {
+                this.registerRequestMiddleware(middleware);
+            }
+        }
+    }
+
+    identify(identity, traits = {}) {
+        this.queue.push({ type: 'identify', identity, traits, timestamp: Date.now() });
+    }
+
+    track(event, payload) {
+        this.queue.push({ type: 'track', event, payload, timestamp: Date.now() });
+    }
+
+    async flush() {
+        if (!this.endpoint || this.queue.length === 0) {
+            this.queue = [];
+            return;
+        }
+
+        const payload = { events: this.queue };
+        this.queue = [];
+        try {
+            const request = await this.applyRequestMiddleware({
+                endpoint: this.endpoint,
+                options: {
+                    method: 'POST',
+                    headers: { ...this.headers },
+                    body: JSON.stringify(payload)
+                },
+                events: payload.events
+            });
+
+            await fetch(request.endpoint, request.options);
+        } catch (error) {
+            console.warn('[HttpTelemetryProvider] Failed to deliver telemetry', error);
+        }
+    }
+
+    registerRequestMiddleware(middleware) {
+        if (typeof middleware === 'function') {
+            this.requestMiddleware.push(middleware);
+        }
+    }
+
+    clearRequestMiddleware() {
+        this.requestMiddleware = [];
+    }
+
+    async applyRequestMiddleware(initialContext) {
+        if (!this.requestMiddleware.length) {
+            return initialContext;
+        }
+
+        let context = {
+            endpoint: initialContext.endpoint,
+            options: {
+                ...(initialContext.options || {}),
+                headers: {
+                    ...(initialContext.options?.headers || {})
+                }
+            },
+            events: initialContext.events,
+            provider: this
+        };
+
+        for (const middleware of this.requestMiddleware) {
+            if (typeof middleware !== 'function') continue;
+            try {
+                const result = await middleware({ ...context });
+                if (!result || typeof result !== 'object') {
+                    continue;
+                }
+
+                if (result.endpoint) {
+                    context.endpoint = result.endpoint;
+                }
+
+                if (result.options) {
+                    const nextOptions = { ...context.options, ...result.options };
+                    nextOptions.headers = {
+                        ...(context.options.headers || {}),
+                        ...(result.options.headers || {})
+                    };
+                    context.options = nextOptions;
+                }
+
+                if (result.metadata) {
+                    context.metadata = { ...(context.metadata || {}), ...result.metadata };
+                }
+            } catch (error) {
+                console.warn('[HttpTelemetryProvider] Request middleware error', error);
+            }
+        }
+
+        return context;
+    }
+}

--- a/src/product/telemetry/PartnerTelemetryProvider.js
+++ b/src/product/telemetry/PartnerTelemetryProvider.js
@@ -1,0 +1,20 @@
+import { TelemetryProvider } from './TelemetryProvider.js';
+
+export class PartnerTelemetryProvider extends TelemetryProvider {
+    constructor(options = {}) {
+        super({ id: options.id || 'partner', metadata: { storage: 'external', partner: options.partner || 'unspecified', ...options.metadata } });
+        this.forward = options.forward ?? (() => Promise.resolve());
+    }
+
+    identify(identity, traits = {}) {
+        return this.forward({ type: 'identify', identity, traits, timestamp: Date.now() });
+    }
+
+    track(event, payload) {
+        return this.forward({ type: 'track', event, payload, timestamp: Date.now() });
+    }
+
+    flush() {
+        return this.forward({ type: 'flush', timestamp: Date.now() });
+    }
+}

--- a/src/product/telemetry/TelemetryProvider.js
+++ b/src/product/telemetry/TelemetryProvider.js
@@ -1,0 +1,17 @@
+export class TelemetryProvider {
+    constructor({ id, metadata = {} } = {}) {
+        if (!id) {
+            throw new Error('TelemetryProvider requires an `id`.');
+        }
+        this.id = id;
+        this.metadata = metadata;
+    }
+
+    identify() {}
+
+    track() {}
+
+    flush() {}
+
+    recordAudit() {}
+}

--- a/src/product/telemetry/middleware/createRequestSigningMiddleware.js
+++ b/src/product/telemetry/middleware/createRequestSigningMiddleware.js
@@ -1,0 +1,127 @@
+const DEFAULT_SIGNATURE_HEADER = 'x-adaptive-signature';
+const DEFAULT_ALGORITHM_HEADER = 'x-adaptive-signature-algorithm';
+const DEFAULT_TIMESTAMP_HEADER = 'x-adaptive-signature-timestamp';
+
+function serializeBody(body) {
+    if (!body) return '';
+    if (typeof body === 'string') return body;
+    if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+        if (typeof Buffer !== 'undefined') {
+            return Buffer.from(body).toString('base64');
+        }
+        return '[binary]';
+    }
+    if (typeof Blob !== 'undefined' && body instanceof Blob) {
+        return '[blob]';
+    }
+    try {
+        return JSON.stringify(body);
+    } catch (error) {
+        return String(body);
+    }
+}
+
+export function createRequestSigningMiddleware(options = {}) {
+    const {
+        signer,
+        header = DEFAULT_SIGNATURE_HEADER,
+        algorithmHeader = DEFAULT_ALGORITHM_HEADER,
+        timestampHeader = DEFAULT_TIMESTAMP_HEADER,
+        includeEventDigest = true,
+        digestSeparator = ':',
+        metadataKey = 'signature'
+    } = options;
+
+    if (typeof signer !== 'function') {
+        throw new Error('[createRequestSigningMiddleware] `signer` function is required.');
+    }
+
+    return async function requestSigningMiddleware(context) {
+        const { endpoint, options: requestOptions = {}, events = [] } = context;
+        const method = (requestOptions.method || 'POST').toUpperCase();
+        const timestamp = new Date().toISOString();
+        const bodyForSigning = serializeBody(requestOptions.body);
+
+        const digestParts = [method, endpoint, timestamp];
+        if (includeEventDigest) {
+            digestParts.push(String(events.length));
+        }
+        const signingInput = {
+            endpoint,
+            method,
+            timestamp,
+            events,
+            body: bodyForSigning,
+            digest: digestParts.join(digestSeparator),
+            metadata: context.metadata || {}
+        };
+
+        const signatureResult = await signer(signingInput);
+        if (!signatureResult) {
+            return {
+                options: {
+                    headers: timestampHeader ? { [timestampHeader]: timestamp } : {}
+                },
+                metadata: { [metadataKey]: { issuedAt: timestamp } }
+            };
+        }
+
+        const headers = {};
+        const metadata = { [metadataKey]: { issuedAt: timestamp } };
+        let nextOptions = {};
+        let nextEndpoint;
+
+        if (typeof signatureResult === 'string') {
+            headers[header] = signatureResult;
+        } else if (typeof signatureResult === 'object') {
+            if (signatureResult.signature) {
+                headers[header] = signatureResult.signature;
+            }
+
+            if (signatureResult.headers && typeof signatureResult.headers === 'object') {
+                Object.assign(headers, signatureResult.headers);
+            }
+
+            if (signatureResult.algorithm) {
+                metadata[metadataKey].algorithm = signatureResult.algorithm;
+            }
+
+            if (signatureResult.metadata && typeof signatureResult.metadata === 'object') {
+                metadata[metadataKey] = { ...metadata[metadataKey], ...signatureResult.metadata };
+            }
+
+            if (signatureResult.options && typeof signatureResult.options === 'object') {
+                nextOptions = signatureResult.options;
+            }
+
+            if (signatureResult.endpoint) {
+                nextEndpoint = signatureResult.endpoint;
+            }
+
+            if (signatureResult.timestamp) {
+                metadata[metadataKey].issuedAt = signatureResult.timestamp;
+            }
+        }
+
+        if (algorithmHeader && !metadata[metadataKey].algorithm && options.algorithm) {
+            metadata[metadataKey].algorithm = options.algorithm;
+        }
+
+        if (timestampHeader) {
+            headers[timestampHeader] = metadata[metadataKey].issuedAt || timestamp;
+        }
+
+        if (algorithmHeader && metadata[metadataKey].algorithm) {
+            headers[algorithmHeader] = metadata[metadataKey].algorithm;
+        }
+
+        return {
+            endpoint: nextEndpoint,
+            options: {
+                headers,
+                ...nextOptions
+            },
+            metadata
+        };
+    };
+}

--- a/src/product/telemetry/storage/RemoteStorageAdapters.js
+++ b/src/product/telemetry/storage/RemoteStorageAdapters.js
@@ -1,0 +1,344 @@
+const DEFAULT_CONTENT_TYPE = 'application/json';
+const DEFAULT_ENCRYPTED_CONTENT_TYPE = 'application/octet-stream';
+
+function resolveFetch(customFetch) {
+    if (customFetch) {
+        return customFetch;
+    }
+    if (typeof fetch === 'function') {
+        return fetch.bind(globalThis);
+    }
+    throw new Error('[RemoteStorageAdapters] No fetch implementation available. Provide one via `fetchImplementation`.');
+}
+
+function defaultSerializeRecords(records, context = {}) {
+    return {
+        exportedAt: new Date().toISOString(),
+        recordCount: Array.isArray(records) ? records.length : 0,
+        ...(context.retentionPolicy ? { retentionPolicy: context.retentionPolicy } : {}),
+        records
+    };
+}
+
+function normalizeRetentionPolicy(retentionPolicy) {
+    if (!retentionPolicy) {
+        return undefined;
+    }
+
+    if (typeof retentionPolicy === 'string') {
+        return { strategy: retentionPolicy };
+    }
+
+    if (typeof retentionPolicy === 'number') {
+        return { strategy: 'timeboxed', maxAgeMs: retentionPolicy };
+    }
+
+    if (typeof retentionPolicy === 'object') {
+        const {
+            strategy = 'custom',
+            maxAgeMs,
+            legalHold,
+            deleteAfterUpload,
+            metadata
+        } = retentionPolicy;
+
+        const normalized = { strategy };
+
+        if (typeof maxAgeMs === 'number' && Number.isFinite(maxAgeMs)) {
+            normalized.maxAgeMs = maxAgeMs;
+        }
+
+        if (typeof legalHold === 'boolean') {
+            normalized.legalHold = legalHold;
+        }
+
+        if (typeof deleteAfterUpload === 'boolean') {
+            normalized.deleteAfterUpload = deleteAfterUpload;
+        }
+
+        if (metadata && typeof metadata === 'object') {
+            normalized.metadata = metadata;
+        }
+
+        return normalized;
+    }
+
+    return undefined;
+}
+
+function isBinaryLike(value) {
+    const isBlobAvailable = typeof Blob !== 'undefined';
+    return value instanceof ArrayBuffer || ArrayBuffer.isView(value) || (isBlobAvailable && value instanceof Blob);
+}
+
+async function buildPayload(records, {
+    serialize,
+    encryptPayload,
+    encryptionContentType = DEFAULT_ENCRYPTED_CONTENT_TYPE,
+    adapterId,
+    retentionPolicy
+}) {
+    const serialized = typeof serialize === 'function'
+        ? serialize(records, { retentionPolicy })
+        : defaultSerializeRecords(records, { retentionPolicy });
+
+    let body = serialized;
+    if (!isBinaryLike(body) && typeof body !== 'string') {
+        body = JSON.stringify(body);
+    }
+
+    let contentType = DEFAULT_CONTENT_TYPE;
+    let headers = {};
+    let metadata = {};
+
+    if (typeof encryptPayload === 'function') {
+        const encryptionResult = await encryptPayload(body, {
+            adapter: adapterId,
+            records,
+            retentionPolicy
+        });
+
+        if (typeof encryptionResult === 'string' || isBinaryLike(encryptionResult)) {
+            body = encryptionResult;
+            contentType = encryptionContentType || contentType;
+        } else if (encryptionResult && typeof encryptionResult === 'object') {
+            if (encryptionResult.body !== undefined) {
+                const nextBody = encryptionResult.body;
+                body = typeof nextBody === 'string' || isBinaryLike(nextBody) ? nextBody : JSON.stringify(nextBody);
+            }
+
+            if (encryptionResult.contentType) {
+                contentType = encryptionResult.contentType;
+            } else if (encryptionResult.useDefaultContentType === false && !encryptionResult.contentType) {
+                contentType = encryptionContentType || contentType;
+            }
+
+            if (encryptionResult.headers && typeof encryptionResult.headers === 'object') {
+                headers = { ...headers, ...encryptionResult.headers };
+            }
+
+            if (encryptionResult.metadata && typeof encryptionResult.metadata === 'object') {
+                metadata = { ...metadata, ...encryptionResult.metadata };
+            }
+        }
+    }
+
+    return {
+        body,
+        contentType,
+        headers,
+        metadata
+    };
+}
+
+export function createSignedS3StorageAdapter(options = {}) {
+    const {
+        signingEndpoint,
+        signingMethod = 'POST',
+        signingHeaders,
+        signingPayload,
+        uploadMethod = 'PUT',
+        fetchImplementation,
+        uploadHeaders,
+        serialize,
+        onUploadComplete,
+        onError,
+        deleteEndpoint,
+        deleteMethod = 'DELETE',
+        retentionPolicy,
+        encryptPayload,
+        encryptionContentType = DEFAULT_ENCRYPTED_CONTENT_TYPE
+    } = options;
+
+    const fetchFn = resolveFetch(fetchImplementation);
+
+    async function obtainUploadTarget(payloadMetadata = {}) {
+        if (!signingEndpoint) {
+            throw new Error('[createSignedS3StorageAdapter] `signingEndpoint` is required.');
+        }
+
+        const response = await fetchFn(signingEndpoint, {
+            method: signingMethod,
+            headers: {
+                'content-type': DEFAULT_CONTENT_TYPE,
+                ...signingHeaders
+            },
+            body: JSON.stringify({
+                operation: 'PUT_OBJECT',
+                ...signingPayload,
+                ...payloadMetadata
+            })
+        });
+
+        if (!response.ok) {
+            const error = new Error(`[createSignedS3StorageAdapter] Failed to obtain signed URL (${response.status})`);
+            onError?.(error);
+            throw error;
+        }
+
+        const data = await response.json();
+        if (!data?.uploadUrl) {
+            const error = new Error('[createSignedS3StorageAdapter] Signing endpoint did not return `uploadUrl`.');
+            onError?.(error);
+            throw error;
+        }
+
+        return data;
+    }
+
+    return {
+        async write(records) {
+            try {
+                if (!Array.isArray(records) || records.length === 0) {
+                    return;
+                }
+
+                const normalizedRetention = normalizeRetentionPolicy(retentionPolicy);
+                const { body, contentType, headers: encryptionHeaders, metadata } = await buildPayload(records, {
+                    serialize,
+                    encryptPayload,
+                    encryptionContentType,
+                    adapterId: 'signed-s3',
+                    retentionPolicy: normalizedRetention
+                });
+
+                const target = await obtainUploadTarget({
+                    recordCount: records.length,
+                    retentionPolicy: normalizedRetention,
+                    encryption: Object.keys(metadata).length ? metadata : undefined
+                });
+
+                const uploadHeadersPayload = {
+                    'content-type': contentType,
+                    ...target.headers,
+                    ...uploadHeaders,
+                    ...encryptionHeaders
+                };
+
+                if (normalizedRetention) {
+                    uploadHeadersPayload['x-amz-meta-retention'] = JSON.stringify(normalizedRetention);
+                }
+
+                if (Object.keys(metadata).length) {
+                    uploadHeadersPayload['x-amz-meta-encryption'] = JSON.stringify(metadata);
+                }
+
+                const response = await fetchFn(target.uploadUrl, {
+                    method: uploadMethod,
+                    headers: uploadHeadersPayload,
+                    body
+                });
+
+                if (!response.ok) {
+                    const error = new Error(`[createSignedS3StorageAdapter] Upload failed (${response.status})`);
+                    onError?.(error);
+                    throw error;
+                }
+
+                onUploadComplete?.({
+                    key: target.key,
+                    location: target.uploadUrl,
+                    recordCount: records.length,
+                    retentionPolicy: normalizedRetention,
+                    encryptionMetadata: metadata
+                });
+            } catch (error) {
+                onError?.(error);
+                throw error;
+            }
+        },
+        async clear() {
+            if (!deleteEndpoint) {
+                return;
+            }
+
+            const response = await fetchFn(deleteEndpoint, {
+                method: deleteMethod,
+                headers: signingHeaders
+            });
+
+            if (!response.ok) {
+                const error = new Error(`[createSignedS3StorageAdapter] Failed to clear remote vault (${response.status})`);
+                onError?.(error);
+                throw error;
+            }
+        },
+        async read() {
+            return [];
+        }
+    };
+}
+
+export function createLogBrokerStorageAdapter(options = {}) {
+    const {
+        endpoint,
+        method = 'POST',
+        headers,
+        fetchImplementation,
+        serialize,
+        onError,
+        retentionPolicy,
+        encryptPayload,
+        encryptionContentType = DEFAULT_ENCRYPTED_CONTENT_TYPE
+    } = options;
+
+    if (!endpoint) {
+        throw new Error('[createLogBrokerStorageAdapter] `endpoint` is required.');
+    }
+
+    const fetchFn = resolveFetch(fetchImplementation);
+
+    return {
+        async write(records) {
+            try {
+                if (!Array.isArray(records) || records.length === 0) {
+                    return;
+                }
+
+                const normalizedRetention = normalizeRetentionPolicy(retentionPolicy);
+                const { body, contentType, headers: encryptionHeaders, metadata } = await buildPayload(records, {
+                    serialize,
+                    encryptPayload,
+                    encryptionContentType,
+                    adapterId: 'log-broker',
+                    retentionPolicy: normalizedRetention
+                });
+
+                const requestHeaders = {
+                    'content-type': contentType,
+                    ...headers,
+                    ...encryptionHeaders
+                };
+
+                if (normalizedRetention) {
+                    requestHeaders['x-retention-policy'] = JSON.stringify(normalizedRetention);
+                }
+
+                if (Object.keys(metadata).length) {
+                    requestHeaders['x-encryption-metadata'] = JSON.stringify(metadata);
+                }
+
+                const response = await fetchFn(endpoint, {
+                    method,
+                    headers: requestHeaders,
+                    body
+                });
+
+                if (!response.ok) {
+                    const error = new Error(`[createLogBrokerStorageAdapter] Failed to deliver compliance batch (${response.status})`);
+                    onError?.(error);
+                    throw error;
+                }
+            } catch (error) {
+                onError?.(error);
+                throw error;
+            }
+        },
+        async clear() {
+            // Log brokers typically treat new uploads as append-only; clearing is a no-op.
+        },
+        async read() {
+            return [];
+        }
+    };
+}

--- a/src/ui/adaptive/InterfacePatternRegistry.js
+++ b/src/ui/adaptive/InterfacePatternRegistry.js
@@ -1,0 +1,92 @@
+/**
+ * InterfacePatternRegistry
+ * ------------------------------------------------------------
+ * Catalogues adaptive UI patterns that can be rendered by the engine. These
+ * patterns expose metadata for monetizable add-ons and integration with design
+ * tooling.
+ */
+
+const DEFAULT_PATTERNS = [
+    {
+        id: 'neuro-glance-feed',
+        name: 'Neuro Glance Feed',
+        category: 'perception',
+        subscriptionTier: 'pro',
+        description: 'Micro-summaries that respond to attention bursts and biometric calmness.',
+        components: ['glanceable-card', 'pulse-strip'],
+        telemetry: {
+            trackEngagement: true,
+            metrics: ['dwell', 'confidence']
+        }
+    },
+    {
+        id: 'holo-command-ring',
+        name: 'Holo Command Ring',
+        category: 'interaction',
+        subscriptionTier: 'enterprise',
+        description: 'Circular intent-driven command palette for neural or gestural activation.',
+        components: ['adaptive-controls', 'intent-feedback'],
+        telemetry: {
+            trackEngagement: true,
+            metrics: ['activation', 'latency']
+        }
+    },
+    {
+        id: 'biometric-rituals',
+        name: 'Biometric Rituals',
+        category: 'wellness',
+        subscriptionTier: 'starter',
+        description: 'Ambient ambient rituals that respond to stress deltas and lighting changes.',
+        components: ['ambient-indicator', 'environmental-visualizer'],
+        telemetry: {
+            trackEngagement: false,
+            metrics: []
+        }
+    }
+];
+
+export class InterfacePatternRegistry {
+    constructor(initialPatterns = DEFAULT_PATTERNS) {
+        this.patterns = new Map();
+        initialPatterns.forEach(pattern => this.patterns.set(pattern.id, pattern));
+    }
+
+    addPattern(pattern) {
+        if (!pattern?.id) {
+            throw new Error('Pattern must include an id');
+        }
+        this.patterns.set(pattern.id, pattern);
+    }
+
+    removePattern(id) {
+        this.patterns.delete(id);
+    }
+
+    getPattern(id) {
+        return this.patterns.get(id) || null;
+    }
+
+    listPatterns(filter = {}) {
+        const entries = Array.from(this.patterns.values());
+        const { category, subscriptionTier } = filter;
+        return entries.filter(pattern => {
+            const matchesCategory = category ? pattern.category === category : true;
+            const matchesTier = subscriptionTier ? pattern.subscriptionTier === subscriptionTier : true;
+            return matchesCategory && matchesTier;
+        });
+    }
+
+    exportForMarketplace() {
+        return this.listPatterns().map(pattern => ({
+            id: pattern.id,
+            name: pattern.name,
+            tier: pattern.subscriptionTier,
+            metadata: {
+                description: pattern.description,
+                components: pattern.components,
+                telemetry: pattern.telemetry
+            }
+        }));
+    }
+}
+

--- a/src/ui/adaptive/SensoryInputBridge.js
+++ b/src/ui/adaptive/SensoryInputBridge.js
@@ -1,0 +1,372 @@
+/**
+ * SensoryInputBridge
+ * ------------------------------------------------------------
+ * Normalizes heterogeneous sensor and intent signals (eye tracking, neural
+ * gestures, biometrics, ambient context) into a common semantic layer that the
+ * adaptive interface engine can consume. Designed to be extended with
+ * wearables-specific adapters and remote data streams.
+ */
+
+import { SensorSchemaRegistry } from './sensors/SensorSchemaRegistry.js';
+
+export class SensoryInputBridge {
+    constructor(options = {}) {
+        const {
+            pollingInterval = 16,
+            decayHalfLife = 2800,
+            confidenceThreshold = 0.35,
+            schemaRegistry,
+            schemas,
+            issueReporter,
+            autoConnectAdapters = true,
+            validationLogLimit = 120
+        } = options;
+
+        this.pollingInterval = pollingInterval;
+        this.decayHalfLife = decayHalfLife;
+        this.confidenceThreshold = confidenceThreshold;
+
+        if (schemaRegistry instanceof SensorSchemaRegistry) {
+            this.schemaRegistry = schemaRegistry;
+        } else {
+            this.schemaRegistry = new SensorSchemaRegistry({ schemas });
+        }
+
+        this.channels = new Map();
+        this.subscribers = new Map();
+        this.adapters = new Map();
+        this.decayTimers = new Map();
+        this.adapterStates = new Map();
+
+        this.state = {
+            focusVector: { x: 0.5, y: 0.5, depth: 0.3 },
+            intentionVector: { x: 0, y: 0, z: 0, w: 0 },
+            engagementLevel: 0.4,
+            biometricStress: 0.2,
+            gestureIntent: null,
+            environment: {
+                luminance: 0.5,
+                noiseLevel: 0.2,
+                motion: 0.1
+            },
+            updatedAt: performance.now()
+        };
+
+        this.loopHandle = null;
+        this.autoConnectAdapters = autoConnectAdapters;
+        this.validationReporter = typeof issueReporter === 'function' ? issueReporter : null;
+        this.validationLog = [];
+        this.validationLogLimit = validationLogLimit;
+    }
+
+    /**
+     * Registers a new sensor adapter. Adapters must implement a `read()` method
+     * that resolves with `{ confidence, payload }`.
+     */
+    registerAdapter(type, adapter) {
+        this.adapters.set(type, adapter);
+        if (!this.channels.has(type)) {
+            this.channels.set(type, []);
+        }
+        this.adapterStates.set(type, { status: 'registered', lastError: null });
+    }
+
+    async connectAdapter(type) {
+        const adapter = this.adapters.get(type);
+        if (!adapter) {
+            throw new Error(`No adapter registered for ${type}`);
+        }
+
+        if (typeof adapter.connect === 'function') {
+            try {
+                await adapter.connect();
+                this.adapterStates.set(type, { status: 'connected', lastError: null });
+                this.emit('adapter:connected', { type, timestamp: performance.now() });
+            } catch (error) {
+                this.adapterStates.set(type, { status: 'error', lastError: error });
+                this.emit('adapter:error', { type, error, timestamp: performance.now() });
+                throw error;
+            }
+        } else {
+            this.adapterStates.set(type, { status: 'ready', lastError: null });
+        }
+    }
+
+    async disconnectAdapter(type) {
+        const adapter = this.adapters.get(type);
+        if (!adapter) {
+            throw new Error(`No adapter registered for ${type}`);
+        }
+
+        if (typeof adapter.disconnect === 'function') {
+            try {
+                await adapter.disconnect();
+                this.adapterStates.set(type, { status: 'disconnected', lastError: null });
+                this.emit('adapter:disconnected', { type, timestamp: performance.now() });
+            } catch (error) {
+                this.adapterStates.set(type, { status: 'error', lastError: error });
+                this.emit('adapter:error', { type, error, timestamp: performance.now() });
+                throw error;
+            }
+        } else {
+            this.adapterStates.set(type, { status: 'ready', lastError: null });
+        }
+    }
+
+    async testAdapter(type) {
+        const adapter = this.adapters.get(type);
+        if (!adapter) {
+            throw new Error(`No adapter registered for ${type}`);
+        }
+
+        if (typeof adapter.test === 'function') {
+            return adapter.test();
+        }
+
+        if (typeof adapter.read === 'function') {
+            const sample = await adapter.read();
+            return Boolean(sample);
+        }
+
+        return false;
+    }
+
+    async connectAllAdapters() {
+        const promises = [];
+        for (const type of this.adapters.keys()) {
+            promises.push(this.connectAdapter(type).catch(() => {}));
+        }
+        await Promise.all(promises);
+    }
+
+    async disconnectAllAdapters() {
+        const promises = [];
+        for (const type of this.adapters.keys()) {
+            promises.push(this.disconnectAdapter(type).catch(() => {}));
+        }
+        await Promise.all(promises);
+    }
+
+    /**
+     * Subscribe to semantic updates.
+     */
+    subscribe(channel, callback) {
+        if (!this.subscribers.has(channel)) {
+            this.subscribers.set(channel, new Set());
+        }
+        this.subscribers.get(channel).add(callback);
+        return () => this.unsubscribe(channel, callback);
+    }
+
+    unsubscribe(channel, callback) {
+        const set = this.subscribers.get(channel);
+        if (!set) return;
+        set.delete(callback);
+    }
+
+    /**
+     * Manual ingestion hook for environments that push data instead of polling.
+     */
+    ingest(type, payload, confidence = 1) {
+        this.processSample(type, { confidence, payload });
+    }
+
+    /**
+     * Begin continuous polling of registered adapters.
+     */
+    start() {
+        if (this.loopHandle) return;
+        if (this.autoConnectAdapters) {
+            this.connectAllAdapters().catch(error => {
+                console.warn('[SensoryInputBridge] Failed to auto-connect adapters', error);
+            });
+        }
+        const loop = async () => {
+            for (const [type, adapter] of this.adapters) {
+                try {
+                    const sample = await adapter.read();
+                    if (sample) {
+                        this.processSample(type, sample);
+                    }
+                } catch (error) {
+                    console.warn(`[SensoryInputBridge] Adapter read failed for ${type}`, error);
+                }
+            }
+            this.loopHandle = setTimeout(loop, this.pollingInterval);
+        };
+        loop();
+    }
+
+    stop() {
+        if (this.loopHandle) {
+            clearTimeout(this.loopHandle);
+            this.loopHandle = null;
+        }
+        if (this.autoConnectAdapters) {
+            this.disconnectAllAdapters().catch(error => {
+                console.warn('[SensoryInputBridge] Failed to auto-disconnect adapters', error);
+            });
+        }
+    }
+
+    processSample(type, sample) {
+        if (!sample || typeof sample.confidence !== 'number') return;
+        if (sample.confidence < this.confidenceThreshold) return;
+
+        const now = performance.now();
+        const { payload: sanitizedPayload, issues } = this.schemaRegistry.validate(type, sample.payload);
+
+        if (issues.length > 0) {
+            console.warn(`[SensoryInputBridge] Schema validation issues for ${type}`, issues);
+            this.validationLog.push({ type, issues, timestamp: now, payload: sanitizedPayload });
+            if (this.validationLog.length > this.validationLogLimit) {
+                this.validationLog.shift();
+            }
+            if (this.validationReporter) {
+                try {
+                    this.validationReporter({ type, issues, payload: sanitizedPayload, timestamp: now });
+                } catch (error) {
+                    console.error('[SensoryInputBridge] validation reporter failed', error);
+                }
+            }
+            this.emit('schema:issue', { type, issues, timestamp: now, payload: sanitizedPayload });
+        }
+
+        if (!this.channels.has(type)) {
+            this.channels.set(type, []);
+        }
+        this.channels.get(type)?.push({ ...sample, payload: sanitizedPayload, issues, receivedAt: now });
+        this.applySemanticMapping(type, sanitizedPayload, sample.confidence, now);
+    }
+
+    applySemanticMapping(type, payload, confidence, timestamp) {
+        switch (type) {
+            case 'eye-tracking':
+                this.updateFocus(payload, confidence, timestamp);
+                break;
+            case 'neural-intent':
+                this.updateIntention(payload, confidence, timestamp);
+                break;
+            case 'biometric':
+                this.updateBiometrics(payload, confidence, timestamp);
+                break;
+            case 'ambient':
+                this.updateEnvironment(payload, confidence, timestamp);
+                break;
+            case 'gesture':
+                this.updateGestures(payload, confidence, timestamp);
+                break;
+            default:
+                // Allow custom adapters to emit semantic channel names directly
+                this.emit(type, { payload, confidence, timestamp });
+                break;
+        }
+    }
+
+    updateFocus(payload, confidence, timestamp) {
+        const { x = 0.5, y = 0.5, depth = 0.3 } = payload || {};
+        this.state.focusVector = {
+            x: this.lerp(this.state.focusVector.x, x, confidence),
+            y: this.lerp(this.state.focusVector.y, y, confidence),
+            depth: this.lerp(this.state.focusVector.depth, depth, confidence)
+        };
+        this.state.updatedAt = timestamp;
+        this.emit('focus', this.state.focusVector);
+        this.scheduleDecay('focus');
+    }
+
+    updateIntention(payload, confidence, timestamp) {
+        const { x = 0, y = 0, z = 0, w = 0, engagement = 0.4 } = payload || {};
+        this.state.intentionVector = {
+            x: this.lerp(this.state.intentionVector.x, x, confidence),
+            y: this.lerp(this.state.intentionVector.y, y, confidence),
+            z: this.lerp(this.state.intentionVector.z, z, confidence),
+            w: this.lerp(this.state.intentionVector.w, w, confidence)
+        };
+        this.state.engagementLevel = this.lerp(this.state.engagementLevel, engagement, confidence);
+        this.state.updatedAt = timestamp;
+        this.emit('intention', this.state.intentionVector);
+        this.emit('engagement', this.state.engagementLevel);
+        this.scheduleDecay('intention');
+        this.scheduleDecay('engagement');
+    }
+
+    updateBiometrics(payload, confidence, timestamp) {
+        const { stress = 0.2, heartRate = 68, temperature = 36.4 } = payload || {};
+        this.state.biometricStress = this.lerp(this.state.biometricStress, stress, confidence);
+        this.state.updatedAt = timestamp;
+        this.emit('biometrics', { stress: this.state.biometricStress, heartRate, temperature });
+        this.scheduleDecay('biometrics');
+    }
+
+    updateEnvironment(payload, confidence, timestamp) {
+        const { luminance = 0.5, noiseLevel = 0.2, motion = 0.1 } = payload || {};
+        this.state.environment = {
+            luminance: this.lerp(this.state.environment.luminance, luminance, confidence),
+            noiseLevel: this.lerp(this.state.environment.noiseLevel, noiseLevel, confidence),
+            motion: this.lerp(this.state.environment.motion, motion, confidence)
+        };
+        this.state.updatedAt = timestamp;
+        this.emit('environment', this.state.environment);
+        this.scheduleDecay('environment');
+    }
+
+    updateGestures(payload, confidence, timestamp) {
+        const { intent = null, vector = { x: 0, y: 0, z: 0 } } = payload || {};
+        this.state.gestureIntent = intent;
+        this.state.updatedAt = timestamp;
+        this.emit('gesture', { intent, vector, confidence });
+        this.scheduleDecay('gesture');
+    }
+
+    scheduleDecay(channel) {
+        if (this.decayTimers.has(channel)) {
+            clearTimeout(this.decayTimers.get(channel));
+        }
+        const timeout = setTimeout(() => {
+            this.emit(`${channel}:decay`, { channel, timestamp: performance.now() });
+        }, this.decayHalfLife);
+        this.decayTimers.set(channel, timeout);
+    }
+
+    emit(channel, payload) {
+        const listeners = this.subscribers.get(channel);
+        if (!listeners) return;
+        for (const callback of listeners) {
+            try {
+                callback(payload);
+            } catch (error) {
+                console.error(`[SensoryInputBridge] subscriber error on ${channel}`, error);
+            }
+        }
+    }
+
+    lerp(start, end, alpha) {
+        return start + (end - start) * alpha;
+    }
+
+    getSnapshot() {
+        return { ...this.state };
+    }
+
+    registerSchema(type, schema) {
+        this.schemaRegistry.register(type, schema);
+    }
+
+    getSchemaRegistry() {
+        return this.schemaRegistry;
+    }
+
+    setValidationReporter(reporter) {
+        this.validationReporter = typeof reporter === 'function' ? reporter : null;
+    }
+
+    getValidationLog() {
+        return [...this.validationLog];
+    }
+
+    getAdapterState(type) {
+        return this.adapterStates.get(type);
+    }
+}
+

--- a/src/ui/adaptive/SpatialLayoutSynthesizer.js
+++ b/src/ui/adaptive/SpatialLayoutSynthesizer.js
@@ -1,0 +1,126 @@
+import { FocusWeightedStrategy } from './strategies/FocusWeightedStrategy.js';
+import { PeripheralHandoffStrategy } from './strategies/PeripheralHandoffStrategy.js';
+import { HapticFallbackStrategy } from './strategies/HapticFallbackStrategy.js';
+import { StressAlertAnnotation } from './annotations/StressAlertAnnotation.js';
+
+const DEFAULT_SURFACES = [
+    { id: 'primary', curvature: 0.12, visibility: 1 },
+    { id: 'peripheral', curvature: 0.38, visibility: 0.6 },
+    { id: 'ambient', curvature: 0.72, visibility: 0.45 }
+];
+
+export class SpatialLayoutSynthesizer {
+    constructor(options = {}) {
+        const {
+            surfaces = DEFAULT_SURFACES,
+            strategies = [],
+            annotations = [],
+            useDefaultStrategies = true,
+            useDefaultAnnotations = true
+        } = options;
+
+        this.surfaces = surfaces.map(surface => ({ ...surface }));
+        this.strategies = [];
+        this.annotations = [];
+
+        if (useDefaultStrategies) {
+            this.registerStrategy(new FocusWeightedStrategy(options.focusStrategy || {}));
+            this.registerStrategy(new PeripheralHandoffStrategy(options.peripheralStrategy || {}));
+            this.registerStrategy(new HapticFallbackStrategy(options.hapticStrategy || {}));
+        }
+
+        strategies.forEach(strategy => this.registerStrategy(strategy));
+
+        if (useDefaultAnnotations) {
+            this.registerAnnotation(new StressAlertAnnotation(options.stressAnnotation || {}));
+        }
+
+        annotations.forEach(annotation => this.registerAnnotation(annotation));
+    }
+
+    registerStrategy(strategy) {
+        this.strategies = [...this.strategies.filter(item => item.id !== strategy.id), strategy]
+            .sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100));
+    }
+
+    registerAnnotation(annotation) {
+        this.annotations = [...this.annotations.filter(item => item.id !== annotation.id), annotation]
+            .sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100));
+    }
+
+    clearStrategies() {
+        this.strategies = [];
+    }
+
+    clearAnnotations() {
+        this.annotations = [];
+    }
+
+    generateLayout(context = {}) {
+        const shared = {};
+        const layout = this.createBaseLayout();
+
+        for (const strategy of this.strategies) {
+            strategy.prepare?.({ context, layout, shared, surfaces: this.surfaces });
+        }
+
+        for (const strategy of this.strategies) {
+            strategy.compose?.({ context, layout, shared, surfaces: this.surfaces });
+        }
+
+        layout.annotations = this.resolveAnnotations({ context, layout, shared });
+
+        return layout;
+    }
+
+    resolveAnnotations({ context, layout, shared }) {
+        const appliedIds = new Set();
+        const annotations = [];
+
+        for (const annotation of this.annotations) {
+            const dependenciesSatisfied = annotation.dependsOn?.every(dep => appliedIds.has(dep)) ?? true;
+            if (!dependenciesSatisfied) continue;
+
+            const shouldApply = annotation.shouldApply?.({ context, layout, shared }) ?? true;
+            if (!shouldApply) continue;
+
+            try {
+                const built = annotation.build?.({ context, layout, shared });
+                if (built) {
+                    annotations.push({ id: annotation.id, ...built });
+                    appliedIds.add(annotation.id);
+                }
+            } catch (error) {
+                console.warn(`[SpatialLayoutSynthesizer] Annotation ${annotation.id} failed`, error);
+            }
+        }
+
+        return annotations;
+    }
+
+    createBaseLayout() {
+        return {
+            intensity: 0.5,
+            zones: this.surfaces.map(surface => ({
+                id: surface.id,
+                curvature: surface.curvature,
+                visibility: surface.visibility,
+                occupancy: 0.45,
+                layeringDepth: surface.id === 'primary' ? 0.18 : surface.id === 'peripheral' ? 0.34 : 0.6,
+                recommendedComponents: []
+            })),
+            motion: {
+                velocity: 0,
+                bias: { x: 0, y: 0, z: 0 },
+                easing: 'ease-in-out'
+            },
+            typographyScale: 1,
+            colorAdaptation: {
+                hueShift: 180,
+                saturation: 60,
+                lightness: 48
+            },
+            annotations: []
+        };
+    }
+}

--- a/src/ui/adaptive/annotations/LayoutAnnotation.js
+++ b/src/ui/adaptive/annotations/LayoutAnnotation.js
@@ -1,0 +1,18 @@
+export class LayoutAnnotation {
+    constructor({ id, priority = 100, dependsOn = [] } = {}) {
+        if (!id) {
+            throw new Error('LayoutAnnotation requires an `id`.');
+        }
+        this.id = id;
+        this.priority = priority;
+        this.dependsOn = dependsOn;
+    }
+
+    shouldApply() {
+        return true;
+    }
+
+    build() {
+        return null;
+    }
+}

--- a/src/ui/adaptive/annotations/StressAlertAnnotation.js
+++ b/src/ui/adaptive/annotations/StressAlertAnnotation.js
@@ -1,0 +1,25 @@
+import { LayoutAnnotation } from './LayoutAnnotation.js';
+
+export class StressAlertAnnotation extends LayoutAnnotation {
+    constructor(options = {}) {
+        super({ id: 'stress-alert', priority: options.priority ?? 20 });
+        this.threshold = options.threshold ?? 0.5;
+    }
+
+    shouldApply({ shared }) {
+        return (shared.focus?.stress ?? 0) >= this.threshold;
+    }
+
+    build({ context, shared }) {
+        const stress = shared.focus?.stress ?? context.biometricStress ?? 0;
+        return {
+            type: 'alert',
+            severity: stress > 0.75 ? 'critical' : 'elevated',
+            message: 'Biometric stress trending high – enable haptic reassurance.',
+            data: {
+                stress,
+                timestamp: Date.now()
+            }
+        };
+    }
+}

--- a/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
+++ b/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
@@ -1,0 +1,357 @@
+const DEFAULT_ZONE_COLORS = {
+    primary: 'rgba(90, 197, 255, 0.85)',
+    peripheral: 'rgba(125, 107, 255, 0.85)',
+    ambient: 'rgba(255, 166, 87, 0.8)'
+};
+
+const DEFAULT_BACKGROUND = {
+    inner: 'rgba(12, 26, 46, 0.4)',
+    outer: 'rgba(6, 12, 22, 0.9)'
+};
+
+function toNumber(value, fallback = 0) {
+    const cast = Number(value);
+    return Number.isFinite(cast) ? cast : fallback;
+}
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function normalizeFocusVector(vector = {}) {
+    return {
+        x: clamp(toNumber(vector.x, 0.5), 0, 1),
+        y: clamp(toNumber(vector.y, 0.5), 0, 1),
+        depth: clamp(toNumber(vector.depth, 0.3), 0, 1)
+    };
+}
+
+function computeBiasAngle(bias = {}) {
+    const x = toNumber(bias.x, 0);
+    const y = toNumber(bias.y, 0);
+    if (x === 0 && y === 0) {
+        return -Math.PI / 2;
+    }
+    return Math.atan2(y, x);
+}
+
+export function buildLayoutBlueprint(layout = {}, design = {}, context = {}) {
+    const focusVector = normalizeFocusVector(context.focusVector);
+    const engagementLevel = clamp(toNumber(context.engagementLevel, 0.4), 0, 1);
+    const biometricStress = clamp(toNumber(context.biometricStress, 0.18), 0, 1);
+    const intensity = clamp(toNumber(layout.intensity, 0.5), 0, 1);
+    const motion = layout.motion || { velocity: 0, bias: { x: 0, y: 0, z: 0 }, easing: 'ease-in-out' };
+
+    const zones = Array.isArray(layout.zones) ? layout.zones : [];
+    const orderedZones = [...zones].sort((a, b) => toNumber(b.layeringDepth, 0) - toNumber(a.layeringDepth, 0));
+
+    const recommendedComponentSet = new Set();
+    const zoneSummaries = orderedZones.map(zone => {
+        const components = Array.isArray(zone.recommendedComponents) ? zone.recommendedComponents : [];
+        components.forEach(component => recommendedComponentSet.add(component));
+
+        const occupancy = clamp(toNumber(zone.occupancy, 0.4), 0, 1);
+        const layeringDepth = clamp(toNumber(zone.layeringDepth, 0.25), 0, 1);
+        const curvature = clamp(toNumber(zone.curvature, 0.3), 0, 1);
+        const surfaceScore = Number(((occupancy * (1.1 - layeringDepth) * (0.85 + intensity * 0.3)) * (1 - biometricStress * 0.35)).toFixed(3));
+
+        return {
+            id: zone.id || 'zone',
+            occupancy,
+            layeringDepth,
+            curvature,
+            visibility: clamp(toNumber(zone.visibility, 0.6), 0, 1),
+            components,
+            surfaceScore
+        };
+    });
+
+    const annotations = Array.isArray(layout.annotations) ? layout.annotations : [];
+
+    return {
+        generatedAt: new Date().toISOString(),
+        intensity,
+        engagementLevel,
+        biometricStress,
+        focusVector,
+        motion: {
+            velocity: clamp(toNumber(motion.velocity, 0), 0, 1),
+            easing: motion.easing || 'ease-in-out',
+            bias: {
+                x: clamp(toNumber(motion.bias?.x, 0), -1, 1),
+                y: clamp(toNumber(motion.bias?.y, 0), -1, 1),
+                z: clamp(toNumber(motion.bias?.z, 0), -1, 1)
+            }
+        },
+        pattern: design?.pattern || null,
+        monetization: design?.monetization || null,
+        integration: design?.integration || null,
+        annotations,
+        zones: zoneSummaries,
+        recommendedComponents: Array.from(recommendedComponentSet)
+    };
+}
+
+export class LayoutBlueprintRenderer {
+    constructor(options = {}) {
+        this.layers = new Map();
+        this.zoneColors = { ...DEFAULT_ZONE_COLORS, ...(options.zoneColors || {}) };
+        this.background = { ...DEFAULT_BACKGROUND, ...(options.background || {}) };
+        this.devicePadding = options.devicePadding ?? 0.12;
+        this.lastSize = 0;
+        this.lastRenderPayload = null;
+        this.resizeObserver = null;
+
+        if (options.layers) {
+            for (const [id, canvas] of Object.entries(options.layers)) {
+                this.attachLayer(id, canvas);
+            }
+        }
+
+        if (options.observe !== false) {
+            this.observeResize();
+        }
+    }
+
+    attachLayer(id, canvas) {
+        if (!canvas) return;
+        const context = canvas.getContext('2d');
+        if (!context) return;
+        this.layers.set(id, { canvas, context });
+        this.resizeCanvas(canvas);
+    }
+
+    detachLayer(id) {
+        const layer = this.layers.get(id);
+        if (!layer) return;
+        this.layers.delete(id);
+    }
+
+    get container() {
+        const first = this.layers.values().next();
+        if (first.done) return null;
+        return first.value.canvas.parentElement || null;
+    }
+
+    observeResize() {
+        const container = this.container;
+        if (!container || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+        this.resizeObserver?.disconnect?.();
+        this.resizeObserver = new ResizeObserver(() => this.resize());
+        this.resizeObserver.observe(container);
+    }
+
+    resize() {
+        const container = this.container;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const size = Math.floor(Math.min(rect.width, rect.height));
+        if (!size || size === this.lastSize) {
+            return;
+        }
+        this.lastSize = size;
+        for (const { canvas } of this.layers.values()) {
+            this.resizeCanvas(canvas, size);
+        }
+        if (this.lastRenderPayload) {
+            this.render(this.lastRenderPayload.layout, this.lastRenderPayload.design, this.lastRenderPayload.context);
+        }
+    }
+
+    resizeCanvas(canvas, size = null) {
+        if (!canvas) return;
+        const targetSize = size ?? this.lastSize ?? 720;
+        canvas.width = targetSize;
+        canvas.height = targetSize;
+    }
+
+    clearLayer(id) {
+        const layer = this.layers.get(id);
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+    }
+
+    clear() {
+        for (const id of this.layers.keys()) {
+            this.clearLayer(id);
+        }
+    }
+
+    render(layout, design, context) {
+        if (!layout) return;
+        this.lastRenderPayload = { layout, design, context };
+        if (!this.lastSize) {
+            this.resize();
+        }
+        const size = this.lastSize || 720;
+        const center = size / 2;
+        const padding = size * this.devicePadding;
+        const radius = center - padding;
+
+        this.drawBackground(size);
+        this.drawShadow(size, center, radius);
+        this.drawZones(layout, size, center, radius);
+        this.drawFocusHighlight(layout, context, size);
+        this.drawAccent(layout, design, size, center);
+    }
+
+    drawBackground(size) {
+        const layer = this.layers.get('background');
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        const gradient = context.createRadialGradient(size / 2, size / 2, size * 0.1, size / 2, size / 2, size * 0.55);
+        gradient.addColorStop(0, this.background.inner);
+        gradient.addColorStop(1, this.background.outer);
+        context.fillStyle = gradient;
+        context.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    drawShadow(size, center, radius) {
+        const layer = this.layers.get('shadow');
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        context.save();
+        context.fillStyle = 'rgba(0, 0, 0, 0.3)';
+        context.filter = 'blur(40px)';
+        context.beginPath();
+        context.ellipse(center, center + radius * 0.18, radius * 0.68, radius * 0.32, 0, 0, Math.PI * 2);
+        context.fill();
+        context.restore();
+    }
+
+    drawZones(layout, size, center, radius) {
+        const layer = this.layers.get('content');
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+
+        const zones = Array.isArray(layout.zones) ? [...layout.zones] : [];
+        zones.sort((a, b) => toNumber(b.layeringDepth, 0) - toNumber(a.layeringDepth, 0));
+
+        const biasAngle = computeBiasAngle(layout.motion?.bias);
+        let currentRadius = radius;
+        const baseThickness = size * 0.06;
+
+        for (const zone of zones) {
+            const color = this.zoneColors[zone.id] || 'rgba(255, 255, 255, 0.75)';
+            const occupancy = clamp(toNumber(zone.occupancy, 0.45), 0.05, 1);
+            const curvature = clamp(toNumber(zone.curvature, 0.4), 0.05, 1);
+            const layeringDepth = clamp(toNumber(zone.layeringDepth, 0.3), 0.05, 1);
+            const thickness = baseThickness * (0.6 + occupancy * 0.8);
+            const sweep = Math.PI * (0.45 + occupancy * 0.9);
+            const start = biasAngle - sweep / 2 + layeringDepth * 0.15;
+            const end = start + sweep * (0.9 + curvature * 0.2);
+
+            context.save();
+            context.strokeStyle = color;
+            context.lineWidth = thickness;
+            context.globalAlpha = 0.65 + (occupancy * 0.25);
+            context.lineCap = 'round';
+            context.beginPath();
+            context.arc(center, center, currentRadius, start, end);
+            context.stroke();
+            context.restore();
+
+            if (Array.isArray(zone.recommendedComponents) && zone.recommendedComponents.length) {
+                const angle = start + (end - start) * 0.65;
+                const pointRadius = currentRadius;
+                const x = center + Math.cos(angle) * pointRadius;
+                const y = center + Math.sin(angle) * pointRadius;
+                context.save();
+                context.fillStyle = color;
+                context.globalAlpha = 0.6;
+                context.beginPath();
+                context.arc(x, y, Math.max(4, thickness * 0.15), 0, Math.PI * 2);
+                context.fill();
+                context.restore();
+            }
+
+            currentRadius -= thickness * 0.8;
+        }
+    }
+
+    drawFocusHighlight(layout, contextSnapshot, size) {
+        const layer = this.layers.get('highlight');
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        const focus = normalizeFocusVector(contextSnapshot?.focusVector);
+        const radius = size * 0.12;
+        const x = focus.x * size;
+        const y = focus.y * size;
+
+        const gradient = context.createRadialGradient(x, y, size * 0.01, x, y, radius);
+        gradient.addColorStop(0, 'rgba(76, 159, 255, 0.5)');
+        gradient.addColorStop(1, 'rgba(76, 159, 255, 0)');
+        context.fillStyle = gradient;
+        context.fillRect(0, 0, canvas.width, canvas.height);
+
+        context.save();
+        context.fillStyle = 'rgba(255, 255, 255, 0.9)';
+        context.beginPath();
+        context.arc(x, y, size * (0.01 + clamp(toNumber(layout.intensity, 0.5), 0, 1) * 0.015), 0, Math.PI * 2);
+        context.fill();
+        context.restore();
+    }
+
+    drawAccent(layout, design, size, center) {
+        const layer = this.layers.get('accent');
+        if (!layer) return;
+        const { context, canvas } = layer;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+
+        const patternName = design?.pattern?.name || 'Adaptive Pattern';
+        const tier = design?.monetization?.tier || 'starter';
+        const components = new Set();
+        for (const zone of layout.zones || []) {
+            if (Array.isArray(zone.recommendedComponents)) {
+                for (const component of zone.recommendedComponents) {
+                    components.add(component);
+                }
+            }
+        }
+        const componentLine = Array.from(components).join('  •  ');
+
+        context.save();
+        context.fillStyle = 'rgba(255, 255, 255, 0.82)';
+        context.textAlign = 'center';
+        context.font = `${Math.round(size * 0.04)}px "Inter", "Segoe UI", sans-serif`;
+        context.fillText(patternName, center, size * 0.16);
+        context.fillStyle = 'rgba(255, 255, 255, 0.58)';
+        context.font = `${Math.round(size * 0.024)}px "Inter", "Segoe UI", sans-serif`;
+        context.fillText(`Tier ${tier}`.toUpperCase(), center, size * 0.21);
+
+        if (componentLine) {
+            context.fillStyle = 'rgba(255, 255, 255, 0.72)';
+            context.font = `${Math.round(size * 0.02)}px "Inter", "Segoe UI", sans-serif`;
+            context.fillText(componentLine, center, size * 0.86);
+        }
+
+        const intensity = clamp(toNumber(layout.intensity, 0.5), 0, 1);
+        const velocity = clamp(toNumber(layout.motion?.velocity, 0), 0, 1);
+        const gaugeWidth = size * 0.18;
+        const gaugeHeight = size * 0.006;
+        const startX = center - gaugeWidth / 2;
+        const baseY = size * 0.9;
+
+        context.fillStyle = 'rgba(255, 255, 255, 0.12)';
+        context.fillRect(startX, baseY, gaugeWidth, gaugeHeight);
+
+        context.fillStyle = 'rgba(76, 159, 255, 0.85)';
+        context.fillRect(startX, baseY, gaugeWidth * intensity, gaugeHeight);
+
+        context.fillStyle = 'rgba(255, 166, 87, 0.8)';
+        context.fillRect(startX, baseY + gaugeHeight * 2, gaugeWidth * velocity, gaugeHeight);
+
+        context.restore();
+    }
+}
+
+export function createLayoutBlueprintRenderer(options = {}) {
+    return new LayoutBlueprintRenderer(options);
+}

--- a/src/ui/adaptive/renderers/ProjectionFieldComposer.js
+++ b/src/ui/adaptive/renderers/ProjectionFieldComposer.js
@@ -1,0 +1,456 @@
+const DEFAULT_PROJECTION_OPTIONS = {
+    resolution: 32,
+    depthBands: 5,
+    haloFalloff: 0.65,
+    haloBaseRadius: 0.24,
+    gestureWeight: 0.4,
+    biasSmoothing: 0.45,
+    bandEasing: 'ease-in-out'
+};
+
+function toNumber(value, fallback = 0) {
+    const cast = Number(value);
+    return Number.isFinite(cast) ? cast : fallback;
+}
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function lerp(a, b, t) {
+    return a + (b - a) * clamp(t, 0, 1);
+}
+
+function ease(value, easing = 'ease-in-out') {
+    const t = clamp(value, 0, 1);
+    switch (easing) {
+        case 'ease-out':
+            return 1 - Math.pow(1 - t, 2);
+        case 'ease-in':
+            return Math.pow(t, 2);
+        case 'linear':
+            return t;
+        default:
+            return t < 0.5
+                ? 2 * t * t
+                : -1 + (4 - 2 * t) * t;
+    }
+}
+
+function normalizeBlueprint(blueprint = {}) {
+    return {
+        intensity: clamp(toNumber(blueprint.intensity, 0.5), 0, 1),
+        engagementLevel: clamp(toNumber(blueprint.engagementLevel, 0.5), 0, 1),
+        biometricStress: clamp(toNumber(blueprint.biometricStress, 0.2), 0, 1),
+        focusVector: {
+            x: clamp(toNumber(blueprint.focusVector?.x, 0.5), 0, 1),
+            y: clamp(toNumber(blueprint.focusVector?.y, 0.5), 0, 1),
+            depth: clamp(toNumber(blueprint.focusVector?.depth, 0.3), 0, 1)
+        },
+        zones: Array.isArray(blueprint.zones) ? blueprint.zones : [],
+        annotations: Array.isArray(blueprint.annotations) ? blueprint.annotations : []
+    };
+}
+
+function normalizeContext(context = {}) {
+    return {
+        gazeVelocity: clamp(toNumber(context.gazeVelocity, 0.35), 0, 1),
+        neuralCoherence: clamp(toNumber(context.neuralCoherence, 0.42), 0, 1),
+        hapticFeedback: clamp(toNumber(context.hapticFeedback, 0.3), 0, 1),
+        ambientVariance: clamp(toNumber(context.ambientVariance, 0.25), 0, 1),
+        gestureIntent: {
+            intensity: clamp(toNumber(context.gestureIntent?.intensity, 0.3), 0, 1),
+            vector: {
+                x: clamp(toNumber(context.gestureIntent?.vector?.x, 0.5), 0, 1),
+                y: clamp(toNumber(context.gestureIntent?.vector?.y, 0.5), 0, 1),
+                z: clamp(toNumber(context.gestureIntent?.vector?.z, 0.4), 0, 1)
+            }
+        }
+    };
+}
+
+function computeDepthBands(options, blueprint, context) {
+    const { depthBands, bandEasing } = options;
+    const { focusVector, engagementLevel, biometricStress } = blueprint;
+    const bands = [];
+    const bandCount = Math.max(3, Math.round(depthBands));
+    const depthBias = ease(focusVector.depth * (1 - biometricStress * 0.35), bandEasing);
+
+    for (let index = 0; index < bandCount; index += 1) {
+        const ratio = index / (bandCount - 1 || 1);
+        const easedRatio = ease(ratio * (0.65 + engagementLevel * 0.35), bandEasing);
+        const intensity = clamp(lerp(0.18, 0.92, easedRatio * (0.7 + context.neuralCoherence * 0.3)), 0, 1);
+        bands.push({
+            id: `band-${index}`,
+            index,
+            ratio,
+            intensity,
+            depth: clamp(easedRatio * (0.8 + depthBias * 0.2), 0, 1)
+        });
+    }
+
+    return bands;
+}
+
+function computeFocusHalo(options, blueprint, context) {
+    const { haloBaseRadius, haloFalloff } = options;
+    const intensity = blueprint.intensity;
+    const engagement = blueprint.engagementLevel;
+    const stress = blueprint.biometricStress;
+    const coherence = context.neuralCoherence;
+
+    const baseRadius = haloBaseRadius * (0.8 + engagement * 0.4);
+    const stressPenalty = (1 - stress * 0.65);
+    const coherenceBoost = 0.9 + coherence * 0.2;
+    const velocityBias = 0.85 + context.gazeVelocity * 0.25;
+
+    const radius = clamp(baseRadius * stressPenalty * coherenceBoost * velocityBias, 0.12, 0.6);
+    const falloff = clamp(haloFalloff * (1 - stress * 0.35) * (0.85 + intensity * 0.2), 0.3, 0.92);
+
+    return {
+        radius,
+        falloff,
+        origin: blueprint.focusVector,
+        stressPenalty,
+        coherenceBoost
+    };
+}
+
+function computeGestureContours(options, blueprint, context) {
+    const { gestureWeight, biasSmoothing } = options;
+    const { zones } = blueprint;
+    const { gestureIntent } = context;
+
+    const contourCount = Math.max(3, Math.round(gestureWeight * 9));
+    const contours = [];
+
+    for (let index = 0; index < contourCount; index += 1) {
+        const zone = zones[index % (zones.length || 1)] || {};
+        const occupancy = clamp(toNumber(zone.occupancy, 0.4), 0, 1);
+        const visibility = clamp(toNumber(zone.visibility, 0.5), 0, 1);
+        const curvature = clamp(toNumber(zone.curvature, 0.4), 0, 1);
+        const intensity = clamp(gestureIntent.intensity * (0.6 + visibility * 0.4), 0, 1);
+
+        contours.push({
+            id: `contour-${index}`,
+            orbit: clamp(0.25 + occupancy * 0.6, 0.2, 0.92),
+            curvature,
+            visibility,
+            intensity,
+            zoneId: zone.id || `zone-${index}`,
+            bias: {
+                x: clamp(lerp(gestureIntent.vector.x, blueprint.focusVector.x, biasSmoothing), 0, 1),
+                y: clamp(lerp(gestureIntent.vector.y, blueprint.focusVector.y, biasSmoothing), 0, 1),
+                z: clamp(lerp(gestureIntent.vector.z, blueprint.focusVector.depth, biasSmoothing), 0, 1)
+            }
+        });
+    }
+
+    return contours;
+}
+
+function computeInteractionLobes(blueprint, context) {
+    const { zones } = blueprint;
+    const lobes = [];
+
+    const baseVolume = clamp((blueprint.intensity + context.neuralCoherence) / 2, 0, 1);
+    const stressFactor = 1 - blueprint.biometricStress * 0.55;
+
+    for (const zone of zones) {
+        const layeringDepth = clamp(toNumber(zone.layeringDepth, 0.3), 0, 1);
+        const visibility = clamp(toNumber(zone.visibility, 0.6), 0, 1);
+        const occupancy = clamp(toNumber(zone.occupancy, 0.5), 0, 1);
+        const lobeVolume = clamp(baseVolume * (0.7 + visibility * 0.3) * (0.8 + occupancy * 0.2) * stressFactor, 0.1, 1);
+
+        lobes.push({
+            id: zone.id || `lobe-${lobes.length}`,
+            volume: lobeVolume,
+            layeringDepth,
+            visibility,
+            saturation: clamp(0.45 + occupancy * 0.4, 0.2, 1)
+        });
+    }
+
+    return lobes;
+}
+
+function computeActivationMatrix(options, blueprint, context) {
+    const resolution = Math.max(8, Math.round(options.resolution));
+    const matrix = [];
+    const halo = computeFocusHalo(options, blueprint, context);
+
+    for (let row = 0; row < resolution; row += 1) {
+        const rowValues = [];
+        for (let col = 0; col < resolution; col += 1) {
+            const x = col / (resolution - 1);
+            const y = row / (resolution - 1);
+            const dx = x - halo.origin.x;
+            const dy = y - halo.origin.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            const haloInfluence = Math.exp(-Math.pow(distance / halo.radius, 2)) * halo.falloff;
+            const engagementInfluence = blueprint.engagementLevel * 0.5;
+            const ambientInfluence = context.ambientVariance * 0.3;
+            const total = clamp(haloInfluence + engagementInfluence + ambientInfluence, 0, 1);
+            rowValues.push(Number(total.toFixed(3)));
+        }
+        matrix.push(rowValues);
+    }
+
+    return matrix;
+}
+
+export function composeProjectionField(blueprint, context = {}, options = {}) {
+    const normalizedBlueprint = normalizeBlueprint(blueprint);
+    const normalizedContext = normalizeContext(context);
+    const mergedOptions = { ...DEFAULT_PROJECTION_OPTIONS, ...(options || {}) };
+
+    const depthBands = computeDepthBands(mergedOptions, normalizedBlueprint, normalizedContext);
+    const focusHalo = computeFocusHalo(mergedOptions, normalizedBlueprint, normalizedContext);
+    const gestureContours = computeGestureContours(mergedOptions, normalizedBlueprint, normalizedContext);
+    const interactionLobes = computeInteractionLobes(normalizedBlueprint, normalizedContext);
+    const activationMatrix = computeActivationMatrix(mergedOptions, normalizedBlueprint, normalizedContext);
+
+    const blueprintAnnotations = normalizedBlueprint.annotations.map(annotation => ({
+        id: annotation.id || 'annotation',
+        type: annotation.type || 'note',
+        priority: toNumber(annotation.priority, 0)
+    }));
+
+    return {
+        generatedAt: new Date().toISOString(),
+        options: {
+            resolution: mergedOptions.resolution,
+            depthBands: mergedOptions.depthBands,
+            haloFalloff: mergedOptions.haloFalloff,
+            haloBaseRadius: mergedOptions.haloBaseRadius,
+            gestureWeight: mergedOptions.gestureWeight,
+            biasSmoothing: mergedOptions.biasSmoothing,
+            bandEasing: mergedOptions.bandEasing
+        },
+        focusHalo,
+        depthBands,
+        gestureContours,
+        interactionLobes,
+        activationMatrix,
+        annotations: blueprintAnnotations,
+        context: normalizedContext,
+        blueprint: normalizedBlueprint
+    };
+}
+
+export class ProjectionFieldComposer {
+    constructor(options = {}) {
+        this.layers = new Map();
+        this.options = { ...DEFAULT_PROJECTION_OPTIONS, ...(options || {}) };
+        this.lastComposition = null;
+        this.lastSize = 0;
+        this.resizeObserver = null;
+
+        if (options.layers) {
+            for (const [id, canvas] of Object.entries(options.layers)) {
+                this.attachLayer(id, canvas);
+            }
+        }
+
+        if (options.observe !== false) {
+            this.observeResize();
+        }
+    }
+
+    setOptions(options = {}) {
+        this.options = { ...this.options, ...(options || {}) };
+        if (this.lastComposition) {
+            this.render(this.lastComposition.blueprint, this.lastComposition.context);
+        }
+    }
+
+    attachLayer(id, canvas) {
+        if (!canvas || typeof canvas.getContext !== 'function') {
+            return;
+        }
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return;
+        }
+        this.layers.set(id, { canvas, context });
+        this.resizeCanvas(canvas);
+    }
+
+    detachLayer(id) {
+        this.layers.delete(id);
+    }
+
+    get container() {
+        const first = this.layers.values().next();
+        if (first.done) return null;
+        return first.value.canvas.parentElement || null;
+    }
+
+    observeResize() {
+        const container = this.container;
+        if (!container || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+        this.resizeObserver?.disconnect?.();
+        this.resizeObserver = new ResizeObserver(() => this.resize());
+        this.resizeObserver.observe(container);
+    }
+
+    resize() {
+        const container = this.container;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const size = Math.floor(Math.min(rect.width, rect.height));
+        if (!size || size === this.lastSize) {
+            return;
+        }
+        this.lastSize = size;
+        for (const { canvas } of this.layers.values()) {
+            this.resizeCanvas(canvas, size);
+        }
+        if (this.lastComposition) {
+            this.render(this.lastComposition.blueprint, this.lastComposition.context);
+        }
+    }
+
+    resizeCanvas(canvas, size = this.lastSize || 480) {
+        const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+        canvas.width = size * dpr;
+        canvas.height = size * dpr;
+        canvas.style.width = `${size}px`;
+        canvas.style.height = `${size}px`;
+        const context = canvas.getContext('2d');
+        if (context) {
+            context.reset?.();
+            context.scale(dpr, dpr);
+        }
+    }
+
+    compose(blueprint, context = {}, options = {}) {
+        const composition = composeProjectionField(blueprint, context, { ...this.options, ...(options || {}) });
+        this.lastComposition = composition;
+        return composition;
+    }
+
+    render(blueprint, context = {}, options = {}) {
+        const composition = this.compose(blueprint, context, options);
+        this.drawComposition(composition);
+        return composition;
+    }
+
+    drawComposition(composition) {
+        if (!composition) return;
+        const size = this.lastSize || this.estimateSize();
+        if (!size) return;
+
+        const baseLayer = this.layers.get('base');
+        const haloLayer = this.layers.get('halo');
+        const bandLayer = this.layers.get('bands');
+        const contourLayer = this.layers.get('contours');
+
+        if (baseLayer) {
+            this.drawActivationMatrix(baseLayer.context, size, composition);
+        }
+        if (bandLayer) {
+            this.drawDepthBands(bandLayer.context, size, composition);
+        }
+        if (haloLayer) {
+            this.drawFocusHalo(haloLayer.context, size, composition);
+        }
+        if (contourLayer) {
+            this.drawGestureContours(contourLayer.context, size, composition);
+        }
+    }
+
+    estimateSize() {
+        const container = this.container;
+        if (!container) return 0;
+        const rect = container.getBoundingClientRect();
+        const size = Math.floor(Math.min(rect.width, rect.height));
+        if (size && size !== this.lastSize) {
+            this.lastSize = size;
+        }
+        return this.lastSize;
+    }
+
+    clear() {
+        for (const { context, canvas } of this.layers.values()) {
+            context.clearRect(0, 0, canvas.width, canvas.height);
+        }
+    }
+
+    drawActivationMatrix(context, size, composition) {
+        context.clearRect(0, 0, size, size);
+        const { activationMatrix } = composition;
+        const rows = activationMatrix.length;
+        const cols = activationMatrix[0]?.length || 0;
+        if (!rows || !cols) {
+            return;
+        }
+        const cellWidth = size / cols;
+        const cellHeight = size / rows;
+        for (let row = 0; row < rows; row += 1) {
+            for (let col = 0; col < cols; col += 1) {
+                const value = activationMatrix[row][col];
+                context.fillStyle = `rgba(76, 159, 255, ${value * 0.6})`;
+                context.fillRect(col * cellWidth, row * cellHeight, cellWidth + 0.5, cellHeight + 0.5);
+            }
+        }
+    }
+
+    drawDepthBands(context, size, composition) {
+        context.clearRect(0, 0, size, size);
+        context.save();
+        context.translate(size / 2, size / 2);
+        const maxRadius = size * 0.46;
+        for (const band of composition.depthBands) {
+            const radius = maxRadius * band.depth;
+            context.beginPath();
+            context.strokeStyle = `rgba(171, 120, 255, ${0.22 + band.intensity * 0.4})`;
+            context.lineWidth = Math.max(1, radius * 0.04);
+            context.arc(0, 0, radius, 0, Math.PI * 2);
+            context.stroke();
+        }
+        context.restore();
+    }
+
+    drawFocusHalo(context, size, composition) {
+        context.clearRect(0, 0, size, size);
+        const centerX = composition.focusHalo.origin.x * size;
+        const centerY = composition.focusHalo.origin.y * size;
+        const radius = composition.focusHalo.radius * size;
+
+        const gradient = context.createRadialGradient(centerX, centerY, radius * 0.2, centerX, centerY, radius);
+        gradient.addColorStop(0, 'rgba(255, 255, 255, 0.8)');
+        gradient.addColorStop(0.45, 'rgba(76, 159, 255, 0.65)');
+        gradient.addColorStop(1, 'rgba(76, 159, 255, 0)');
+
+        context.fillStyle = gradient;
+        context.beginPath();
+        context.arc(centerX, centerY, radius, 0, Math.PI * 2);
+        context.fill();
+    }
+
+    drawGestureContours(context, size, composition) {
+        context.clearRect(0, 0, size, size);
+        context.save();
+        for (const contour of composition.gestureContours) {
+            const radius = size * contour.orbit * 0.48;
+            const centerX = contour.bias.x * size;
+            const centerY = contour.bias.y * size;
+            const angle = contour.bias.z * Math.PI * 2;
+            const arc = Math.PI * (0.35 + contour.curvature * 0.6);
+            context.beginPath();
+            context.strokeStyle = `rgba(255, 166, 87, ${0.35 + contour.intensity * 0.5})`;
+            context.lineWidth = Math.max(1.2, size * 0.01 * (0.6 + contour.intensity * 0.6));
+            context.arc(centerX, centerY, radius, angle - arc / 2, angle + arc / 2);
+            context.stroke();
+        }
+        context.restore();
+    }
+}
+
+export function createProjectionFieldComposer(options = {}) {
+    return new ProjectionFieldComposer(options);
+}
+

--- a/src/ui/adaptive/sensors/SensorSchemaRegistry.js
+++ b/src/ui/adaptive/sensors/SensorSchemaRegistry.js
@@ -1,0 +1,283 @@
+/**
+ * @typedef {Object} SensorSchemaIssue
+ * @property {string} field
+ * @property {string} code
+ * @property {string} [message]
+ */
+
+/**
+ * @typedef {Object} SensorSchemaResult
+ * @property {Record<string, any>} payload
+ * @property {SensorSchemaIssue[]} issues
+ */
+
+/**
+ * @typedef {{ normalize(payload: Record<string, any>, registry: SensorSchemaRegistry): SensorSchemaResult | Record<string, any>; fallback?: Record<string, any>; }} SensorSchemaDefinition
+ */
+
+const clamp = (value, min, max) => {
+    if (typeof min === 'number' && value < min) {
+        return min;
+    }
+    if (typeof max === 'number' && value > max) {
+        return max;
+    }
+    return value;
+};
+
+export class SensorSchemaRegistry {
+    constructor(options = {}) {
+        const { registerDefaults = true, schemas } = options;
+        this.schemas = new Map();
+
+        if (registerDefaults) {
+            this.registerDefaultSchemas();
+        }
+
+        if (schemas) {
+            this.loadCustomSchemas(schemas);
+        }
+    }
+
+    /**
+     * @param {string} type
+     * @param {SensorSchemaDefinition | ((payload: Record<string, any>) => SensorSchemaResult | Record<string, any>)} schema
+     */
+    register(type, schema) {
+        if (!type || typeof type !== 'string') {
+            throw new Error('SensorSchemaRegistry.register requires a sensor type string');
+        }
+
+        const normalizedSchema = typeof schema === 'function' ? { normalize: schema } : schema;
+        if (!normalizedSchema || typeof normalizedSchema.normalize !== 'function') {
+            throw new Error(`Sensor schema for ${type} must provide a normalize(payload) function`);
+        }
+
+        this.schemas.set(type, normalizedSchema);
+    }
+
+    /**
+     * @param {string} type
+     * @param {Record<string, any>} payload
+     * @returns {SensorSchemaResult}
+     */
+    validate(type, payload) {
+        const schema = this.schemas.get(type);
+        if (!schema) {
+            return { payload: payload ?? {}, issues: [] };
+        }
+
+        try {
+            const result = schema.normalize(payload ?? {}, this);
+            if (!result || typeof result !== 'object') {
+                return { payload: {}, issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }] };
+            }
+
+            if ('payload' in result) {
+                return {
+                    payload: result.payload ?? {},
+                    issues: Array.isArray(result.issues) ? result.issues : []
+                };
+            }
+
+            return { payload: result, issues: [] };
+        } catch (error) {
+            return {
+                payload: schema.fallback ?? {},
+                issues: [{ field: '*', code: 'schema-error', message: error.message }]
+            };
+        }
+    }
+
+    registerDefaultSchemas() {
+        this.register('eye-tracking', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    x: this.ensureNumber(payload.x, {
+                        field: 'x',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.5,
+                        issues
+                    }),
+                    y: this.ensureNumber(payload.y, {
+                        field: 'y',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.5,
+                        issues
+                    }),
+                    depth: this.ensureNumber(payload.depth, {
+                        field: 'depth',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.3,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { x: 0.5, y: 0.5, depth: 0.3 }
+        });
+
+        this.register('neural-intent', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    x: this.ensureNumber(payload.x, { field: 'x', min: -1, max: 1, defaultValue: 0, issues }),
+                    y: this.ensureNumber(payload.y, { field: 'y', min: -1, max: 1, defaultValue: 0, issues }),
+                    z: this.ensureNumber(payload.z, { field: 'z', min: -1, max: 1, defaultValue: 0, issues }),
+                    w: this.ensureNumber(payload.w, { field: 'w', min: -1, max: 1, defaultValue: 0, issues }),
+                    engagement: this.ensureNumber(payload.engagement, {
+                        field: 'engagement',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 0.4,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { x: 0, y: 0, z: 0, w: 0, engagement: 0.4 }
+        });
+
+        this.register('biometric', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    stress: this.ensureNumber(payload.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, issues }),
+                    heartRate: this.ensureInteger(payload.heartRate, {
+                        field: 'heartRate',
+                        min: 30,
+                        max: 220,
+                        defaultValue: 68,
+                        issues
+                    }),
+                    temperature: this.ensureNumber(payload.temperature, {
+                        field: 'temperature',
+                        min: 32,
+                        max: 40,
+                        defaultValue: 36.4,
+                        precision: 1,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { stress: 0.2, heartRate: 68, temperature: 36.4 }
+        });
+
+        this.register('ambient', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    luminance: this.ensureNumber(payload.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, issues }),
+                    noiseLevel: this.ensureNumber(payload.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, issues }),
+                    motion: this.ensureNumber(payload.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, issues })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 }
+        });
+
+        this.register('gesture', {
+            normalize: payload => {
+                const issues = [];
+                const normalized = {
+                    intent: this.ensureString(payload.intent, { field: 'intent', allowEmpty: true, issues }),
+                    vector: this.ensureVector(payload.vector, {
+                        field: 'vector',
+                        min: -1,
+                        max: 1,
+                        defaultValue: 0,
+                        issues
+                    })
+                };
+                return { payload: normalized, issues };
+            },
+            fallback: { intent: null, vector: { x: 0, y: 0, z: 0 } }
+        });
+    }
+
+    loadCustomSchemas(schemas) {
+        if (Array.isArray(schemas)) {
+            for (const entry of schemas) {
+                if (entry && typeof entry === 'object' && entry.type) {
+                    this.register(entry.type, entry.schema);
+                }
+            }
+            return;
+        }
+
+        if (typeof schemas === 'object') {
+            for (const [type, schema] of Object.entries(schemas)) {
+                this.register(type, schema);
+            }
+        }
+    }
+
+    ensureNumber(value, { field, min, max, defaultValue = 0, precision, issues }) {
+        let numberValue = Number(value);
+        if (value === undefined || value === null || Number.isNaN(numberValue)) {
+            issues?.push({ field, code: 'type', message: 'Expected numeric value.' });
+            numberValue = defaultValue;
+        }
+
+        const clamped = clamp(numberValue, min, max);
+        if (typeof min === 'number' && clamped === min && numberValue < min) {
+            issues?.push({ field, code: 'min', message: `Value below minimum; clamped to ${min}.` });
+        }
+        if (typeof max === 'number' && clamped === max && numberValue > max) {
+            issues?.push({ field, code: 'max', message: `Value above maximum; clamped to ${max}.` });
+        }
+
+        let finalValue = clamped;
+        if (typeof precision === 'number') {
+            const factor = 10 ** precision;
+            finalValue = Math.round(finalValue * factor) / factor;
+        }
+
+        return finalValue;
+    }
+
+    ensureInteger(value, { field, min, max, defaultValue = 0, issues }) {
+        const numberValue = this.ensureNumber(value, { field, min, max, defaultValue, issues });
+        return Math.round(numberValue);
+    }
+
+    ensureString(value, { field, allowEmpty = false, fallback = null, issues }) {
+        if (typeof value !== 'string') {
+            if (value == null) {
+                if (!allowEmpty) {
+                    issues?.push({ field, code: 'type', message: 'Expected string value.' });
+                }
+                return fallback;
+            }
+
+            try {
+                value = String(value);
+            } catch (error) {
+                issues?.push({ field, code: 'type', message: 'Value is not coercible to string.' });
+                return fallback;
+            }
+        }
+
+        const normalized = value.trim();
+        if (!allowEmpty && normalized.length === 0) {
+            issues?.push({ field, code: 'empty', message: 'String value cannot be empty.' });
+            return fallback;
+        }
+
+        return normalized.length === 0 ? fallback : normalized;
+    }
+
+    ensureVector(value, { field, min, max, defaultValue = 0, issues }) {
+        const base = value && typeof value === 'object' ? value : {};
+        return {
+            x: this.ensureNumber(base.x, { field: `${field}.x`, min, max, defaultValue, issues }),
+            y: this.ensureNumber(base.y, { field: `${field}.y`, min, max, defaultValue, issues }),
+            z: this.ensureNumber(base.z, { field: `${field}.z`, min, max, defaultValue, issues })
+        };
+    }
+}

--- a/src/ui/adaptive/simulators/ProjectionScenarioSimulator.js
+++ b/src/ui/adaptive/simulators/ProjectionScenarioSimulator.js
@@ -1,0 +1,237 @@
+import { composeProjectionField } from '../renderers/ProjectionFieldComposer.js';
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function toNumber(value, fallback = 0) {
+    const cast = Number(value);
+    return Number.isFinite(cast) ? cast : fallback;
+}
+
+function deepClone(value) {
+    if (typeof structuredClone === 'function') {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeScenarioDescriptor(descriptor = {}) {
+    if (!descriptor.id) {
+        throw new Error('ProjectionScenarioSimulator: scenario descriptor requires an `id`.');
+    }
+    const cycleMs = Math.max(1000, toNumber(descriptor.cycleMs, 8000));
+    return {
+        id: descriptor.id,
+        name: descriptor.name || descriptor.id,
+        description: descriptor.description || '',
+        cycleMs,
+        blueprint: descriptor.blueprint ? deepClone(descriptor.blueprint) : null,
+        context: descriptor.context ? deepClone(descriptor.context) : {},
+        modulation: descriptor.modulation || {},
+        metadata: descriptor.metadata || {},
+        anchors: descriptor.anchors || []
+    };
+}
+
+function applyRange(value, modulation, progress) {
+    if (!modulation) return value;
+    const start = toNumber(modulation.start, value);
+    const end = toNumber(modulation.end, value);
+    const easing = modulation.easing || 'linear';
+    const eased = ease(progress, easing);
+    return start + (end - start) * eased;
+}
+
+function ease(t, easing) {
+    const clamped = clamp(t, 0, 1);
+    switch (easing) {
+        case 'ease-in':
+            return Math.pow(clamped, 2);
+        case 'ease-out':
+            return 1 - Math.pow(1 - clamped, 2);
+        case 'anticipate':
+            return Math.pow(clamped, 2) * ((2 + 1) * clamped - 2);
+        case 'ease-in-out':
+            return clamped < 0.5
+                ? 2 * clamped * clamped
+                : -1 + (4 - 2 * clamped) * clamped;
+        default:
+            return clamped;
+    }
+}
+
+function mixBlueprint(baseBlueprint = {}, modulation = {}, progress = 0) {
+    const blueprint = deepClone(baseBlueprint);
+    blueprint.intensity = clamp(applyRange(toNumber(baseBlueprint.intensity, 0.5), modulation.intensity, progress), 0, 1);
+    blueprint.engagementLevel = clamp(applyRange(toNumber(baseBlueprint.engagementLevel, 0.4), modulation.engagementLevel, progress), 0, 1);
+    blueprint.biometricStress = clamp(applyRange(toNumber(baseBlueprint.biometricStress, 0.2), modulation.biometricStress, progress), 0, 1);
+
+    const focus = blueprint.focusVector || { x: 0.5, y: 0.5, depth: 0.3 };
+    blueprint.focusVector = {
+        x: clamp(applyRange(focus.x, modulation.focusX, progress), 0, 1),
+        y: clamp(applyRange(focus.y, modulation.focusY, progress), 0, 1),
+        depth: clamp(applyRange(focus.depth, modulation.focusDepth, progress), 0, 1)
+    };
+
+    const zones = Array.isArray(blueprint.zones) ? blueprint.zones : [];
+    if (Array.isArray(modulation.zoneOccupancy)) {
+        for (const zoneMod of modulation.zoneOccupancy) {
+            const zone = zones.find(item => item.id === zoneMod.id);
+            if (zone) {
+                zone.occupancy = clamp(applyRange(toNumber(zone.occupancy, 0.4), zoneMod, progress), 0, 1);
+            }
+        }
+    }
+
+    return blueprint;
+}
+
+function mixContext(baseContext = {}, modulation = {}, progress = 0) {
+    const context = deepClone(baseContext);
+    context.engagementLevel = clamp(applyRange(toNumber(baseContext.engagementLevel, 0.4), modulation.engagementLevel, progress), 0, 1);
+    context.gazeVelocity = clamp(applyRange(toNumber(baseContext.gazeVelocity, 0.35), modulation.gazeVelocity, progress), 0, 1);
+    context.neuralCoherence = clamp(applyRange(toNumber(baseContext.neuralCoherence, 0.45), modulation.neuralCoherence, progress), 0, 1);
+    context.hapticFeedback = clamp(applyRange(toNumber(baseContext.hapticFeedback, 0.3), modulation.hapticFeedback, progress), 0, 1);
+
+    const gestureVector = baseContext.gestureIntent?.vector || { x: 0.5, y: 0.5, z: 0.4 };
+    const intensity = toNumber(baseContext.gestureIntent?.intensity, 0.3);
+    context.gestureIntent = {
+        intensity: clamp(applyRange(intensity, modulation.gestureIntensity, progress), 0, 1),
+        vector: {
+            x: clamp(applyRange(gestureVector.x, modulation.gestureX, progress), 0, 1),
+            y: clamp(applyRange(gestureVector.y, modulation.gestureY, progress), 0, 1),
+            z: clamp(applyRange(gestureVector.z, modulation.gestureZ, progress), 0, 1)
+        }
+    };
+
+    return context;
+}
+
+export class ProjectionScenarioSimulator {
+    constructor(options = {}) {
+        this.scenarios = new Map();
+        this.activeScenarioId = null;
+        this.lastResult = null;
+        this.lastAdaptiveState = null;
+        this.options = { autoStart: options.autoStart ?? true };
+        this.composer = options.composer || null;
+        this.listeners = new Map();
+    }
+
+    on(event, listener) {
+        if (!this.listeners.has(event)) {
+            this.listeners.set(event, new Set());
+        }
+        this.listeners.get(event).add(listener);
+        return () => this.listeners.get(event)?.delete(listener);
+    }
+
+    emit(event, payload) {
+        const listeners = this.listeners.get(event);
+        if (!listeners) return;
+        for (const listener of listeners) {
+            listener(payload);
+        }
+    }
+
+    registerScenario(descriptor) {
+        const scenario = normalizeScenarioDescriptor(descriptor);
+        this.scenarios.set(scenario.id, scenario);
+        if (!this.activeScenarioId) {
+            this.activeScenarioId = scenario.id;
+            this.emit('scenario:activated', scenario);
+        }
+        return scenario;
+    }
+
+    removeScenario(id) {
+        if (!this.scenarios.has(id)) {
+            return false;
+        }
+        const wasActive = this.activeScenarioId === id;
+        this.scenarios.delete(id);
+        if (wasActive) {
+            const next = this.scenarios.keys().next();
+            this.activeScenarioId = next.done ? null : next.value;
+            if (this.activeScenarioId) {
+                this.emit('scenario:activated', this.scenarios.get(this.activeScenarioId));
+            }
+        }
+        return true;
+    }
+
+    listScenarios() {
+        return Array.from(this.scenarios.values()).map(entry => deepClone(entry));
+    }
+
+    getScenario(id) {
+        const scenario = this.scenarios.get(id);
+        return scenario ? deepClone(scenario) : null;
+    }
+
+    setActiveScenario(id) {
+        if (!this.scenarios.has(id)) {
+            throw new Error(`ProjectionScenarioSimulator: unknown scenario '${id}'.`);
+        }
+        this.activeScenarioId = id;
+        this.emit('scenario:activated', this.scenarios.get(id));
+        return this.getScenario(id);
+    }
+
+    getActiveScenario() {
+        return this.activeScenarioId ? this.getScenario(this.activeScenarioId) : null;
+    }
+
+    observeAdaptiveState(state) {
+        this.lastAdaptiveState = state ? deepClone(state) : null;
+    }
+
+    step(options = {}) {
+        if (!this.activeScenarioId) {
+            return null;
+        }
+        const scenario = this.scenarios.get(this.activeScenarioId);
+        if (!scenario) {
+            return null;
+        }
+        const now = options.timestamp || Date.now();
+        const cycleMs = Math.max(1000, scenario.cycleMs);
+        const progress = (now % cycleMs) / cycleMs;
+
+        const baseBlueprint = scenario.blueprint || this.lastAdaptiveState?.blueprint || {};
+        const baseContext = scenario.context || this.lastAdaptiveState?.context || {};
+
+        const blueprint = mixBlueprint(baseBlueprint, scenario.modulation.blueprint || {}, progress);
+        const context = mixContext(baseContext, scenario.modulation.context || {}, progress);
+
+        const composition = this.compose(blueprint, context, scenario.modulation.composerOptions);
+        const anchors = scenario.anchors.map(anchor => ({ ...anchor, progress }));
+
+        this.lastResult = {
+            id: scenario.id,
+            name: scenario.name,
+            progress,
+            cycleMs,
+            blueprint,
+            context,
+            composition,
+            anchors
+        };
+
+        this.emit('scenario:frame', this.lastResult);
+        return this.lastResult;
+    }
+
+    compose(blueprint, context = {}, composerOptions = {}) {
+        if (this.composer && typeof this.composer.compose === 'function') {
+            return this.composer.compose(blueprint, context, composerOptions);
+        }
+        return composeProjectionField(blueprint, context, composerOptions);
+    }
+
+    getLastResult() {
+        return this.lastResult ? deepClone(this.lastResult) : null;
+    }
+}
+

--- a/src/ui/adaptive/strategies/FocusWeightedStrategy.js
+++ b/src/ui/adaptive/strategies/FocusWeightedStrategy.js
@@ -1,0 +1,84 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class FocusWeightedStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'focus-weighted', priority: options.priority ?? 10 });
+        this.focusAmplifier = options.focusAmplifier ?? 1.2;
+        this.engagementWeight = options.engagementWeight ?? 0.65;
+        this.motionSensitivity = options.motionSensitivity ?? 0.35;
+    }
+
+    prepare({ context, layout, shared }) {
+        const { focusVector = { x: 0.5, y: 0.5, depth: 0.3 }, engagementLevel = 0.4, biometricStress = 0 } = context;
+        const focusMagnitude = Math.sqrt(
+            Math.pow((focusVector.x ?? 0.5) - 0.5, 2) +
+            Math.pow((focusVector.y ?? 0.5) - 0.5, 2) +
+            Math.pow(((focusVector.depth ?? 0.3)) - 0.3, 2)
+        );
+        const invertedFocus = 1 - Math.min(focusMagnitude * this.focusAmplifier, 1);
+        const engagementBoost = engagementLevel * this.engagementWeight;
+        const stressPenalty = biometricStress * 0.45;
+        const intensity = Math.max(0.1, Math.min(1, invertedFocus + engagementBoost - stressPenalty));
+
+        layout.intensity = intensity;
+        layout.typographyScale = Math.max(0.8, 1.0 + engagementLevel * 0.15 - biometricStress * 0.1);
+
+        shared.focus = {
+            intensity,
+            stress: biometricStress
+        };
+    }
+
+    compose({ context, layout }) {
+        const { intentionVector = { x: 0, y: 0, z: 0, w: 0 }, gestureIntent, environment = { luminance: 0.4, noiseLevel: 0.2, motion: 0.2 } } = context;
+        const vectorMagnitude = Math.sqrt(
+            Math.pow(intentionVector.x ?? 0, 2) +
+            Math.pow(intentionVector.y ?? 0, 2) +
+            Math.pow(intentionVector.z ?? 0, 2) +
+            Math.pow(intentionVector.w ?? 0, 2)
+        );
+        const baseVelocity = Math.min(1, vectorMagnitude * this.motionSensitivity + 0.1);
+        layout.motion = {
+            velocity: baseVelocity,
+            bias: gestureIntent?.vector || { x: 0, y: 0, z: 0 },
+            easing: gestureIntent?.intent === 'hold' ? 'ease-out' : 'ease-in-out'
+        };
+
+        layout.zones = (layout.zones || []).map(zone => {
+            const visibility = (zone.visibility ?? 0.6) * (0.6 + layout.intensity * 0.4);
+            const luminanceCompensation = 1 - (environment.luminance ?? 0) * 0.3;
+            const noiseCompensation = 1 - (environment.noiseLevel ?? 0) * 0.2;
+            const occupancy = Math.max(0.1, Math.min(1, visibility * luminanceCompensation * noiseCompensation));
+
+            return {
+                ...zone,
+                occupancy,
+                layeringDepth: this.computeLayering(zone.id, layout.intensity),
+                recommendedComponents: this.recommendComponents(zone.id, layout.intensity)
+            };
+        });
+
+        const ambientInfluence = (environment.luminance ?? 0) * 0.5 + (environment.motion ?? 0) * 0.35;
+        const stressTint = (context.biometricStress ?? 0) * 12;
+        layout.colorAdaptation = {
+            hueShift: Math.round((ambientInfluence * 45 + 180) % 360),
+            saturation: Math.max(40, 75 - stressTint),
+            lightness: Math.max(30, 60 - (environment.luminance ?? 0) * 20)
+        };
+    }
+
+    computeLayering(zoneId, intensity) {
+        const base = zoneId === 'primary' ? 0.15 : zoneId === 'peripheral' ? 0.32 : 0.58;
+        return Math.min(1, base + intensity * 0.4);
+    }
+
+    recommendComponents(zoneId, intensity) {
+        if (zoneId === 'primary') {
+            return intensity > 0.65 ? ['holographic-panel', 'adaptive-controls'] : ['glanceable-card'];
+        }
+        if (zoneId === 'peripheral') {
+            return intensity > 0.5 ? ['ambient-indicator', 'intent-feedback'] : ['pulse-strip'];
+        }
+        return ['environmental-visualizer'];
+    }
+}

--- a/src/ui/adaptive/strategies/HapticFallbackStrategy.js
+++ b/src/ui/adaptive/strategies/HapticFallbackStrategy.js
@@ -1,0 +1,27 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class HapticFallbackStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'haptic-fallback', priority: options.priority ?? 40 });
+        this.activationStress = options.activationStress ?? 0.45;
+        this.minIntensity = options.minIntensity ?? 0.35;
+    }
+
+    compose({ layout, shared }) {
+        const stress = shared.focus?.stress ?? 0;
+        const intensity = layout.intensity ?? shared.focus?.intensity ?? 0.5;
+        if (stress < this.activationStress && intensity > this.minIntensity) {
+            return;
+        }
+
+        layout.zones = (layout.zones || []).map(zone => {
+            const updated = { ...zone };
+            updated.recommendedComponents = [...(zone.recommendedComponents || [])];
+            if (!updated.recommendedComponents.includes('haptic-pulse')) {
+                updated.recommendedComponents.push('haptic-pulse');
+            }
+            updated.layeringDepth = Math.min(1, (zone.layeringDepth ?? 0.4) + 0.12);
+            return updated;
+        });
+    }
+}

--- a/src/ui/adaptive/strategies/LayoutStrategy.js
+++ b/src/ui/adaptive/strategies/LayoutStrategy.js
@@ -1,0 +1,17 @@
+export class LayoutStrategy {
+    constructor({ id, priority = 100 } = {}) {
+        if (!id) {
+            throw new Error('LayoutStrategy requires an `id`.');
+        }
+        this.id = id;
+        this.priority = priority;
+    }
+
+    prepare() {
+        return undefined;
+    }
+
+    compose() {
+        return undefined;
+    }
+}

--- a/src/ui/adaptive/strategies/PeripheralHandoffStrategy.js
+++ b/src/ui/adaptive/strategies/PeripheralHandoffStrategy.js
@@ -1,0 +1,50 @@
+import { LayoutStrategy } from './LayoutStrategy.js';
+
+export class PeripheralHandoffStrategy extends LayoutStrategy {
+    constructor(options = {}) {
+        super({ id: 'peripheral-handoff', priority: options.priority ?? 30 });
+        this.primaryBias = options.primaryBias ?? 0.6;
+        this.handoffThreshold = options.handoffThreshold ?? 0.55;
+    }
+
+    prepare({ context, shared }) {
+        shared.environment = context.environment || { luminance: 0.4, noiseLevel: 0.2 };
+    }
+
+    compose({ layout, shared }) {
+        if (!layout.zones) return;
+
+        const environment = shared.environment;
+        const intensity = shared.focus?.intensity ?? layout.intensity ?? 0.5;
+        const noiseInfluence = environment.noiseLevel ?? 0;
+        const luminanceInfluence = environment.luminance ?? 0;
+
+        const primary = layout.zones.find(zone => zone.id === 'primary');
+        const peripheral = layout.zones.find(zone => zone.id === 'peripheral');
+        const ambient = layout.zones.find(zone => zone.id === 'ambient');
+
+        if (!primary) return;
+
+        if (intensity > this.handoffThreshold && noiseInfluence > 0.25) {
+            const shift = Math.min(0.2, (intensity - this.handoffThreshold) * 0.4 + noiseInfluence * 0.1);
+            primary.occupancy = Math.max(0.35, primary.occupancy - shift);
+            if (peripheral) {
+                peripheral.occupancy = Math.min(0.95, peripheral.occupancy + shift * 0.7);
+            }
+            if (ambient) {
+                ambient.occupancy = Math.min(0.8, ambient.occupancy + shift * 0.3);
+            }
+        } else {
+            primary.occupancy = Math.max(this.primaryBias, primary.occupancy);
+        }
+
+        if (peripheral) {
+            peripheral.recommendedComponents = peripheral.recommendedComponents || [];
+            if (intensity < 0.45 && luminanceInfluence < 0.35) {
+                if (!peripheral.recommendedComponents.includes('glow-band')) {
+                    peripheral.recommendedComponents.push('glow-band');
+                }
+            }
+        }
+    }
+}

--- a/src/ui/components/ConsentPanel.js
+++ b/src/ui/components/ConsentPanel.js
@@ -1,0 +1,250 @@
+function createElement(tag, className) {
+    const element = document.createElement(tag);
+    if (className) {
+        element.className = className;
+    }
+    return element;
+}
+
+function formatTimestamp(timestamp) {
+    if (!timestamp) return '';
+    try {
+        return new Date(timestamp).toISOString().replace('T', ' ').replace('Z', 'Z');
+    } catch (error) {
+        return String(timestamp);
+    }
+}
+
+function defaultDownloadFormatter(records) {
+    return JSON.stringify({
+        generatedAt: new Date().toISOString(),
+        records
+    }, null, 2);
+}
+
+function defaultFileName(prefix = 'compliance-log') {
+    return `${prefix}-${Date.now()}.json`;
+}
+
+export function createConsentPanel(options = {}) {
+    const {
+        container,
+        consentOptions = [],
+        getTelemetryConsent,
+        onConsentToggle,
+        getComplianceRecords,
+        getTelemetryAuditTrail,
+        refreshInterval = 6000,
+        downloadFormatter = defaultDownloadFormatter,
+        downloadFileNamePrefix = 'compliance-log',
+        onDownload,
+        onRender,
+        trackConsentToggle,
+        createAnchor = () => document.createElement('a'),
+        heading = 'Telemetry & Consent'
+    } = options;
+
+    if (!container) {
+        throw new Error('[ConsentPanel] `container` is required.');
+    }
+
+    const state = {
+        consent: {},
+        refreshTimer: null,
+        elements: {},
+        destroyed: false
+    };
+
+    function buildStructure() {
+        container.innerHTML = '';
+
+        const headingEl = createElement('h2');
+        headingEl.textContent = heading;
+        container.appendChild(headingEl);
+
+        const grid = createElement('div', 'consent-grid');
+        const status = createElement('div', 'consent-status');
+        const downloadButton = createElement('button', 'secondary');
+        downloadButton.type = 'button';
+        downloadButton.textContent = 'Download Compliance Log';
+        const logList = createElement('ul', 'compliance-log');
+
+        const toggles = new Map();
+        consentOptions.forEach(option => {
+            const label = createElement('label', 'consent-toggle');
+            const wrapper = createElement('div');
+            const titleEl = createElement('span');
+            titleEl.textContent = option.title;
+            const description = createElement('small');
+            description.textContent = option.description;
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.dataset.consent = option.classification;
+            input.setAttribute('aria-label', option.title);
+
+            wrapper.appendChild(titleEl);
+            wrapper.appendChild(description);
+            label.appendChild(wrapper);
+            label.appendChild(input);
+            grid.appendChild(label);
+            toggles.set(option.classification, input);
+        });
+
+        container.appendChild(grid);
+        container.appendChild(status);
+        container.appendChild(downloadButton);
+        container.appendChild(logList);
+
+        state.elements = {
+            grid,
+            status,
+            downloadButton,
+            logList,
+            toggles
+        };
+    }
+
+    function syncToggles(consent) {
+        state.elements.toggles.forEach((input, classification) => {
+            if (classification in consent) {
+                input.checked = Boolean(consent[classification]);
+            }
+        });
+    }
+
+    function renderStatus(consentSnapshot, metadata = {}) {
+        const enabled = Object.entries(consentSnapshot)
+            .filter(([, value]) => Boolean(value))
+            .map(([key]) => key.toUpperCase());
+        const disabled = Object.entries(consentSnapshot)
+            .filter(([, value]) => !value)
+            .map(([key]) => key.toUpperCase());
+        const auditTrail = typeof getTelemetryAuditTrail === 'function' ? getTelemetryAuditTrail() : [];
+        const auditCount = Array.isArray(auditTrail) ? auditTrail.length : 0;
+        const source = metadata.source ? `Last change via ${metadata.source}.` : '';
+
+        state.elements.status.innerHTML = `
+            <strong>Active:</strong> ${enabled.length ? enabled.join(', ') : 'None'}<br>
+            <strong>Opt-out:</strong> ${disabled.length ? disabled.join(', ') : 'None'}<br>
+            <strong>Audit Entries:</strong> ${auditCount}<br>
+            ${source}
+        `.trim();
+
+        onRender?.({ consent: consentSnapshot, metadata });
+    }
+
+    function renderComplianceLog() {
+        const recordsSource = typeof getComplianceRecords === 'function' ? getComplianceRecords() : [];
+        const records = Array.isArray(recordsSource) ? recordsSource : [];
+        const recent = records.slice(-4).reverse();
+        state.elements.logList.innerHTML = '';
+
+        if (!recent.length) {
+            const empty = document.createElement('li');
+            empty.textContent = 'No compliance events captured yet.';
+            state.elements.logList.appendChild(empty);
+            return;
+        }
+
+        recent.forEach(entry => {
+            const item = document.createElement('li');
+            item.textContent = `${entry.event} • ${entry.classification?.toUpperCase?.() ?? ''}`.trim();
+            const meta = document.createElement('span');
+            const sourceLabel = entry.source ? ` • ${entry.source}` : '';
+            meta.textContent = `${formatTimestamp(entry.timestamp)}${sourceLabel}`;
+            item.appendChild(meta);
+            state.elements.logList.appendChild(item);
+        });
+    }
+
+    function handleDownload() {
+        const recordsSource = typeof getComplianceRecords === 'function' ? getComplianceRecords() : [];
+        const records = Array.isArray(recordsSource) ? recordsSource : [];
+        const payload = downloadFormatter(records);
+        if (onDownload) {
+            onDownload({ records, payload });
+            return;
+        }
+
+        const blob = new Blob([payload], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = createAnchor();
+        link.href = url;
+        link.download = defaultFileName(downloadFileNamePrefix);
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    function handleToggle(event) {
+        const input = event.target;
+        const classification = input.dataset.consent;
+        const enabled = input.checked;
+
+        onConsentToggle?.(classification, enabled);
+        trackConsentToggle?.(classification, enabled);
+    }
+
+    function attachListeners() {
+        state.elements.toggles.forEach(input => {
+            input.addEventListener('change', handleToggle);
+        });
+        state.elements.downloadButton.addEventListener('click', handleDownload);
+    }
+
+    function detachListeners() {
+        state.elements.toggles.forEach(input => {
+            input.removeEventListener('change', handleToggle);
+        });
+        state.elements.downloadButton.removeEventListener('click', handleDownload);
+    }
+
+    function scheduleRefresh() {
+        if (!refreshInterval || refreshInterval <= 0) {
+            return;
+        }
+        clearInterval(state.refreshTimer);
+        state.refreshTimer = setInterval(() => {
+            if (state.destroyed) {
+                clearInterval(state.refreshTimer);
+                return;
+            }
+            renderComplianceLog();
+        }, refreshInterval);
+    }
+
+    function mount() {
+        buildStructure();
+        attachListeners();
+        const consentSnapshot = typeof getTelemetryConsent === 'function' ? getTelemetryConsent() : {};
+        state.consent = consentSnapshot;
+        syncToggles(consentSnapshot);
+        renderStatus(consentSnapshot);
+        renderComplianceLog();
+        scheduleRefresh();
+        return api;
+    }
+
+    function destroy() {
+        state.destroyed = true;
+        clearInterval(state.refreshTimer);
+        detachListeners();
+    }
+
+    function handleConsentDecision(consentSnapshot, metadata = {}) {
+        state.consent = consentSnapshot;
+        syncToggles(consentSnapshot);
+        renderStatus(consentSnapshot, metadata);
+        renderComplianceLog();
+    }
+
+    const api = {
+        mount,
+        destroy,
+        refreshComplianceLog: renderComplianceLog,
+        handleConsentDecision
+    };
+
+    return api;
+}

--- a/tests/consent-compliance-smoke.spec.js
+++ b/tests/consent-compliance-smoke.spec.js
@@ -1,0 +1,32 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Consent & Compliance Smoke @smoke', () => {
+  test('@smoke toggles consent and exports compliance log', async ({ page }) => {
+    await page.goto('/wearable-designer.html');
+
+    const analyticsToggle = page.locator('#telemetryConsentPanel input[data-consent="analytics"]');
+    await expect(analyticsToggle).toBeVisible();
+    await expect(analyticsToggle).not.toBeChecked();
+
+    const status = page.locator('#telemetryConsentPanel .consent-status');
+    await expect(status).toContainText('Audit Entries');
+
+    await analyticsToggle.check();
+
+    await expect(status).toContainText('ANALYTICS', { timeout: 10000 });
+    const statusText = await status.textContent();
+    const auditMatch = statusText.match(/Audit Entries:\s*(\d+)/i);
+    expect(auditMatch).toBeTruthy();
+    expect(Number(auditMatch[1])).toBeGreaterThan(0);
+
+    const logItem = page.locator('#telemetryConsentPanel .compliance-log li').first();
+    await expect(logItem).toContainText('privacy.consent');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download Compliance Log' }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/vib34d-compliance-log/);
+  });
+});

--- a/tests/vitest/adaptive-sdk.test.js
+++ b/tests/vitest/adaptive-sdk.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createAdaptiveSDK } from '../../src/core/AdaptiveSDK.js';
+
+function createHeadlessAdaptiveSDK(config = {}) {
+  const { environment, ...rest } = config;
+  return createAdaptiveSDK({
+    ...rest,
+    environment: {
+      mode: 'headless',
+      ...(environment || {})
+    }
+  });
+}
+
+describe('createAdaptiveSDK', () => {
+  it('creates a consent panel using default consent options', () => {
+    const container = document.createElement('div');
+    const sdk = createHeadlessAdaptiveSDK({
+      consentOptions: [
+        { classification: 'analytics', title: 'Analytics', description: 'Allow aggregated analytics' }
+      ]
+    });
+
+    const onConsentToggle = vi.fn();
+
+    const panel = sdk.createConsentPanel({
+      container,
+      getTelemetryConsent: () => ({ analytics: false }),
+      onConsentToggle,
+      getComplianceRecords: () => [],
+      getTelemetryAuditTrail: () => []
+    });
+
+    panel.mount();
+
+    const toggles = container.querySelectorAll('.consent-toggle');
+    expect(toggles.length).toBe(1);
+    expect(toggles[0].querySelector('span')?.textContent).toBe('Analytics');
+
+    const input = toggles[0].querySelector('input');
+    input.checked = true;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onConsentToggle).toHaveBeenCalledWith('analytics', true);
+
+    panel.destroy();
+  });
+
+  it('forwards request middleware registration to telemetry providers', () => {
+    const provider = {
+      id: 'stub-provider',
+      registerRequestMiddleware: vi.fn()
+    };
+
+    const sdk = createHeadlessAdaptiveSDK({
+      replaceDefaultProviders: true,
+      telemetryProviders: [provider]
+    });
+
+    const middleware = () => {};
+    sdk.registerTelemetryRequestMiddleware(middleware);
+
+    expect(provider.registerRequestMiddleware).toHaveBeenCalledWith(middleware);
+  });
+
+  it('configures remote license attestation helpers', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url.includes('attest')) {
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ valid: true });
+          }
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ revoked: false, entitlements: [] });
+        }
+      };
+    });
+
+    const sdk = createHeadlessAdaptiveSDK({
+      license: {
+        key: 'remote-license',
+        expiresAt: '2025-12-31T00:00:00Z',
+        autoValidate: false,
+        attestor: {
+          attestationUrl: 'https://licensing.example/attest',
+          revocationUrl: 'https://licensing.example/revoke',
+          entitlementsUrl: 'https://licensing.example/entitlements',
+          fetch: fetchMock,
+          pollIntervalMs: 1000,
+          minimumPollIntervalMs: 50
+        },
+        attestorBinding: {
+          bindToLicenseManager: true,
+          attestorOptions: { immediate: false }
+        }
+      }
+    });
+
+    const status = await sdk.requestLicenseAttestation();
+
+    expect(status.state).toBe('valid');
+    expect(fetchMock).toHaveBeenCalled();
+    expect(Array.isArray(sdk.getLicenseAttestationHistory())).toBe(true);
+  });
+
+  it('registers and applies license attestation profiles during bootstrap', () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ valid: true });
+      }
+    }));
+
+    const sdk = createHeadlessAdaptiveSDK({
+      licenseAttestationProfiles: [
+        {
+          id: 'profile-default',
+          attestor: {
+            attestationUrl: 'https://licensing.example/profile/attest',
+            fetch: fetchMock
+          },
+          binding: { attestorOptions: { immediate: true } },
+          sla: { failOpen: true }
+        }
+      ],
+      defaultLicenseAttestationProfileId: 'profile-default',
+      license: {
+        key: 'profile-license',
+        attestorProfileId: 'profile-default',
+        autoValidate: false
+      }
+    });
+
+    const profiles = sdk.getLicenseAttestationProfiles();
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]?.id).toBe('profile-default');
+
+    const applied = sdk.setLicenseAttestorFromProfile('profile-default', {
+      binding: { attestorOptions: { immediate: false } }
+    });
+
+    expect(applied.binding.attestorOptions).toEqual({ immediate: false });
+    expect(sdk.licenseAttestor).toBe(applied.attestor);
+  });
+
+  it('bootstraps license attestation profile packs via config', () => {
+    const sdk = createHeadlessAdaptiveSDK({
+      licenseAttestationProfilePackId: 'enterprise-saas',
+      licenseAttestationProfilePackOptions: {
+        regions: ['global', 'emea'],
+        baseUrl: 'https://licensing.partner.example.com'
+      }
+    });
+
+    const profiles = sdk.getLicenseAttestationProfiles();
+    const ids = profiles.map(profile => profile.id);
+
+    expect(ids).toContain('enterprise-saas/global');
+    expect(ids).toContain('enterprise-saas/emea');
+    expect(sdk.telemetry.getAuditTrail().some(entry => entry.event === 'system.license.attestation_profile_pack_registered')).toBe(true);
+  });
+
+  it('bootstraps without browser DOM when using headless mode', () => {
+    const sdk = createHeadlessAdaptiveSDK();
+
+    expect(sdk.engine.environment.mode).toBe('headless');
+    expect(() => sdk.updateTelemetryConsent({ analytics: true })).not.toThrow();
+    expect(Array.isArray(sdk.telemetry.getAuditTrail())).toBe(true);
+  });
+});

--- a/tests/vitest/commercialization-snapshot-storage-adapters.test.js
+++ b/tests/vitest/commercialization-snapshot-storage-adapters.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createCommercializationSnapshotRemoteStorage,
+  createSignedS3CommercializationSnapshotStorage,
+  createCommercializationSnapshotPayload
+} from '../../src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js';
+
+const baseSnapshot = {
+  id: 'snapshot-01',
+  capturedAt: '2025-10-20T12:00:00.000Z',
+  context: { trigger: 'test', licenseKey: 'secret-key' },
+  kpis: { totalPacks: 2, totalAdoption: 5 },
+  summary: { packs: [], profiles: [], segments: {}, regions: {}, sla: {} }
+};
+
+describe('CommercializationSnapshotStorageAdapters', () => {
+  it('redacts context keys and omits summary when configured', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const adapter = { write };
+    const storage = createCommercializationSnapshotRemoteStorage({
+      adapter,
+      includeSummary: false,
+      redactContextKeys: ['licenseKey']
+    });
+
+    await storage.saveSnapshots([baseSnapshot]);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const payload = write.mock.calls[0][0];
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload[0].context.licenseKey).toBeUndefined();
+    expect(payload[0].summary).toBeUndefined();
+    expect(payload[0].kpis.totalPacks).toBe(2);
+  });
+
+  it('wraps the signed S3 adapter and serializes payload metadata', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: 'https://example.com/upload', key: 'snapshots.json', headers: {} })
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const storage = createSignedS3CommercializationSnapshotStorage({
+      signingEndpoint: 'https://example.com/sign',
+      fetchImplementation: fetchMock
+    });
+
+    await storage.saveSnapshots([baseSnapshot]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const uploadCall = fetchMock.mock.calls[1];
+    expect(uploadCall[0]).toBe('https://example.com/upload');
+    const body = uploadCall[1]?.body;
+    expect(typeof body).toBe('string');
+    expect(body).toContain('"snapshotCount":1');
+
+    const payload = createCommercializationSnapshotPayload([baseSnapshot], {
+      retentionPolicy: { strategy: 'timeboxed', maxAgeMs: 86_400_000 }
+    });
+    expect(payload.snapshotCount).toBe(1);
+    expect(payload.retentionPolicy).toEqual({ strategy: 'timeboxed', maxAgeMs: 86_400_000 });
+  });
+});

--- a/tests/vitest/compliance-vault-telemetry-provider.test.js
+++ b/tests/vitest/compliance-vault-telemetry-provider.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ComplianceVaultTelemetryProvider } from '../../src/product/telemetry/ComplianceVaultTelemetryProvider.js';
+
+describe('ComplianceVaultTelemetryProvider', () => {
+  it('captures compliance events and persists them through the storage adapter', async () => {
+    const write = vi.fn(() => Promise.resolve());
+    const clear = vi.fn(() => Promise.resolve());
+    const provider = new ComplianceVaultTelemetryProvider({
+      storageAdapter: {
+        read: () => [{
+          event: 'seed',
+          classification: 'compliance',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          payload: null
+        }],
+        write,
+        clear
+      },
+      maxRecords: 2
+    });
+
+    await provider.whenReady();
+    expect(provider.getRecords()).toHaveLength(1);
+
+    provider.track(
+      'compliance.alert',
+      {
+        payload: { issue: 'schema' },
+        classification: 'compliance',
+        timestamp: '2025-01-01T00:00:01.000Z'
+      },
+      { classification: 'compliance' }
+    );
+
+    await Promise.resolve();
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(provider.getRecords()).toHaveLength(2);
+
+    provider.recordAudit({
+      event: 'compliance.manual',
+      classification: 'compliance',
+      payload: { note: 'reviewed' },
+      timestamp: '2025-01-01T00:00:02.000Z'
+    });
+
+    await Promise.resolve();
+    const records = provider.getRecords();
+    expect(records).toHaveLength(2);
+    expect(records[0].event).toBe('compliance.alert');
+    expect(records[1].source).toBe('audit-log');
+    expect(write).toHaveBeenCalledTimes(2);
+
+    await provider.clear();
+    expect(provider.getRecords()).toHaveLength(0);
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports async storage initialization and surfaces errors', async () => {
+    const write = vi.fn(() => Promise.resolve());
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new ComplianceVaultTelemetryProvider({
+      storageAdapter: {
+        read: () => Promise.resolve([
+          {
+            event: 'existing',
+            classification: 'compliance',
+            timestamp: '2025-01-01T00:00:00.000Z'
+          }
+        ]),
+        write
+      }
+    });
+
+    await provider.whenReady();
+    expect(provider.getRecords()).toHaveLength(1);
+
+    const erroringAdapter = new ComplianceVaultTelemetryProvider({
+      storageAdapter: {
+        write: () => Promise.reject(new Error('boom'))
+      }
+    });
+
+    erroringAdapter.track('compliance.issue', { classification: 'compliance' }, { classification: 'compliance' });
+    await Promise.resolve();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/vitest/consent-panel.test.js
+++ b/tests/vitest/consent-panel.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createConsentPanel } from '../../src/ui/components/ConsentPanel.js';
+
+describe('createConsentPanel', () => {
+  let container;
+  let consent;
+  let records;
+  let audit;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<section id="panel" class="panel"></section>';
+    container = document.getElementById('panel');
+    consent = { system: true, analytics: false };
+    records = [
+      {
+        event: 'privacy.consent.updated',
+        classification: 'compliance',
+        timestamp: '2025-01-01T00:00:00.000Z',
+        source: 'ui'
+      }
+    ];
+    audit = [
+      { event: 'privacy.consent.updated', classification: 'compliance', timestamp: '2025-01-01T00:00:00.000Z' }
+    ];
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders consent controls and updates status on decisions', () => {
+    const onConsentToggle = vi.fn((classification, enabled) => {
+      consent[classification] = enabled;
+    });
+
+    const panel = createConsentPanel({
+      container,
+      consentOptions: [
+        { classification: 'system', title: 'System Diagnostics', description: 'Required' },
+        { classification: 'analytics', title: 'Analytics', description: 'Optional' }
+      ],
+      getTelemetryConsent: () => consent,
+      getComplianceRecords: () => records,
+      getTelemetryAuditTrail: () => audit,
+      refreshInterval: 0,
+      onConsentToggle,
+      trackConsentToggle: vi.fn()
+    });
+
+    panel.mount();
+
+    const inputs = container.querySelectorAll('.consent-toggle input');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+
+    const status = container.querySelector('.consent-status').innerHTML;
+    expect(status.toLowerCase()).toContain('audit entries');
+
+    panel.handleConsentDecision({ system: false, analytics: true }, { source: 'test-suite' });
+    const updatedStatus = container.querySelector('.consent-status').innerHTML;
+    expect(updatedStatus).toContain('Last change via test-suite.');
+
+    const logItems = container.querySelectorAll('.compliance-log li');
+    expect(logItems).toHaveLength(1);
+    expect(logItems[0].textContent).toContain('privacy.consent.updated');
+
+    panel.destroy();
+  });
+
+  it('invokes callbacks when toggles change and triggers downloads', () => {
+    const onConsentToggle = vi.fn((classification, enabled) => {
+      consent[classification] = enabled;
+    });
+    const trackConsentToggle = vi.fn();
+    const onDownload = vi.fn();
+    const createObjectURL = vi.fn(() => 'blob://test');
+    const revokeObjectURL = vi.fn();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+
+    const panel = createConsentPanel({
+      container,
+      consentOptions: [
+        { classification: 'system', title: 'System Diagnostics', description: 'Required' },
+        { classification: 'analytics', title: 'Analytics', description: 'Optional' }
+      ],
+      getTelemetryConsent: () => consent,
+      getComplianceRecords: () => records,
+      getTelemetryAuditTrail: () => audit,
+      refreshInterval: 0,
+      onConsentToggle,
+      trackConsentToggle,
+      downloadFileNamePrefix: 'test-log',
+      onDownload
+    });
+
+    const api = panel.mount();
+
+    try {
+      const analyticsToggle = container.querySelector('input[data-consent="analytics"]');
+      analyticsToggle.checked = true;
+      analyticsToggle.dispatchEvent(new Event('change'));
+
+      expect(onConsentToggle).toHaveBeenCalledWith('analytics', true);
+      expect(trackConsentToggle).toHaveBeenCalledWith('analytics', true);
+
+      const downloadButton = container.querySelector('button.secondary');
+      downloadButton.click();
+      expect(onDownload).toHaveBeenCalledWith(expect.objectContaining({ records }));
+      expect(createObjectURL).not.toHaveBeenCalled();
+      expect(revokeObjectURL).not.toHaveBeenCalled();
+    } finally {
+      api.destroy();
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
+});

--- a/tests/vitest/layout-blueprint-renderer.test.js
+++ b/tests/vitest/layout-blueprint-renderer.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { buildLayoutBlueprint } from '../../src/ui/adaptive/renderers/LayoutBlueprintRenderer.js';
+
+describe('buildLayoutBlueprint', () => {
+    const baseLayout = {
+        intensity: 0.72,
+        motion: { velocity: 0.42, bias: { x: 0.3, y: -0.1, z: 0.05 }, easing: 'ease-out' },
+        zones: [
+            {
+                id: 'primary',
+                occupancy: 0.7,
+                layeringDepth: 0.22,
+                curvature: 0.14,
+                visibility: 0.8,
+                recommendedComponents: ['holographic-panel', 'adaptive-controls']
+            },
+            {
+                id: 'peripheral',
+                occupancy: 0.45,
+                layeringDepth: 0.4,
+                curvature: 0.35,
+                visibility: 0.62,
+                recommendedComponents: ['ambient-indicator']
+            }
+        ],
+        annotations: [{ id: 'stress-alert', type: 'insight', message: 'Check biometrics' }]
+    };
+
+    const baseDesign = {
+        pattern: { id: 'neuro-glance-feed', name: 'Neuro Glance Feed' },
+        monetization: { tier: 'starter' },
+        integration: { figmaPlugin: 'vib34d-neuro' }
+    };
+
+    const baseContext = {
+        focusVector: { x: 0.58, y: 0.44, depth: 0.33 },
+        engagementLevel: 0.61,
+        biometricStress: 0.18
+    };
+
+    it('summarizes layout geometry and recommended components', () => {
+        const blueprint = buildLayoutBlueprint(baseLayout, baseDesign, baseContext);
+
+        expect(blueprint.intensity).toBeCloseTo(0.72, 2);
+        expect(blueprint.motion.velocity).toBeCloseTo(0.42, 2);
+        expect(blueprint.motion.bias).toEqual({ x: 0.3, y: -0.1, z: 0.05 });
+        expect(blueprint.recommendedComponents).toEqual(expect.arrayContaining([
+            'holographic-panel',
+            'adaptive-controls',
+            'ambient-indicator'
+        ]));
+        expect(blueprint.recommendedComponents).toHaveLength(3);
+        const primaryZone = blueprint.zones.find(zone => zone.id === 'primary');
+        expect(primaryZone).toBeDefined();
+        expect(primaryZone).toMatchObject({
+            components: ['holographic-panel', 'adaptive-controls']
+        });
+        expect(blueprint.annotations).toHaveLength(1);
+    });
+
+    it('applies defaults when layout details are missing', () => {
+        const blueprint = buildLayoutBlueprint({}, {}, {});
+        expect(blueprint.intensity).toBeGreaterThan(0);
+        expect(blueprint.motion.velocity).toBeGreaterThanOrEqual(0);
+        expect(blueprint.focusVector).toEqual({ x: 0.5, y: 0.5, depth: 0.3 });
+        expect(blueprint.zones).toEqual([]);
+        expect(blueprint.recommendedComponents).toEqual([]);
+    });
+
+    it('normalizes metrics and clamps values', () => {
+        const layout = {
+            intensity: 2,
+            motion: { velocity: -1.3, bias: { x: 5, y: -5, z: 2 }, easing: 'ease-in' },
+            zones: [
+                { id: 'primary', occupancy: 1.8, layeringDepth: -0.6, curvature: 2, visibility: 2 }
+            ]
+        };
+        const context = { engagementLevel: 1.6, biometricStress: -0.2, focusVector: { x: 2, y: -1, depth: 5 } };
+        const blueprint = buildLayoutBlueprint(layout, baseDesign, context);
+
+        expect(blueprint.intensity).toBeLessThanOrEqual(1);
+        expect(blueprint.motion.velocity).toBeGreaterThanOrEqual(0);
+        expect(blueprint.motion.bias).toEqual({ x: 1, y: -1, z: 1 });
+        expect(blueprint.zones[0]).toMatchObject({
+            occupancy: 1,
+            layeringDepth: 0,
+            curvature: 1,
+            visibility: 1
+        });
+        expect(blueprint.engagementLevel).toBeLessThanOrEqual(1);
+        expect(blueprint.biometricStress).toBeGreaterThanOrEqual(0);
+        expect(blueprint.focusVector).toEqual({ x: 1, y: 0, depth: 1 });
+    });
+});

--- a/tests/vitest/license-attestation-profile-catalog.test.js
+++ b/tests/vitest/license-attestation-profile-catalog.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_LICENSE_ATTESTATION_PROFILE_PACKS,
+  resolveLicenseAttestationProfilePack,
+  instantiateLicenseAttestationProfilePack
+} from '../../src/product/licensing/LicenseAttestationProfileCatalog.js';
+
+describe('LicenseAttestationProfileCatalog', () => {
+  it('exposes default pack descriptors', () => {
+    expect(Array.isArray(DEFAULT_LICENSE_ATTESTATION_PROFILE_PACKS)).toBe(true);
+    expect(DEFAULT_LICENSE_ATTESTATION_PROFILE_PACKS.some(pack => pack.id === 'enterprise-saas')).toBe(true);
+  });
+
+  it('resolves default pack identifiers with overrides', () => {
+    const pack = resolveLicenseAttestationProfilePack('enterprise-saas', {
+      regions: ['global', 'apac'],
+      baseUrl: 'https://licensing.example.com'
+    });
+
+    expect(pack.id).toBe('enterprise-saas');
+    expect(pack.profiles).toHaveLength(2);
+    expect(pack.profiles[0].attestor.attestationUrl).toContain('https://licensing.example.com');
+    expect(pack.defaultProfileId).toBe('enterprise-saas/global');
+  });
+
+  it('instantiates custom pack descriptors', () => {
+    const descriptor = {
+      id: 'custom-pack',
+      name: 'Custom Pack',
+      description: 'Custom description',
+      profiles: [
+        {
+          id: 'custom/profile',
+          attestor: { attestationUrl: 'https://custom.example/attest' },
+          metadata: { segment: 'custom' }
+        }
+      ]
+    };
+
+    const pack = instantiateLicenseAttestationProfilePack(descriptor);
+    expect(pack.id).toBe('custom-pack');
+    expect(pack.profiles).toHaveLength(1);
+    expect(pack.profiles[0].metadata.segment).toBe('custom');
+  });
+});

--- a/tests/vitest/license-attestation-profile-registry.test.js
+++ b/tests/vitest/license-attestation-profile-registry.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LicenseAttestationProfileRegistry } from '../../src/product/licensing/LicenseAttestationProfileRegistry.js';
+import { RemoteLicenseAttestor } from '../../src/product/licensing/RemoteLicenseAttestor.js';
+
+describe('LicenseAttestationProfileRegistry', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ valid: true });
+      }
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers profiles and instantiates attestors with overrides', () => {
+    const registry = new LicenseAttestationProfileRegistry();
+
+    registry.registerProfile({
+      id: 'enterprise-basic',
+      name: 'Enterprise Basic',
+      attestor: {
+        attestationUrl: 'https://licensing.example/attest',
+        fetch: fetchMock,
+        pollIntervalMs: 900000
+      },
+      binding: {
+        bindToLicenseManager: true,
+        attestorOptions: { immediate: true }
+      },
+      sla: { failOpen: false, responseTargetMs: 5000 }
+    });
+
+    const { attestor, binding, profile } = registry.createAttestor('enterprise-basic', {
+      attestorOptions: { pollIntervalMs: 600000 },
+      binding: { attestorOptions: { immediate: false } },
+      metadata: { region: 'na' }
+    });
+
+    expect(attestor).toBeInstanceOf(RemoteLicenseAttestor);
+    expect(binding.attestorOptions).toEqual({ immediate: false });
+    expect(profile.metadata).toEqual({ region: 'na' });
+    expect(profile.sla?.responseTargetMs).toBe(5000);
+  });
+
+  it('uses the default profile when no id is provided', () => {
+    const registry = new LicenseAttestationProfileRegistry({ defaultProfileId: 'wearables-pro' });
+
+    registry.registerProfile('wearables-pro', {
+      attestor: {
+        attestationUrl: 'https://licensing.example/pro/attest',
+        fetch: fetchMock
+      }
+    });
+
+    const result = registry.createAttestor();
+    expect(result.profile.id).toBe('wearables-pro');
+    expect(registry.getDefaultProfileId()).toBe('wearables-pro');
+  });
+
+  it('allows clearing the default profile', () => {
+    const registry = new LicenseAttestationProfileRegistry();
+
+    registry.registerProfile({
+      id: 'studio-default',
+      attestor: {
+        attestationUrl: 'https://licensing.example/studio/attest',
+        fetch: fetchMock
+      }
+    });
+
+    expect(registry.getDefaultProfileId()).toBe('studio-default');
+    registry.clearDefaultProfile();
+    expect(registry.getDefaultProfileId()).toBeNull();
+  });
+});

--- a/tests/vitest/license-commercialization-reporter.test.js
+++ b/tests/vitest/license-commercialization-reporter.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LicenseCommercializationReporter } from '../../src/product/licensing/LicenseCommercializationReporter.js';
+
+const baseProfile = {
+    id: 'enterprise/global',
+    name: 'Enterprise Global',
+    description: 'Global coverage',
+    metadata: { segment: 'enterprise', region: 'global' },
+    sla: { responseTargetMs: 900, availability: '99.9%', breachWindowMs: 300000 }
+};
+
+describe('LicenseCommercializationReporter', () => {
+    it('aggregates packs, segments, and adoption metrics', () => {
+        const updates = [];
+        const reporter = new LicenseCommercializationReporter({
+            onUpdate: summary => updates.push(summary)
+        });
+
+        reporter.recordProfileRegistration(baseProfile, { source: 'direct' });
+        reporter.recordPackRegistration({
+            id: 'enterprise-saas',
+            name: 'Enterprise SaaS',
+            description: 'Enterprise coverage',
+            metadata: { segment: 'enterprise' },
+            profiles: [baseProfile],
+            defaultProfileId: baseProfile.id
+        }, { registeredProfileIds: [baseProfile.id], defaultProfileId: baseProfile.id, appliedDefault: true });
+        reporter.recordDefaultProfileChange(baseProfile.id, { packId: 'enterprise-saas' });
+        reporter.recordProfileApplied(baseProfile, {});
+
+        const summary = reporter.getSummary();
+        expect(summary.packs).toHaveLength(1);
+        expect(summary.packs[0].adoptionCount).toBe(1);
+        expect(summary.segments.enterprise.profileCount).toBe(1);
+        expect(summary.segments.enterprise.adoptionCount).toBe(1);
+        expect(summary.regions.global.profileCount).toBe(1);
+        expect(summary.sla.responseTargetMs).toEqual({ min: 900, max: 900, average: 900 });
+        expect(summary.defaultProfileId).toBe(baseProfile.id);
+        expect(updates.length).toBeGreaterThan(0);
+    });
+
+    it('handles packs without defaults and normalizes availability values', () => {
+        const reporter = new LicenseCommercializationReporter();
+        const profile = {
+            id: 'studio/global',
+            name: 'Studio Global',
+            metadata: { segment: 'studio', region: 'latam' },
+            sla: { responseTargetMs: 1500, availability: 99.5, breachWindowMs: 900000 }
+        };
+
+        reporter.recordPackRegistration({
+            id: 'studio-collab',
+            name: 'Studio Pack',
+            description: 'Studio coverage',
+            profiles: [profile],
+            defaultProfileId: null
+        }, { registeredProfileIds: [profile.id], defaultProfileId: null, appliedDefault: false });
+        reporter.recordProfileRegistration(profile, { packId: 'studio-collab' });
+
+        const summary = reporter.getSummary();
+        expect(summary.packs[0].appliedDefault).toBe(false);
+        expect(summary.segments.studio.profileCount).toBe(1);
+        expect(summary.regions.latam.profileCount).toBe(1);
+        expect(summary.sla.availabilityPercent).toEqual({ min: 99.5, max: 99.5, average: 99.5 });
+    });
+
+    it('supports multiple update listeners and removal', () => {
+        const reporter = new LicenseCommercializationReporter();
+        const listenerA = vi.fn();
+        const listenerB = vi.fn();
+
+        const unsubscribe = reporter.addUpdateListener(listenerA);
+        reporter.addUpdateListener(listenerB);
+
+        reporter.recordProfileRegistration(baseProfile);
+        expect(listenerA).toHaveBeenCalled();
+        expect(listenerB).toHaveBeenCalled();
+
+        listenerA.mockClear();
+        listenerB.mockClear();
+        unsubscribe();
+
+        reporter.recordProfileApplied(baseProfile);
+        expect(listenerA).not.toHaveBeenCalled();
+        expect(listenerB).toHaveBeenCalled();
+    });
+});

--- a/tests/vitest/license-commercialization-snapshot-store.test.js
+++ b/tests/vitest/license-commercialization-snapshot-store.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  LicenseCommercializationSnapshotStore,
+  createInMemoryCommercializationSnapshotStorage
+} from '../../src/product/licensing/LicenseCommercializationSnapshotStore.js';
+
+const baseSummary = {
+  packs: [
+    { id: 'enterprise', adoptionCount: 3, profileIds: ['enterprise/default'] },
+    { id: 'studio', adoptionCount: 0, profileIds: ['studio/core'] }
+  ],
+  profiles: [
+    { id: 'enterprise/default', adoptionCount: 3 },
+    { id: 'studio/core', adoptionCount: 0 }
+  ],
+  segments: {
+    enterprise: { profileCount: 1, adoptionCount: 3 },
+    studio: { profileCount: 1, adoptionCount: 0 }
+  },
+  regions: {
+    global: { profileCount: 2, adoptionCount: 3 }
+  },
+  defaultProfileId: 'enterprise/default',
+  lastUpdated: '2025-10-20T12:00:00.000Z'
+};
+
+describe('LicenseCommercializationSnapshotStore', () => {
+  it('computes KPIs when recording snapshots', () => {
+    const store = new LicenseCommercializationSnapshotStore();
+    const snapshot = store.recordSnapshot(baseSummary, { trigger: 'test' });
+
+    expect(snapshot.kpis.totalPacks).toBe(2);
+    expect(snapshot.kpis.totalProfiles).toBe(2);
+    expect(snapshot.kpis.totalAdoption).toBe(3);
+    expect(snapshot.kpis.activePacks).toBe(1);
+    expect(snapshot.kpis.activeProfiles).toBe(1);
+    expect(snapshot.kpis.topSegments[0].key).toBe('enterprise');
+  });
+
+  it('enforces snapshot limits and persists via storage adapter', () => {
+    const storage = createInMemoryCommercializationSnapshotStorage();
+    const store = new LicenseCommercializationSnapshotStore({ maxSnapshots: 2, storage });
+
+    store.recordSnapshot(baseSummary, { trigger: 'first' });
+    store.recordSnapshot({ ...baseSummary, lastUpdated: '2025-10-20T13:00:00.000Z' }, { trigger: 'second' });
+    store.recordSnapshot({ ...baseSummary, lastUpdated: '2025-10-20T14:00:00.000Z' }, { trigger: 'third' });
+
+    const snapshots = store.getSnapshots();
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0].context.trigger).toBe('third');
+    expect(storage.loadSnapshots()).toHaveLength(2);
+  });
+
+  it('generates KPI reports and exports BI payloads', () => {
+    const store = new LicenseCommercializationSnapshotStore();
+
+    store.recordSnapshot(baseSummary, { trigger: 'baseline' });
+    store.recordSnapshot({
+      ...baseSummary,
+      profiles: [
+        { id: 'enterprise/default', adoptionCount: 5 },
+        { id: 'studio/core', adoptionCount: 1 }
+      ]
+    }, { trigger: 'growth' });
+
+    const report = store.getKpiReport();
+    expect(report.latest.kpis.totalAdoption).toBe(6);
+    expect(report.deltas.totalAdoption).toBe(3);
+
+    const json = store.exportForBi({ format: 'json', includeSummary: false });
+    expect(json).toContain('"snapshotCount"');
+
+    const csv = store.exportForBi({ format: 'csv' });
+    expect(csv.split('\n')[1]).toContain('6');
+  });
+
+  it('notifies listeners on change', () => {
+    const listener = vi.fn();
+    const store = new LicenseCommercializationSnapshotStore({ onChange: listener });
+
+    store.recordSnapshot(baseSummary, { trigger: 'listener-test' });
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('awaits asynchronous storage hydration and appends snapshots remotely', async () => {
+    const loadSnapshots = vi.fn().mockResolvedValue([
+      {
+        id: 'existing',
+        capturedAt: '2025-10-20T08:00:00.000Z',
+        context: { trigger: 'hydrated' },
+        kpis: { totalPacks: 1 }
+      }
+    ]);
+    const appendSnapshot = vi.fn().mockResolvedValue(undefined);
+
+    const store = new LicenseCommercializationSnapshotStore({
+      storage: {
+        loadSnapshots,
+        appendSnapshot
+      }
+    });
+
+    await store.whenReady();
+    expect(store.getSnapshots()).toHaveLength(1);
+
+    store.recordSnapshot(baseSummary, { trigger: 'async' });
+    expect(appendSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates clear operations to the storage adapter', () => {
+    const clearSnapshots = vi.fn();
+    const store = new LicenseCommercializationSnapshotStore({
+      storage: { clearSnapshots }
+    });
+
+    store.clearSnapshots();
+    expect(clearSnapshots).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/vitest/license-manager.test.js
+++ b/tests/vitest/license-manager.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LicenseManager } from '../../src/product/licensing/LicenseManager.js';
+
+describe('LicenseManager', () => {
+  it('returns unregistered status when no license is set', async () => {
+    const manager = new LicenseManager({ clock: () => new Date('2025-01-01T00:00:00Z') });
+    const status = await manager.validate();
+
+    expect(status.state).toBe('unregistered');
+    expect(manager.getValidationHistory()).toHaveLength(1);
+  });
+
+  it('validates licenses through registered validators and merges metadata', async () => {
+    const validator = vi.fn().mockResolvedValue({ valid: true, metadata: { region: 'EU' } });
+    const manager = new LicenseManager({
+      validators: [validator],
+      clock: () => new Date('2025-06-01T00:00:00Z')
+    });
+
+    manager.setLicense({
+      key: 'tenant-key',
+      tenantId: 'tenant-123',
+      features: ['core', 'telemetry'],
+      expiresAt: '2025-12-31T00:00:00Z'
+    });
+
+    const status = await manager.validate({ environment: 'staging' });
+
+    expect(status.state).toBe('valid');
+    expect(status.metadata).toEqual({ region: 'EU' });
+    expect(validator).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'tenant-key' }),
+      expect.objectContaining({ environment: 'staging' })
+    );
+  });
+
+  it('flags expired licenses and records history entries', async () => {
+    const manager = new LicenseManager({ clock: () => new Date('2025-03-01T00:00:00Z') });
+    manager.setLicense({ key: 'expired', expiresAt: '2025-01-01T00:00:00Z' });
+
+    const status = await manager.validate();
+
+    expect(status.state).toBe('expired');
+    expect(manager.getValidationHistory()).toHaveLength(1);
+    expect(manager.isActive()).toBe(false);
+  });
+
+  it('handles validator failures gracefully', async () => {
+    const validator = vi.fn().mockImplementation(() => {
+      throw new Error('Network error');
+    });
+    const manager = new LicenseManager({ validators: [validator], clock: () => new Date('2025-04-01T00:00:00Z') });
+
+    manager.setLicense({ key: 'tenant', expiresAt: '2025-12-01T00:00:00Z' });
+    const status = await manager.validate();
+
+    expect(status.state).toBe('invalid');
+    expect(status.reason).toBe('VALIDATOR_ERROR');
+    expect(manager.isActive()).toBe(false);
+  });
+
+  it('merges entitlement metadata into the license record', async () => {
+    const manager = new LicenseManager({ clock: () => new Date('2025-05-01T00:00:00Z') });
+    manager.registerValidator(async () => ({ valid: true, metadata: { entitlements: ['remote-pack'] } }));
+
+    manager.setLicense({ key: 'entitlement-test', features: ['core'], expiresAt: '2025-12-31T00:00:00Z' });
+    const status = await manager.validate();
+
+    expect(status.state).toBe('valid');
+    expect(status.metadata.entitlements).toEqual(['remote-pack']);
+    expect(manager.getLicense().features).toContain('remote-pack');
+  });
+
+  it('throws when required features are missing', () => {
+    const manager = new LicenseManager();
+    manager.setLicense({ key: 'basic', features: ['core'] });
+
+    expect(() => manager.requireFeature('advanced')).toThrow(/required feature/);
+  });
+});

--- a/tests/vitest/projection-field-composer.test.js
+++ b/tests/vitest/projection-field-composer.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { composeProjectionField, ProjectionFieldComposer } from '../../src/ui/adaptive/renderers/ProjectionFieldComposer.js';
+
+describe('ProjectionFieldComposer', () => {
+    const blueprint = {
+        intensity: 0.62,
+        engagementLevel: 0.58,
+        biometricStress: 0.18,
+        focusVector: { x: 0.48, y: 0.41, depth: 0.32 },
+        zones: [
+            { id: 'primary', occupancy: 0.54, visibility: 0.82, layeringDepth: 0.24 },
+            { id: 'peripheral', occupancy: 0.32, visibility: 0.74, layeringDepth: 0.36 }
+        ],
+        annotations: [{ id: 'stress', type: 'alert', priority: 4 }]
+    };
+
+    const context = {
+        gazeVelocity: 0.44,
+        neuralCoherence: 0.52,
+        hapticFeedback: 0.31,
+        ambientVariance: 0.22,
+        gestureIntent: {
+            intensity: 0.48,
+            vector: { x: 0.46, y: 0.52, z: 0.38 }
+        }
+    };
+
+    it('composes projection field metrics from blueprint and context', () => {
+        const composition = composeProjectionField(blueprint, context, { resolution: 12, depthBands: 4 });
+        expect(composition).toBeTruthy();
+        expect(composition.focusHalo.radius).toBeGreaterThan(0);
+        expect(composition.depthBands).toHaveLength(4);
+        expect(composition.activationMatrix.length).toBe(12);
+        expect(composition.activationMatrix[0]).toHaveLength(12);
+        expect(composition.annotations[0]).toEqual({ id: 'stress', type: 'alert', priority: 4 });
+    });
+
+    it('renders via ProjectionFieldComposer without throwing', () => {
+        const composer = new ProjectionFieldComposer({ observe: false, resolution: 10 });
+        const composition = composer.render(blueprint, context, { resolution: 10 });
+        expect(composition.activationMatrix.length).toBe(10);
+        expect(composer.compose(blueprint, context).focusHalo.radius).toBeLessThan(1);
+    });
+});

--- a/tests/vitest/projection-scenario-simulator.test.js
+++ b/tests/vitest/projection-scenario-simulator.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProjectionScenarioSimulator } from '../../src/ui/adaptive/simulators/ProjectionScenarioSimulator.js';
+
+const baseBlueprint = {
+    intensity: 0.5,
+    engagementLevel: 0.45,
+    biometricStress: 0.2,
+    focusVector: { x: 0.5, y: 0.5, depth: 0.3 },
+    zones: [
+        { id: 'primary', occupancy: 0.5, visibility: 0.8, layeringDepth: 0.2 },
+        { id: 'peripheral', occupancy: 0.4, visibility: 0.6, layeringDepth: 0.3 }
+    ]
+};
+
+const baseContext = {
+    gazeVelocity: 0.4,
+    neuralCoherence: 0.5,
+    hapticFeedback: 0.3,
+    ambientVariance: 0.25,
+    gestureIntent: {
+        intensity: 0.35,
+        vector: { x: 0.48, y: 0.52, z: 0.38 }
+    }
+};
+
+describe('ProjectionScenarioSimulator', () => {
+    let simulator;
+
+    beforeEach(() => {
+        simulator = new ProjectionScenarioSimulator({ autoStart: true });
+        simulator.observeAdaptiveState({ blueprint: baseBlueprint, context: baseContext });
+    });
+
+    it('registers scenarios and emits frames', () => {
+        const listener = vi.fn();
+        simulator.on('scenario:frame', listener);
+        simulator.registerScenario({
+            id: 'scenario-a',
+            name: 'Scenario A',
+            cycleMs: 8000,
+            modulation: {
+                blueprint: {
+                    intensity: { start: 0.4, end: 0.7 },
+                    focusX: { start: 0.5, end: 0.65 },
+                    zoneOccupancy: [{ id: 'primary', start: 0.5, end: 0.35 }]
+                },
+                context: {
+                    gestureIntensity: { start: 0.3, end: 0.6 },
+                    neuralCoherence: { start: 0.5, end: 0.7 }
+                }
+            }
+        });
+
+        const frame = simulator.step({ timestamp: 1234 });
+        expect(frame).toBeTruthy();
+        expect(frame?.composition.focusHalo.radius).toBeGreaterThan(0);
+        expect(frame?.composition.depthBands.length).toBeGreaterThan(0);
+        expect(listener).toHaveBeenCalled();
+    });
+
+    it('supports switching scenarios', () => {
+        simulator.registerScenario({ id: 'scenario-a', modulation: {} });
+        simulator.registerScenario({ id: 'scenario-b', modulation: { blueprint: { intensity: { start: 0.5, end: 0.8 } } } });
+        simulator.setActiveScenario('scenario-b');
+        const frame = simulator.step({ timestamp: 4321 });
+        expect(frame?.id).toBe('scenario-b');
+    });
+
+    it('returns realtime frame when no scenario stepped', () => {
+        const realtime = simulator.getLastResult();
+        expect(realtime).toBeNull();
+    });
+});

--- a/tests/vitest/remote-license-attestor.test.js
+++ b/tests/vitest/remote-license-attestor.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LicenseManager } from '../../src/product/licensing/LicenseManager.js';
+import { RemoteLicenseAttestor } from '../../src/product/licensing/RemoteLicenseAttestor.js';
+
+function createResponse(data, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async text() {
+      return JSON.stringify(data);
+    }
+  };
+}
+
+describe('RemoteLicenseAttestor', () => {
+  let clockDate;
+
+  beforeEach(() => {
+    clockDate = new Date('2025-06-01T00:00:00Z');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('validates remotely and merges entitlements into the license manager', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url.includes('attest')) {
+        return createResponse({
+          valid: true,
+          nextCheckInMs: 2000,
+          metadata: { region: 'NA' }
+        });
+      }
+      if (url.includes('revoke')) {
+        return createResponse({ revoked: false });
+      }
+      if (url.includes('entitlements')) {
+        return createResponse({ entitlements: ['vision-kit'], ttlMs: 5000 });
+      }
+      throw new Error(`Unhandled URL ${url}`);
+    });
+
+    const manager = new LicenseManager({ clock: () => clockDate });
+    const attestor = new RemoteLicenseAttestor({
+      attestationUrl: 'https://licensing.example/attest',
+      revocationUrl: 'https://licensing.example/revoke',
+      entitlementsUrl: 'https://licensing.example/entitlements',
+      fetch: fetchMock,
+      pollIntervalMs: 8000,
+      minimumPollIntervalMs: 1000,
+      clock: () => clockDate
+    });
+
+    attestor.bindToLicenseManager(manager, { immediate: false });
+    manager.setLicense({ key: 'tenant-license', expiresAt: '2025-12-31T00:00:00Z', features: ['core'] });
+
+    const status = await manager.validate({ environment: 'staging' });
+
+    expect(status.state).toBe('valid');
+    expect(status.metadata.remote.attestation.valid).toBe(true);
+    expect(status.metadata.entitlements).toEqual(['vision-kit']);
+    expect(manager.getLicense().features).toContain('vision-kit');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(attestor.getHistory()).toHaveLength(1);
+  });
+
+  it('fails closed when remote attestation errors', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url.includes('attest')) {
+        throw new Error('network down');
+      }
+      return createResponse({});
+    });
+
+    const manager = new LicenseManager({ clock: () => clockDate });
+    const attestor = new RemoteLicenseAttestor({
+      attestationUrl: 'https://licensing.example/attest',
+      fetch: fetchMock,
+      clock: () => clockDate
+    });
+
+    attestor.bindToLicenseManager(manager, { immediate: false });
+    manager.setLicense({ key: 'tenant-license', expiresAt: '2025-12-31T00:00:00Z' });
+
+    const status = await manager.validate();
+
+    expect(status.state).toBe('invalid');
+    expect(status.reason).toBe('REMOTE_ATTESTATION_ERROR');
+  });
+
+  it('supports fail-open mode while surfacing error metadata', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('timeout');
+    });
+
+    const manager = new LicenseManager({ clock: () => clockDate });
+    const attestor = new RemoteLicenseAttestor({
+      attestationUrl: 'https://licensing.example/attest',
+      fetch: fetchMock,
+      failOpen: true,
+      clock: () => clockDate
+    });
+
+    attestor.bindToLicenseManager(manager, { immediate: false });
+    manager.setLicense({ key: 'tenant-license', expiresAt: '2025-12-31T00:00:00Z' });
+
+    const status = await manager.validate();
+
+    expect(status.state).toBe('valid');
+    expect(status.metadata.remote.error).toMatch(/timeout/);
+    expect(status.metadata.remote.failOpen).toBe(true);
+  });
+
+  it('schedules follow-up validations using remote guidance', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async (url) => {
+      if (url.includes('attest')) {
+        return createResponse({ valid: true, nextCheckInMs: 500 });
+      }
+      if (url.includes('revoke')) {
+        return createResponse({ revoked: false });
+      }
+      if (url.includes('entitlements')) {
+        return createResponse({ entitlements: [], ttlMs: 1000 });
+      }
+      throw new Error(`Unhandled URL ${url}`);
+    });
+
+    const manager = new LicenseManager({ clock: () => clockDate });
+    const attestor = new RemoteLicenseAttestor({
+      attestationUrl: 'https://licensing.example/attest',
+      revocationUrl: 'https://licensing.example/revoke',
+      entitlementsUrl: 'https://licensing.example/entitlements',
+      fetch: fetchMock,
+      pollIntervalMs: 2000,
+      minimumPollIntervalMs: 100,
+      clock: () => clockDate
+    });
+
+    const validationListener = vi.fn();
+    attestor.on('validation', validationListener);
+
+    attestor.bindToLicenseManager(manager, { immediate: false });
+    manager.setLicense({ key: 'tenant-license', expiresAt: '2025-12-31T00:00:00Z' });
+
+    try {
+      await manager.validate();
+      fetchMock.mockClear();
+      validationListener.mockClear();
+
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(validationListener).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/vitest/remote-storage-adapters.test.js
+++ b/tests/vitest/remote-storage-adapters.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSignedS3StorageAdapter, createLogBrokerStorageAdapter } from '../../src/product/telemetry/storage/RemoteStorageAdapters.js';
+
+function createFetchResponse({ ok = true, status = 200, json } = {}) {
+  return {
+    ok,
+    status,
+    json: json || (async () => ({}))
+  };
+}
+
+describe('RemoteStorageAdapters', () => {
+  it('uploads compliance records via signed S3 adapter', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(createFetchResponse({
+        json: async () => ({ uploadUrl: 'https://example.com/upload', key: 'vault.json', headers: { 'x-amz-meta-test': '1' } })
+      }))
+      .mockResolvedValueOnce(createFetchResponse());
+
+    const onUploadComplete = vi.fn();
+
+    const adapter = createSignedS3StorageAdapter({
+      signingEndpoint: 'https://example.com/sign',
+      fetchImplementation: fetchMock,
+      onUploadComplete
+    });
+
+    await adapter.write([
+      { event: 'privacy.consent.updated', classification: 'compliance', timestamp: '2025-01-01T00:00:00.000Z' }
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://example.com/sign');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.com/upload');
+    expect(onUploadComplete).toHaveBeenCalledWith(expect.objectContaining({ key: 'vault.json', recordCount: 1 }));
+  });
+
+  it('supports retention policies and encryption metadata for signed S3 uploads', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(createFetchResponse({
+        json: async () => ({
+          uploadUrl: 'https://example.com/upload',
+          key: 'vault.json',
+          headers: {}
+        })
+      }))
+      .mockResolvedValueOnce(createFetchResponse());
+
+    const encryptPayload = vi.fn(async (body) => ({
+      body: `encrypted:${body}`,
+      contentType: 'application/x-adaptive-encrypted',
+      headers: { 'x-amz-server-side-encryption': 'aws:kms' },
+      metadata: { keyId: 'kms-key-id' }
+    }));
+
+    const onUploadComplete = vi.fn();
+
+    const adapter = createSignedS3StorageAdapter({
+      signingEndpoint: 'https://example.com/sign',
+      fetchImplementation: fetchMock,
+      retentionPolicy: { strategy: 'timeboxed', maxAgeMs: 86_400_000 },
+      encryptPayload,
+      onUploadComplete
+    });
+
+    await adapter.write([
+      { event: 'privacy.consent.updated', classification: 'compliance', timestamp: '2025-01-01T00:00:00.000Z' }
+    ]);
+
+    expect(encryptPayload).toHaveBeenCalledOnce();
+
+    const signingCall = fetchMock.mock.calls[0];
+    const signingBody = JSON.parse(signingCall[1].body);
+    expect(signingBody.retentionPolicy).toEqual({ strategy: 'timeboxed', maxAgeMs: 86_400_000 });
+    expect(signingBody.encryption).toEqual({ keyId: 'kms-key-id' });
+
+    const uploadCall = fetchMock.mock.calls[1];
+    const uploadHeaders = uploadCall[1].headers;
+    expect(uploadHeaders['x-amz-meta-retention']).toBe(JSON.stringify({ strategy: 'timeboxed', maxAgeMs: 86_400_000 }));
+    expect(uploadHeaders['x-amz-meta-encryption']).toBe(JSON.stringify({ keyId: 'kms-key-id' }));
+    expect(uploadHeaders['x-amz-server-side-encryption']).toBe('aws:kms');
+    expect(uploadHeaders['content-type']).toBe('application/x-adaptive-encrypted');
+    expect(uploadCall[1].body).toMatch(/^encrypted:\{"exportedAt":/);
+
+    expect(onUploadComplete).toHaveBeenCalledWith(expect.objectContaining({
+      recordCount: 1,
+      retentionPolicy: { strategy: 'timeboxed', maxAgeMs: 86_400_000 },
+      encryptionMetadata: { keyId: 'kms-key-id' }
+    }));
+  });
+
+  it('delivers payloads to a log broker endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse());
+    const adapter = createLogBrokerStorageAdapter({
+      endpoint: 'https://broker.example.com/ingest',
+      fetchImplementation: fetchMock
+    });
+
+    await adapter.write([
+      { event: 'privacy.consent.updated', classification: 'compliance', timestamp: '2025-01-01T00:00:00.000Z' },
+      { event: 'sensors.schema_issue', classification: 'compliance', timestamp: '2025-01-01T00:01:00.000Z' }
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.method).toBe('POST');
+    const body = JSON.parse(options.body);
+    expect(body.records).toHaveLength(2);
+  });
+
+  it('applies retention headers and encryption metadata for log brokers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse());
+    const encryptPayload = vi.fn(async (body) => `enc::${body}`);
+
+    const adapter = createLogBrokerStorageAdapter({
+      endpoint: 'https://broker.example.com/ingest',
+      fetchImplementation: fetchMock,
+      retentionPolicy: 3_600_000,
+      encryptPayload,
+      encryptionContentType: 'application/vnd.adaptive-log'
+    });
+
+    await adapter.write([
+      { event: 'privacy.consent.updated', classification: 'compliance', timestamp: '2025-01-01T00:00:00.000Z' }
+    ]);
+
+    expect(encryptPayload).toHaveBeenCalledOnce();
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers['x-retention-policy']).toBe(JSON.stringify({ strategy: 'timeboxed', maxAgeMs: 3_600_000 }));
+    expect(options.headers['content-type']).toBe('application/vnd.adaptive-log');
+    expect(options.body).toMatch(/^enc::\{"exportedAt":/);
+  });
+});

--- a/tests/vitest/request-signing-middleware.test.js
+++ b/tests/vitest/request-signing-middleware.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createRequestSigningMiddleware } from '../../src/product/telemetry/middleware/createRequestSigningMiddleware.js';
+
+describe('createRequestSigningMiddleware', () => {
+  it('throws when signer is missing', () => {
+    expect(() => createRequestSigningMiddleware()).toThrow();
+  });
+
+  it('injects signature headers from string signer result', async () => {
+    const middleware = createRequestSigningMiddleware({
+      signer: () => 'signed-token',
+      algorithm: 'HMAC-SHA256'
+    });
+
+    const result = await middleware({
+      endpoint: 'https://telemetry.example/collect',
+      options: { method: 'POST', body: JSON.stringify({ events: [] }), headers: {} },
+      events: [],
+      provider: { id: 'http' }
+    });
+
+    expect(result.options.headers['x-adaptive-signature']).toBe('signed-token');
+    expect(result.options.headers['x-adaptive-signature-algorithm']).toBe('HMAC-SHA256');
+    expect(result.metadata.signature).toBeTruthy();
+  });
+
+  it('merges custom metadata and headers from signer object result', async () => {
+    const middleware = createRequestSigningMiddleware({
+      signer: () => ({
+        signature: 'custom',
+        algorithm: 'RSA-SHA256',
+        headers: { Authorization: 'Bearer token' },
+        metadata: { keyId: 'kms-key-1' },
+        timestamp: '2025-10-16T00:00:00.000Z'
+      })
+    });
+
+    const result = await middleware({
+      endpoint: 'https://telemetry.example/collect',
+      options: { method: 'POST', headers: {} },
+      events: [{ event: 'test' }],
+      provider: { id: 'http' }
+    });
+
+    expect(result.options.headers['x-adaptive-signature']).toBe('custom');
+    expect(result.options.headers.Authorization).toBe('Bearer token');
+    expect(result.options.headers['x-adaptive-signature-algorithm']).toBe('RSA-SHA256');
+    expect(result.metadata.signature.keyId).toBe('kms-key-1');
+    expect(result.metadata.signature.issuedAt).toBe('2025-10-16T00:00:00.000Z');
+  });
+});

--- a/tests/vitest/sensory-input-bridge.test.js
+++ b/tests/vitest/sensory-input-bridge.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SensoryInputBridge } from '../../src/ui/adaptive/SensoryInputBridge.js';
+import { SensorSchemaRegistry } from '../../src/ui/adaptive/sensors/SensorSchemaRegistry.js';
+
+describe('SensoryInputBridge schema validation', () => {
+  let bridge;
+
+  beforeEach(() => {
+    bridge = new SensoryInputBridge({ confidenceThreshold: 0 });
+  });
+
+  it('clamps invalid focus payloads and emits sanitized values', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const focusUpdates = [];
+
+    bridge.subscribe('focus', payload => focusUpdates.push(payload));
+    bridge.ingest('eye-tracking', { x: 2.6, y: -0.4, depth: 'bad' }, 1);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Schema validation issues for eye-tracking'),
+      expect.any(Array)
+    );
+
+    const snapshot = bridge.getSnapshot();
+    expect(snapshot.focusVector.x).toBe(1);
+    expect(snapshot.focusVector.y).toBe(0);
+    expect(snapshot.focusVector.depth).toBeCloseTo(0.3);
+
+    expect(focusUpdates.at(-1)).toEqual({ x: 1, y: 0, depth: 0.3 });
+
+    warnSpy.mockRestore();
+  });
+
+  it('normalizes neural intent engagement and maintains engagement state', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    bridge.subscribe('engagement', () => {});
+    bridge.ingest('neural-intent', { x: '0.5', engagement: 1.7 }, 1);
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    const snapshot = bridge.getSnapshot();
+    expect(snapshot.intentionVector.x).toBeCloseTo(0.5);
+    expect(snapshot.engagementLevel).toBeCloseTo(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('supports runtime schema registration via registerSchema', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = new SensorSchemaRegistry({ registerDefaults: false });
+    const customBridge = new SensoryInputBridge({ schemaRegistry: registry, confidenceThreshold: 0 });
+
+    let emitted;
+    customBridge.subscribe('custom', payload => {
+      emitted = payload;
+    });
+
+    customBridge.registerSchema('custom', {
+      normalize: payload => {
+        const issues = [];
+        const numericValue = typeof payload.value === 'number' ? payload.value : 42;
+        if (typeof payload.value !== 'number') {
+          issues.push({ field: 'value', code: 'type' });
+        }
+        return { payload: { value: numericValue }, issues };
+      },
+      fallback: { value: 0 }
+    });
+
+    customBridge.ingest('custom', { value: 'abc' }, 1);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Schema validation issues for custom'),
+      expect.any(Array)
+    );
+    expect(emitted).toMatchObject({ payload: { value: 42 }, confidence: 1 });
+
+    warnSpy.mockRestore();
+  });
+
+  it('invokes validation reporter and logs issues', () => {
+    const reporter = vi.fn();
+    const validationBridge = new SensoryInputBridge({ confidenceThreshold: 0, issueReporter: reporter });
+
+    validationBridge.ingest('eye-tracking', { x: 10 }, 1);
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    const log = validationBridge.getValidationLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].type).toBe('eye-tracking');
+  });
+
+  it('supports manual adapter lifecycle management', async () => {
+    const adapter = {
+      connect: vi.fn().mockResolvedValue(),
+      disconnect: vi.fn().mockResolvedValue(),
+      read: vi.fn().mockResolvedValue(null)
+    };
+
+    bridge.registerAdapter('gesture', adapter);
+
+    await bridge.connectAdapter('gesture');
+    expect(adapter.connect).toHaveBeenCalled();
+    expect(bridge.getAdapterState('gesture').status).toBe('connected');
+
+    await bridge.disconnectAdapter('gesture');
+    expect(adapter.disconnect).toHaveBeenCalled();
+    expect(bridge.getAdapterState('gesture').status).toBe('disconnected');
+  });
+
+  it('falls back to read when testing adapters without explicit test hook', async () => {
+    const adapter = {
+      read: vi.fn().mockResolvedValue({ confidence: 1, payload: { intent: 'nod' } })
+    };
+
+    bridge.registerAdapter('gesture', adapter);
+    const result = await bridge.testAdapter('gesture');
+
+    expect(result).toBe(true);
+    expect(adapter.read).toHaveBeenCalled();
+  });
+});

--- a/tests/vitest/spatial-layout-synthesizer.test.js
+++ b/tests/vitest/spatial-layout-synthesizer.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SpatialLayoutSynthesizer } from '../../src/ui/adaptive/SpatialLayoutSynthesizer.js';
+import { LayoutStrategy } from '../../src/ui/adaptive/strategies/LayoutStrategy.js';
+import { LayoutAnnotation } from '../../src/ui/adaptive/annotations/LayoutAnnotation.js';
+
+const baseContext = {
+  focusVector: { x: 0.52, y: 0.47, depth: 0.28 },
+  intentionVector: { x: 0.1, y: 0.2, z: 0.05, w: 0.08 },
+  engagementLevel: 0.6,
+  biometricStress: 0.2,
+  gestureIntent: { intent: 'swipe', vector: { x: 0.3, y: 0.1, z: 0 } },
+  environment: { luminance: 0.4, noiseLevel: 0.1, motion: 0.2 }
+};
+
+class VelocityBoostStrategy extends LayoutStrategy {
+  constructor() {
+    super({ id: 'velocity-boost', priority: 1 });
+  }
+
+  prepare({ layout }) {
+    layout.intensity = 0.9;
+  }
+
+  compose({ layout }) {
+    layout.motion = {
+      velocity: 0.92,
+      bias: { x: 0.4, y: 0.1, z: 0 },
+      easing: 'ease-in'
+    };
+  }
+}
+
+class DebugAnnotation extends LayoutAnnotation {
+  constructor() {
+    super({ id: 'debug', priority: 1 });
+  }
+
+  shouldApply() {
+    return true;
+  }
+
+  build({ layout }) {
+    return { message: `intensity:${layout.intensity}` };
+  }
+}
+
+describe('SpatialLayoutSynthesizer', () => {
+  let synthesizer;
+
+  beforeEach(() => {
+    synthesizer = new SpatialLayoutSynthesizer();
+  });
+
+  it('generates layout with baseline zones and motion details', () => {
+    const layout = synthesizer.generateLayout(baseContext);
+
+    expect(layout.intensity).toBeGreaterThan(0);
+    expect(layout.intensity).toBeLessThanOrEqual(1);
+    expect(layout.zones).toHaveLength(3);
+    expect(layout.motion.velocity).toBeGreaterThan(0);
+    expect(['ease-in-out', 'ease-out']).toContain(layout.motion.easing);
+
+    const primaryZone = layout.zones.find(zone => zone.id === 'primary');
+    expect(primaryZone).toBeDefined();
+    expect(primaryZone.recommendedComponents.length).toBeGreaterThan(0);
+  });
+
+  it('supports runtime strategy swapping without touching core class', () => {
+    const customSynth = new SpatialLayoutSynthesizer({ useDefaultStrategies: false });
+    customSynth.registerStrategy(new VelocityBoostStrategy());
+
+    const layout = customSynth.generateLayout(baseContext);
+
+    expect(layout.intensity).toBe(0.9);
+    expect(layout.motion.velocity).toBeCloseTo(0.92);
+    expect(layout.motion.easing).toBe('ease-in');
+  });
+
+  it('supports annotations and guards against annotation failures', () => {
+    const annotation = new DebugAnnotation();
+    synthesizer.registerAnnotation(annotation);
+
+    const layout = synthesizer.generateLayout(baseContext);
+    expect(layout.annotations).toContainEqual({ id: 'debug', message: expect.stringContaining('intensity:') });
+
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    synthesizer.registerAnnotation(
+      new (class BrokenAnnotation extends LayoutAnnotation {
+        constructor() {
+          super({ id: 'broken' });
+        }
+        build() {
+          throw new Error('fail');
+        }
+      })()
+    );
+
+    const layoutWithFailure = synthesizer.generateLayout(baseContext);
+    expect(layoutWithFailure.annotations).toEqual(expect.arrayContaining([{ id: 'debug', message: expect.any(String) }]));
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Annotation broken failed'),
+      expect.any(Error)
+    );
+
+    consoleWarn.mockRestore();
+  });
+});

--- a/types/adaptive-sdk.d.ts
+++ b/types/adaptive-sdk.d.ts
@@ -1,0 +1,1370 @@
+export interface SensorSchemaIssue {
+  field: string;
+  code: string;
+  message?: string;
+}
+
+export interface SensorSchemaNormalizationResult<TPayload> {
+  payload: TPayload;
+  issues: SensorSchemaIssue[];
+}
+
+export interface SensorSchema<TInput = unknown, TNormalized = TInput> {
+  normalize(payload: TInput): SensorSchemaNormalizationResult<TNormalized> | TNormalized;
+  fallback?: TNormalized;
+}
+
+export interface SensorAdapterSample<TPayload = unknown> {
+  confidence: number;
+  payload: TPayload;
+}
+
+export interface SensorAdapter<TPayload = unknown> {
+  read(): Promise<SensorAdapterSample<TPayload> | void> | SensorAdapterSample<TPayload> | void;
+  connect?(): Promise<void> | void;
+  disconnect?(): Promise<void> | void;
+  test?(): Promise<boolean> | boolean;
+}
+
+export interface TelemetryConsentMap {
+  [classification: string]: boolean;
+}
+
+export interface TelemetryAuditEntry {
+  event: string;
+  payload: Record<string, unknown> | null;
+  classification: string;
+  timestamp: string;
+  licenseKey?: string;
+  source?: string;
+}
+
+export interface TelemetryRequestContext {
+  endpoint: string;
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+  };
+  events: Array<Record<string, unknown>>;
+  metadata?: Record<string, unknown>;
+  provider: { id: string } & Record<string, unknown>;
+}
+
+export type TelemetryRequestMiddleware = (
+  context: TelemetryRequestContext
+) => Promise<Partial<TelemetryRequestContext> | void> | Partial<TelemetryRequestContext> | void;
+
+export interface TelemetryConfig extends Record<string, unknown> {
+  requestMiddleware?: TelemetryRequestMiddleware[];
+  licenseAttestationProfiles?: LicenseAttestationProfile[];
+  defaultLicenseAttestationProfileId?: string;
+  licenseAttestationProfilePackId?: string;
+  licenseAttestationProfilePackOptions?: LicenseAttestationProfilePackOptions;
+  licenseAttestationProfilePacks?: Array<
+    | string
+    | LicenseAttestationProfilePackConfig
+    | LicenseAttestationProfilePackDescriptor
+  >;
+  commercialization?: LicenseCommercializationOptions;
+  commercializationReporter?: LicenseCommercializationReporter;
+}
+
+export interface LicenseDetails {
+  key: string;
+  tenantId?: string;
+  features?: string[];
+  expiresAt?: string | number | Date;
+  issuedAt?: string | number | Date;
+  signature?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LicenseStatus {
+  state: 'unregistered' | 'pending' | 'valid' | 'invalid' | 'expired';
+  reason: string;
+  validatedAt: string | null;
+  metadata?: Record<string, unknown>;
+  error?: string;
+}
+
+export type LicenseValidator = (
+  license: LicenseDetails,
+  context?: Record<string, unknown>
+) =>
+  | Promise<
+      | { valid?: boolean; reason?: string; metadata?: Record<string, unknown> }
+      | boolean
+      | void
+    >
+  | { valid?: boolean; reason?: string; metadata?: Record<string, unknown> }
+  | boolean
+  | void;
+
+export interface LicenseManagerOptions {
+  clock?: () => Date | string | number;
+  logger?: { warn?: (...args: unknown[]) => void };
+  validators?: LicenseValidator[];
+}
+
+export interface LicenseConfig extends LicenseDetails {
+  validators?: LicenseValidator[];
+  autoValidate?: boolean;
+  managerOptions?: Omit<LicenseManagerOptions, 'validators'>;
+  attestor?: RemoteLicenseAttestor | RemoteLicenseAttestorOptions;
+  attestorBinding?: RemoteLicenseAttestorBindingOptions;
+  attestorProfileId?: string;
+  attestorProfileOverrides?: LicenseAttestorProfileOverrides;
+}
+
+export interface RemoteLicenseAttestationMetadata {
+  valid?: boolean;
+  reason?: string;
+  attestedAt?: string;
+  nextCheckAt?: string | null;
+  nextCheckInMs?: number | null;
+  metadata?: Record<string, unknown> | null;
+  raw?: Record<string, unknown>;
+  skipped?: boolean;
+}
+
+export interface RemoteLicenseRevocationMetadata {
+  revoked?: boolean;
+  reason?: string;
+  checkedAt?: string;
+  metadata?: Record<string, unknown> | null;
+  raw?: Record<string, unknown>;
+  skipped?: boolean;
+}
+
+export interface RemoteLicenseEntitlementMetadata {
+  entitlements?: string[];
+  updatedAt?: string;
+  ttlMs?: number | null;
+  metadata?: Record<string, unknown> | null;
+  raw?: Record<string, unknown>;
+  skipped?: boolean;
+}
+
+export interface RemoteLicenseAttestationSummary {
+  attestation?: RemoteLicenseAttestationMetadata;
+  revocation?: RemoteLicenseRevocationMetadata;
+  entitlements?: RemoteLicenseEntitlementMetadata;
+}
+
+export interface LicenseAttestationProfileSLA {
+  failOpen?: boolean;
+  responseTargetMs?: number;
+  retryPolicy?: string;
+  availability?: string;
+  notes?: string;
+  breachWindowMs?: number;
+}
+
+export interface LicenseAttestorProfileOverrides {
+  attestorOptions?: Partial<RemoteLicenseAttestorOptions> & Record<string, unknown>;
+  binding?: RemoteLicenseAttestorBindingOptions;
+  metadata?: Record<string, unknown>;
+  attestor?: RemoteLicenseAttestor;
+}
+
+export interface LicenseAttestationProfile {
+  id: string;
+  name?: string;
+  description?: string;
+  attestor?: RemoteLicenseAttestor | RemoteLicenseAttestorOptions;
+  createAttestor?: (options: {
+    profile: LicenseAttestationProfile;
+    attestorOptions?: Record<string, unknown>;
+    overrides?: LicenseAttestorProfileOverrides;
+  }) => RemoteLicenseAttestor;
+  binding?: RemoteLicenseAttestorBindingOptions;
+  sla?: LicenseAttestationProfileSLA;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LicenseAttestationProfilePackOptions {
+  regions?: string[];
+  baseUrl?: string;
+  pollIntervalMs?: number;
+  minimumPollIntervalMs?: number;
+  failOpen?: boolean;
+  headers?: Record<string, string>;
+  collaborationId?: string;
+  projectCode?: string;
+  defaultProfileId?: string;
+  metadata?: Record<string, unknown>;
+  applyDefault?: boolean;
+  sla?: Partial<LicenseAttestationProfileSLA>;
+}
+
+export interface LicenseAttestationProfilePackDescriptor {
+  id?: string;
+  name?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  defaults?: LicenseAttestationProfilePackOptions;
+  profiles?: LicenseAttestationProfile[];
+  buildProfiles?: (options?: LicenseAttestationProfilePackOptions) => LicenseAttestationProfile[];
+}
+
+export interface LicenseAttestationProfilePackConfig {
+  id: string;
+  options?: LicenseAttestationProfilePackOptions;
+}
+
+export interface LicenseAttestationProfilePackResult {
+  id: string;
+  name: string;
+  description: string;
+  defaultProfileId: string | null;
+  profileIds: string[];
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface LicenseCommercializationMetricSummary {
+  min: number;
+  max: number;
+  average: number;
+}
+
+export interface LicenseCommercializationSLASummary {
+  responseTargetMs: LicenseCommercializationMetricSummary | null;
+  availabilityPercent: LicenseCommercializationMetricSummary | null;
+  breachWindowMs: LicenseCommercializationMetricSummary | null;
+}
+
+export interface LicenseCommercializationSegmentSummary {
+  profileCount: number;
+  packIds: string[];
+  adoptionCount: number;
+}
+
+export interface LicenseCommercializationRegionSummary {
+  profileCount: number;
+  adoptionCount: number;
+}
+
+export interface LicenseCommercializationProfileSummary {
+  id: string;
+  name?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  sla?: LicenseAttestationProfileSLA;
+  packId: string | null;
+  registeredAt: string | null;
+  source: string;
+  adoptionCount: number;
+  lastAppliedAt: string | null;
+}
+
+export interface LicenseCommercializationPackSummary {
+  id: string;
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown> | null;
+  profileIds: string[];
+  registeredAt: string | null;
+  appliedDefault: boolean;
+  defaultProfileId: string | null;
+  adoptionCount: number;
+  options?: Record<string, unknown> | null;
+}
+
+export interface LicenseCommercializationSummary {
+  packs: LicenseCommercializationPackSummary[];
+  profiles: LicenseCommercializationProfileSummary[];
+  segments: Record<string, LicenseCommercializationSegmentSummary>;
+  regions: Record<string, LicenseCommercializationRegionSummary>;
+  sla: LicenseCommercializationSLASummary;
+  defaultProfileId: string | null;
+  lastUpdated: string | null;
+}
+
+export interface LicenseCommercializationSnapshotKpis {
+  totalPacks: number;
+  totalProfiles: number;
+  totalAdoption: number;
+  activePacks: number;
+  activeProfiles: number;
+  adoptionPerPack: number;
+  adoptionPerProfile: number;
+  segmentCount: number;
+  regionCount: number;
+  defaultProfileId: string | null;
+  lastUpdated: string | null;
+  topSegments: Array<{ key: string; adoption: number; profiles: number }>;
+  topRegions: Array<{ key: string; adoption: number; profiles: number }>;
+}
+
+export interface LicenseCommercializationSnapshotContext extends Record<string, unknown> {
+  trigger?: string;
+  capturedBy?: string;
+  licenseKey?: string;
+  scheduledAt?: string;
+}
+
+export interface LicenseCommercializationSnapshot {
+  id: string;
+  capturedAt: string;
+  summary?: LicenseCommercializationSummary;
+  context: LicenseCommercializationSnapshotContext;
+  kpis: LicenseCommercializationSnapshotKpis;
+}
+
+export interface LicenseCommercializationKpiReport {
+  latest: LicenseCommercializationSnapshot | null;
+  previous: LicenseCommercializationSnapshot | null;
+  deltas: Record<string, number>;
+}
+
+export interface LicenseCommercializationReporterOptions {
+  onUpdate?: (summary: LicenseCommercializationSummary) => void;
+  emitProfileDetails?: boolean;
+  enabled?: boolean;
+}
+
+export interface LicenseCommercializationSnapshotStorage {
+  loadSnapshots?: () =>
+    | LicenseCommercializationSnapshot[]
+    | unknown[]
+    | Promise<LicenseCommercializationSnapshot[] | unknown[]>;
+  saveSnapshots?: (
+    snapshots: LicenseCommercializationSnapshot[] | unknown[]
+  ) => void | Promise<void>;
+  appendSnapshot?: (
+    snapshot: LicenseCommercializationSnapshot | unknown
+  ) => void | Promise<void>;
+  clearSnapshots?: () => void | Promise<void>;
+}
+
+export interface LicenseCommercializationSnapshotStoreOptions {
+  maxSnapshots?: number;
+  storage?: LicenseCommercializationSnapshotStorage;
+  onChange?: (snapshots: LicenseCommercializationSnapshot[]) => void;
+}
+
+export interface CommercializationSnapshotTransformContext {
+  includeSummary: boolean;
+  redactContextKeys: string[];
+}
+
+export type CommercializationSnapshotTransform = (
+  snapshot: LicenseCommercializationSnapshot | unknown,
+  context: CommercializationSnapshotTransformContext
+) => LicenseCommercializationSnapshot | Record<string, unknown> | null | undefined;
+
+export interface CommercializationSnapshotRemoteStorageOptions {
+  adapter: {
+    write: (records: unknown[]) => void | Promise<void>;
+    read?: () => unknown[] | Promise<unknown[]>;
+    clear?: () => void | Promise<void>;
+  };
+  includeSummary?: boolean;
+  redactContextKeys?: string[];
+  transformSnapshot?: CommercializationSnapshotTransform;
+  transformIncoming?: (
+    records: unknown[],
+    context: CommercializationSnapshotTransformContext
+  ) => LicenseCommercializationSnapshot[];
+  onError?: (error: unknown) => void;
+}
+
+export interface SignedS3CommercializationSnapshotStorageOptions
+  extends SignedS3StorageAdapterOptions {
+  includeSummary?: boolean;
+  redactContextKeys?: string[];
+  transformSnapshot?: CommercializationSnapshotTransform;
+  transformIncoming?: (
+    records: unknown[],
+    context: CommercializationSnapshotTransformContext
+  ) => LicenseCommercializationSnapshot[];
+  onError?: (error: unknown) => void;
+  serialize?: (
+    snapshots: LicenseCommercializationSnapshot[],
+    context: Record<string, unknown>
+  ) => unknown;
+}
+
+export interface LogBrokerCommercializationSnapshotStorageOptions
+  extends LogBrokerStorageAdapterOptions {
+  includeSummary?: boolean;
+  redactContextKeys?: string[];
+  transformSnapshot?: CommercializationSnapshotTransform;
+  transformIncoming?: (
+    records: unknown[],
+    context: CommercializationSnapshotTransformContext
+  ) => LicenseCommercializationSnapshot[];
+  onError?: (error: unknown) => void;
+  serialize?: (
+    snapshots: LicenseCommercializationSnapshot[],
+    context: Record<string, unknown>
+  ) => unknown;
+}
+
+export interface LicenseCommercializationOptions extends LicenseCommercializationReporterOptions {
+  snapshotStore?: false | LicenseCommercializationSnapshotStore | LicenseCommercializationSnapshotStoreOptions;
+  snapshotStoreOptions?: LicenseCommercializationSnapshotStoreOptions;
+  snapshotIntervalMs?: number;
+  captureInitialSnapshot?: boolean;
+}
+
+export interface LicenseAttestationProfileBindingResult {
+  attestor: RemoteLicenseAttestor;
+  binding: RemoteLicenseAttestorBindingOptions;
+  profile: LicenseAttestationProfile;
+}
+
+export interface RemoteLicenseAttestorOptions {
+  attestationUrl?: string;
+  revocationUrl?: string;
+  entitlementsUrl?: string;
+  fetch?: (...args: unknown[]) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+  headers?: Record<string, string>;
+  pollIntervalMs?: number;
+  minimumPollIntervalMs?: number;
+  failOpen?: boolean;
+  historyLimit?: number;
+  clock?: () => Date | string | number;
+  transformRequest?: (options: {
+    type: string;
+    payload: Record<string, unknown>;
+    request?: Record<string, unknown>;
+  }) => Record<string, unknown> | void;
+  transformResponse?: (options: {
+    type: string;
+    response: unknown;
+    text: string;
+  }) => Record<string, unknown> | void;
+}
+
+export interface RemoteLicenseAttestorBindingOptions {
+  bindToLicenseManager?: boolean;
+  attestorOptions?: Record<string, unknown>;
+}
+
+export interface RemoteLicenseAttestorEvents {
+  attestation: {
+    license: LicenseDetails;
+    context?: Record<string, unknown>;
+    attestation: RemoteLicenseAttestationMetadata;
+  };
+  revocation: {
+    license: LicenseDetails;
+    context?: Record<string, unknown>;
+    revocation: RemoteLicenseRevocationMetadata;
+  };
+  entitlements: {
+    license: LicenseDetails;
+    context?: Record<string, unknown>;
+    entitlements: RemoteLicenseEntitlementMetadata;
+  };
+  validation: {
+    license: LicenseDetails;
+    context?: Record<string, unknown>;
+    result: RemoteLicenseAttestationSummary;
+  };
+  error: {
+    type: string;
+    license?: LicenseDetails;
+    context?: Record<string, unknown>;
+    error: unknown;
+  };
+  schedule: {
+    delayMs: number;
+    context?: Record<string, unknown>;
+  };
+}
+
+export interface AdaptiveEnvironmentOptions {
+  mode?: 'browser' | 'headless' | string;
+  skipVisualization?: boolean;
+  skipUiBindings?: boolean;
+  skipGallery?: boolean;
+  skipExport?: boolean;
+  skipStatus?: boolean;
+  autoStart?: boolean;
+}
+
+export interface AdaptiveSDKConfig {
+  sensory?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+  design?: Record<string, unknown>;
+  telemetry?: TelemetryConfig;
+  marketplaceHooks?: Record<string, unknown>;
+  projection?: ProjectionConfig;
+  environment?: AdaptiveEnvironmentOptions;
+  layoutStrategies?: any[];
+  layoutAnnotations?: any[];
+  telemetryProviders?: any[];
+  replaceDefaultProviders?: boolean;
+  licenseAttestationProfiles?: LicenseAttestationProfile[];
+  defaultLicenseAttestationProfileId?: string;
+  licenseAttestorProfileId?: string;
+  licenseAttestorProfileOverrides?: LicenseAttestorProfileOverrides;
+  sensorSchemas?: Array<{ type: string; schema: SensorSchema }> | Record<string, SensorSchema>;
+  sensorAdapters?: Array<{ type: string; instance: SensorAdapter; autoConnect?: boolean }>;
+  telemetryConsent?: TelemetryConsentMap;
+  consentOptions?: ConsentToggleOption[];
+  licenseManager?: LicenseManager;
+  license?: LicenseConfig;
+  licenseAttestor?: RemoteLicenseAttestor | RemoteLicenseAttestorOptions;
+  licenseAttestorBinding?: RemoteLicenseAttestorBindingOptions;
+  commercialization?: LicenseCommercializationOptions;
+  commercializationReporter?: LicenseCommercializationReporter;
+}
+
+export interface AdaptiveSDK {
+  engine: any;
+  sensoryBridge: any;
+  layoutSynthesizer: any;
+  telemetry: any;
+  projectionComposer: ProjectionFieldComposer;
+  projectionSimulator: ProjectionScenarioSimulator;
+  licenseManager?: LicenseManager;
+  licenseAttestor?: RemoteLicenseAttestor;
+  registerLayoutStrategy(strategy: any): any;
+  registerLayoutAnnotation(annotation: any): any;
+  registerTelemetryProvider(provider: any): any;
+  registerTelemetryRequestMiddleware(middleware: TelemetryRequestMiddleware): any;
+  clearTelemetryRequestMiddleware(): any;
+  registerLicenseAttestationProfile(
+    profile: LicenseAttestationProfile | string,
+    options?: Omit<LicenseAttestationProfile, 'id'>
+  ): LicenseAttestationProfile;
+  registerLicenseAttestationProfilePack(
+    pack: string | LicenseAttestationProfilePackDescriptor,
+    options?: LicenseAttestationProfilePackOptions
+  ): LicenseAttestationProfilePackResult;
+  getLicenseAttestationProfiles(): LicenseAttestationProfile[];
+  getLicenseAttestationProfile(id: string): LicenseAttestationProfile | null;
+  setDefaultLicenseAttestationProfile(id: string): void;
+  setLicenseAttestorFromProfile(
+    profileId: string,
+    overrides?: LicenseAttestorProfileOverrides
+  ): LicenseAttestationProfileBindingResult;
+  registerSensorSchema(type: string, schema: SensorSchema): any;
+  registerSensorAdapter(type: string, adapter: SensorAdapter, options?: { autoConnect?: boolean }): any;
+  connectSensorAdapter(type: string): Promise<void>;
+  disconnectSensorAdapter(type: string): Promise<void>;
+  testSensorAdapter(type: string): Promise<boolean | void>;
+  updateTelemetryConsent(consent: TelemetryConsentMap, metadata?: Record<string, unknown>): void;
+  getTelemetryConsent(): TelemetryConsentMap;
+  getTelemetryAuditTrail(): TelemetryAuditEntry[];
+  getLicenseCommercializationSummary(): LicenseCommercializationSummary;
+  getLicenseCommercializationReporter(): LicenseCommercializationReporter | null;
+  getLicenseCommercializationSnapshotStore(): LicenseCommercializationSnapshotStore | null;
+  captureLicenseCommercializationSnapshot(
+    context?: Record<string, unknown>
+  ): LicenseCommercializationSnapshot | null;
+  getLicenseCommercializationSnapshots(
+    options?: LicenseCommercializationSnapshotQueryOptions
+  ): LicenseCommercializationSnapshot[];
+  getLicenseCommercializationKpiReport(options?: { limit?: number }): LicenseCommercializationKpiReport;
+  exportLicenseCommercializationSnapshots(
+    options?: LicenseCommercializationSnapshotExportOptions
+  ): string | Record<string, unknown> | null;
+  startLicenseCommercializationSnapshotSchedule(
+    intervalMs?: number,
+    context?: Record<string, unknown>
+  ): (() => void) | null;
+  stopLicenseCommercializationSnapshotSchedule(): void;
+  setLicense(license: LicenseDetails): void;
+  validateLicense(context?: Record<string, unknown>): Promise<LicenseStatus>;
+  getLicenseStatus(): LicenseStatus;
+  getLicenseHistory(): Array<{ status: LicenseStatus; timestamp: string }>;
+  getLicenseAttestationHistory(): Array<{ timestamp: string; entry: RemoteLicenseAttestationSummary }>;
+  setLicenseAttestor(attestor: RemoteLicenseAttestor | RemoteLicenseAttestorOptions | null, options?: RemoteLicenseAttestorBindingOptions): void;
+  requestLicenseAttestation(context?: Record<string, unknown>): Promise<LicenseStatus>;
+  onLicenseStatusChange(listener: (status: LicenseStatus) => void): () => void;
+  createConsentPanel(options: ConsentPanelOptions): ConsentPanelApi;
+  composeProjectionField(
+    blueprintOrLayout: LayoutBlueprint | Record<string, unknown>,
+    design?: Record<string, unknown>,
+    context?: Record<string, unknown>,
+    options?: ProjectionComposerOptions
+  ): ProjectionFieldComposition | null;
+  getProjectionFrame(): ProjectionScenarioFrame | null;
+  stepProjectionSimulation(options?: { timestamp?: number }): ProjectionScenarioFrame | null;
+  registerProjectionScenario(descriptor: ProjectionScenarioDescriptor): ProjectionScenarioDescriptor;
+  removeProjectionScenario(id: string): boolean;
+  listProjectionScenarios(): ProjectionScenarioDescriptor[];
+  getProjectionScenario(id: string): ProjectionScenarioDescriptor | null;
+  setActiveProjectionScenario(id: string): ProjectionScenarioDescriptor | null;
+  getActiveProjectionScenario(): ProjectionScenarioDescriptor | null;
+}
+
+export interface ComplianceVaultStorageAdapter {
+  read?(): TelemetryAuditEntry[] | Promise<TelemetryAuditEntry[]>;
+  write?(records: TelemetryAuditEntry[]): void | Promise<void>;
+  clear?(): void | Promise<void>;
+}
+
+export interface ComplianceVaultTelemetryProviderOptions {
+  id?: string;
+  metadata?: Record<string, unknown>;
+  storageKey?: string;
+  maxRecords?: number;
+  includeClassifications?: string[];
+  storageAdapter?: ComplianceVaultStorageAdapter;
+}
+
+export class ComplianceVaultTelemetryProvider {
+  constructor(options?: ComplianceVaultTelemetryProviderOptions);
+  id: string;
+  metadata: Record<string, unknown>;
+  getRecords(): TelemetryAuditEntry[];
+  clear(): void;
+  flush(): void;
+  whenReady(): Promise<TelemetryAuditEntry[]>;
+}
+
+export interface ConsentToggleOption {
+  classification: string;
+  title: string;
+  description: string;
+}
+
+export interface ConsentPanelOptions {
+  container: HTMLElement;
+  consentOptions?: ConsentToggleOption[];
+  getTelemetryConsent?: () => TelemetryConsentMap;
+  onConsentToggle?: (classification: string, enabled: boolean) => void;
+  getComplianceRecords?: () => TelemetryAuditEntry[];
+  getTelemetryAuditTrail?: () => TelemetryAuditEntry[];
+  refreshInterval?: number;
+  downloadFormatter?: (records: TelemetryAuditEntry[]) => string;
+  downloadFileNamePrefix?: string;
+  onDownload?: (options: { records: TelemetryAuditEntry[]; payload: unknown }) => void;
+  onRender?: (options: { consent: TelemetryConsentMap; metadata?: Record<string, unknown> }) => void;
+  trackConsentToggle?: (classification: string, enabled: boolean) => void;
+  heading?: string;
+}
+
+export interface ConsentPanelApi {
+  mount(): ConsentPanelApi;
+  destroy(): void;
+  refreshComplianceLog(): void;
+  handleConsentDecision(consent: TelemetryConsentMap, metadata?: Record<string, unknown>): void;
+}
+
+export interface LayoutBlueprintZoneSummary {
+  id: string;
+  occupancy: number;
+  layeringDepth: number;
+  curvature: number;
+  visibility: number;
+  components: string[];
+  surfaceScore: number;
+}
+
+export interface LayoutBlueprintMotionBias {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface LayoutBlueprintMotion {
+  velocity: number;
+  easing: string;
+  bias: LayoutBlueprintMotionBias;
+}
+
+export interface LayoutBlueprint {
+  generatedAt: string;
+  intensity: number;
+  engagementLevel: number;
+  biometricStress: number;
+  focusVector: { x: number; y: number; depth: number };
+  motion: LayoutBlueprintMotion;
+  pattern: Record<string, unknown> | null;
+  monetization: Record<string, unknown> | null;
+  integration: Record<string, unknown> | null;
+  annotations: Array<Record<string, unknown>>;
+  zones: LayoutBlueprintZoneSummary[];
+  recommendedComponents: string[];
+}
+
+export interface ProjectionComposerOptions {
+  resolution?: number;
+  depthBands?: number;
+  haloFalloff?: number;
+  haloBaseRadius?: number;
+  gestureWeight?: number;
+  biasSmoothing?: number;
+  bandEasing?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out';
+}
+
+export interface ProjectionFieldFocusHalo {
+  radius: number;
+  falloff: number;
+  origin: { x: number; y: number; depth: number };
+  stressPenalty: number;
+  coherenceBoost: number;
+}
+
+export interface ProjectionFieldDepthBand {
+  id: string;
+  index: number;
+  ratio: number;
+  intensity: number;
+  depth: number;
+}
+
+export interface ProjectionFieldGestureContour {
+  id: string;
+  orbit: number;
+  curvature: number;
+  visibility: number;
+  intensity: number;
+  zoneId: string;
+  bias: { x: number; y: number; depth: number };
+}
+
+export interface ProjectionFieldInteractionLobe {
+  id: string;
+  volume: number;
+  layeringDepth: number;
+  visibility: number;
+  saturation: number;
+}
+
+export interface ProjectionFieldAnnotationSummary {
+  id: string;
+  type: string;
+  priority: number;
+}
+
+export interface ProjectionFieldComposition {
+  generatedAt: string;
+  options: ProjectionComposerOptions;
+  focusHalo: ProjectionFieldFocusHalo;
+  depthBands: ProjectionFieldDepthBand[];
+  gestureContours: ProjectionFieldGestureContour[];
+  interactionLobes: ProjectionFieldInteractionLobe[];
+  activationMatrix: number[][];
+  annotations: ProjectionFieldAnnotationSummary[];
+  context: Record<string, unknown>;
+  blueprint: LayoutBlueprint;
+}
+
+export interface ProjectionFieldComposerLayers {
+  base?: HTMLCanvasElement | null;
+  halo?: HTMLCanvasElement | null;
+  bands?: HTMLCanvasElement | null;
+  contours?: HTMLCanvasElement | null;
+}
+
+export interface ProjectionFieldComposerOptions extends ProjectionComposerOptions {
+  layers?: ProjectionFieldComposerLayers;
+  observe?: boolean;
+}
+
+export class ProjectionFieldComposer {
+  constructor(options?: ProjectionFieldComposerOptions);
+  compose(
+    blueprint: LayoutBlueprint,
+    context?: Record<string, unknown>,
+    options?: ProjectionComposerOptions
+  ): ProjectionFieldComposition;
+  render(
+    blueprint: LayoutBlueprint,
+    context?: Record<string, unknown>,
+    options?: ProjectionComposerOptions
+  ): ProjectionFieldComposition;
+  setOptions(options?: ProjectionComposerOptions): void;
+  attachLayer(id: string, canvas: HTMLCanvasElement | null | undefined): void;
+  detachLayer(id: string): void;
+  resize(): void;
+  clear(): void;
+}
+
+export function composeProjectionField(
+  blueprint: LayoutBlueprint,
+  context?: Record<string, unknown>,
+  options?: ProjectionComposerOptions
+): ProjectionFieldComposition;
+
+export function createProjectionFieldComposer(
+  options?: ProjectionFieldComposerOptions
+): ProjectionFieldComposer;
+
+export interface ProjectionScenarioAnchor {
+  id?: string;
+  label?: string;
+  description?: string;
+}
+
+export interface ProjectionScenarioBlueprintModulation {
+  intensity?: { start?: number; end?: number; easing?: string };
+  engagementLevel?: { start?: number; end?: number; easing?: string };
+  biometricStress?: { start?: number; end?: number; easing?: string };
+  focusX?: { start?: number; end?: number; easing?: string };
+  focusY?: { start?: number; end?: number; easing?: string };
+  focusDepth?: { start?: number; end?: number; easing?: string };
+  zoneOccupancy?: Array<{ id: string; start?: number; end?: number; easing?: string }>;
+}
+
+export interface ProjectionScenarioContextModulation {
+  engagementLevel?: { start?: number; end?: number; easing?: string };
+  gazeVelocity?: { start?: number; end?: number; easing?: string };
+  neuralCoherence?: { start?: number; end?: number; easing?: string };
+  hapticFeedback?: { start?: number; end?: number; easing?: string };
+  gestureIntensity?: { start?: number; end?: number; easing?: string };
+  gestureX?: { start?: number; end?: number; easing?: string };
+  gestureY?: { start?: number; end?: number; easing?: string };
+  gestureZ?: { start?: number; end?: number; easing?: string };
+}
+
+export interface ProjectionScenarioModulation {
+  blueprint?: ProjectionScenarioBlueprintModulation;
+  context?: ProjectionScenarioContextModulation;
+  composerOptions?: ProjectionComposerOptions;
+}
+
+export interface ProjectionScenarioDescriptor {
+  id: string;
+  name?: string;
+  description?: string;
+  cycleMs?: number;
+  blueprint?: LayoutBlueprint;
+  context?: Record<string, unknown>;
+  modulation?: ProjectionScenarioModulation;
+  metadata?: Record<string, unknown>;
+  anchors?: ProjectionScenarioAnchor[];
+}
+
+export interface ProjectionScenarioFrameAnchor extends ProjectionScenarioAnchor {
+  progress: number;
+}
+
+export interface ProjectionScenarioFrame {
+  id: string;
+  name: string;
+  progress: number;
+  cycleMs: number;
+  blueprint: LayoutBlueprint;
+  context: Record<string, unknown>;
+  composition: ProjectionFieldComposition;
+  anchors: ProjectionScenarioFrameAnchor[];
+}
+
+export interface ProjectionScenarioSimulatorOptions {
+  autoStart?: boolean;
+  composer?: ProjectionFieldComposer;
+}
+
+export class ProjectionScenarioSimulator {
+  constructor(options?: ProjectionScenarioSimulatorOptions);
+  registerScenario(descriptor: ProjectionScenarioDescriptor): ProjectionScenarioDescriptor;
+  removeScenario(id: string): boolean;
+  listScenarios(): ProjectionScenarioDescriptor[];
+  getScenario(id: string): ProjectionScenarioDescriptor | null;
+  setActiveScenario(id: string): ProjectionScenarioDescriptor | null;
+  getActiveScenario(): ProjectionScenarioDescriptor | null;
+  observeAdaptiveState(state: {
+    layout?: Record<string, unknown>;
+    blueprint?: LayoutBlueprint;
+    context?: Record<string, unknown>;
+  }): void;
+  step(options?: { timestamp?: number }): ProjectionScenarioFrame | null;
+  compose(
+    blueprint: LayoutBlueprint,
+    context?: Record<string, unknown>,
+    options?: ProjectionComposerOptions
+  ): ProjectionFieldComposition;
+  getLastResult(): ProjectionScenarioFrame | null;
+  on(event: string, listener: (payload: unknown) => void): () => void;
+}
+
+export interface ProjectionConfig {
+  composer?: ProjectionFieldComposerOptions;
+  simulator?: ProjectionScenarioSimulatorOptions;
+}
+
+export interface LayoutBlueprintRendererLayers {
+  [layerId: string]: HTMLCanvasElement | null | undefined;
+}
+
+export interface LayoutBlueprintRendererOptions {
+  layers?: LayoutBlueprintRendererLayers;
+  zoneColors?: Record<string, string>;
+  background?: { inner?: string; outer?: string };
+  devicePadding?: number;
+  observe?: boolean;
+}
+
+export class LayoutBlueprintRenderer {
+  constructor(options?: LayoutBlueprintRendererOptions);
+  attachLayer(id: string, canvas: HTMLCanvasElement | null | undefined): void;
+  detachLayer(id: string): void;
+  resize(): void;
+  clear(): void;
+  render(layout: Record<string, unknown>, design?: Record<string, unknown>, context?: Record<string, unknown>): void;
+}
+
+export function createLayoutBlueprintRenderer(options?: LayoutBlueprintRendererOptions): LayoutBlueprintRenderer;
+
+export function buildLayoutBlueprint(
+  layout?: Record<string, unknown>,
+  design?: Record<string, unknown>,
+  context?: Record<string, unknown>
+): LayoutBlueprint;
+
+export interface RequestSigningMiddlewareOptions {
+  signer: (
+    payload: {
+      endpoint: string;
+      method: string;
+      timestamp: string;
+      body: string;
+      events: Array<Record<string, unknown>>;
+      digest: string;
+      metadata: Record<string, unknown>;
+    }
+  ) => Promise<string | Record<string, unknown> | void> | string | Record<string, unknown> | void;
+  header?: string;
+  algorithmHeader?: string;
+  timestampHeader?: string;
+  includeEventDigest?: boolean;
+  digestSeparator?: string;
+  metadataKey?: string;
+  algorithm?: string;
+}
+
+export function createRequestSigningMiddleware(
+  options: RequestSigningMiddlewareOptions
+): TelemetryRequestMiddleware;
+
+export type RemoteStorageRetentionPolicy =
+  | string
+  | number
+  | {
+      strategy?: string;
+      maxAgeMs?: number;
+      legalHold?: boolean;
+      deleteAfterUpload?: boolean;
+      metadata?: Record<string, unknown>;
+    };
+
+export interface NormalizedRetentionPolicy {
+  strategy: string;
+  maxAgeMs?: number;
+  legalHold?: boolean;
+  deleteAfterUpload?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EncryptPayloadContext {
+  adapter: string;
+  records: TelemetryAuditEntry[];
+  retentionPolicy?: NormalizedRetentionPolicy;
+}
+
+export type EncryptPayloadResult =
+  | string
+  | ArrayBuffer
+  | ArrayBufferView
+  | Blob
+  | {
+      body?: string | ArrayBuffer | ArrayBufferView | Blob | Record<string, unknown>;
+      contentType?: string;
+      headers?: Record<string, string>;
+      metadata?: Record<string, unknown>;
+      useDefaultContentType?: boolean;
+    };
+
+export interface SignedS3StorageAdapterOptions {
+  signingEndpoint: string;
+  signingMethod?: string;
+  signingHeaders?: Record<string, string>;
+  signingPayload?: Record<string, unknown>;
+  uploadMethod?: string;
+  uploadHeaders?: Record<string, string>;
+  fetchImplementation?: typeof fetch;
+  serialize?: (
+    records: TelemetryAuditEntry[],
+    context: { retentionPolicy?: NormalizedRetentionPolicy }
+  ) => string | object | ArrayBuffer | ArrayBufferView | Blob;
+  retentionPolicy?: RemoteStorageRetentionPolicy;
+  encryptPayload?: (
+    payload: string | ArrayBuffer | ArrayBufferView | Blob,
+    context: EncryptPayloadContext
+  ) => Promise<EncryptPayloadResult> | EncryptPayloadResult;
+  encryptionContentType?: string;
+  onUploadComplete?: (info: {
+    key?: string;
+    location?: string;
+    recordCount: number;
+    retentionPolicy?: NormalizedRetentionPolicy;
+    encryptionMetadata?: Record<string, unknown>;
+  }) => void;
+  onError?: (error: Error) => void;
+  deleteEndpoint?: string;
+  deleteMethod?: string;
+}
+
+export interface LogBrokerStorageAdapterOptions {
+  endpoint: string;
+  method?: string;
+  headers?: Record<string, string>;
+  fetchImplementation?: typeof fetch;
+  serialize?: (
+    records: TelemetryAuditEntry[],
+    context: { retentionPolicy?: NormalizedRetentionPolicy }
+  ) => string | object | ArrayBuffer | ArrayBufferView | Blob;
+  retentionPolicy?: RemoteStorageRetentionPolicy;
+  encryptPayload?: (
+    payload: string | ArrayBuffer | ArrayBufferView | Blob,
+    context: EncryptPayloadContext
+  ) => Promise<EncryptPayloadResult> | EncryptPayloadResult;
+  encryptionContentType?: string;
+  onError?: (error: Error) => void;
+}
+
+export interface RemoteStorageAdapter {
+  write(records: TelemetryAuditEntry[]): Promise<void>;
+  clear(): Promise<void | undefined>;
+  read(): Promise<TelemetryAuditEntry[]>;
+}
+
+export class LicenseAttestationProfileRegistry {
+  constructor(options?: { defaultProfileId?: string });
+  hasProfile(id: string): boolean;
+  registerProfile(
+    profile: LicenseAttestationProfile | string,
+    options?: Omit<LicenseAttestationProfile, 'id'>
+  ): LicenseAttestationProfile;
+  registerProfiles(profiles: LicenseAttestationProfile[]): LicenseAttestationProfile[];
+  getProfile(id: string): LicenseAttestationProfile | null;
+  getProfiles(): LicenseAttestationProfile[];
+  setDefaultProfile(id: string): void;
+  getDefaultProfileId(): string | null;
+  clearDefaultProfile(): void;
+  removeProfile(id: string): void;
+  createAttestor(
+    profileId?: string,
+    overrides?: LicenseAttestorProfileOverrides
+  ): LicenseAttestationProfileBindingResult;
+}
+
+export class LicenseManager {
+  constructor(options?: LicenseManagerOptions);
+  setLicense(license: LicenseDetails | null): LicenseStatus;
+  clearLicense(): LicenseStatus;
+  getLicense(): LicenseDetails | null;
+  validate(context?: Record<string, unknown>): Promise<LicenseStatus>;
+  registerValidator(validator: LicenseValidator): () => void;
+  onStatusChange(listener: (status: LicenseStatus) => void): () => void;
+  getStatus(): LicenseStatus;
+  getValidationHistory(): Array<{ status: LicenseStatus; timestamp: string }>;
+  hasFeature(feature: string): boolean;
+  requireFeature(feature: string): void;
+  isActive(): boolean;
+}
+
+export class RemoteLicenseAttestor {
+  constructor(options?: RemoteLicenseAttestorOptions);
+  getHistory(): Array<{ timestamp: string; entry: RemoteLicenseAttestationSummary }>;
+  getLastResult(): RemoteLicenseAttestationSummary | null;
+  createValidator(): LicenseValidator;
+  bindToLicenseManager(manager: LicenseManager, options?: Record<string, unknown>): () => void;
+  detach(): void;
+  on<TEvent extends keyof RemoteLicenseAttestorEvents>(event: TEvent, listener: (payload: RemoteLicenseAttestorEvents[TEvent]) => void): () => void;
+  off<TEvent extends keyof RemoteLicenseAttestorEvents>(event: TEvent, listener: (payload: RemoteLicenseAttestorEvents[TEvent]) => void): void;
+}
+
+export class LicenseCommercializationReporter {
+  constructor(options?: LicenseCommercializationReporterOptions);
+  recordPackRegistration(pack: Record<string, unknown>, context?: Record<string, unknown>): void;
+  recordProfileRegistration(profile: LicenseAttestationProfile | Record<string, unknown>, context?: Record<string, unknown>): void;
+  recordProfileApplied(profile: LicenseAttestationProfile | Record<string, unknown>, context?: Record<string, unknown>): void;
+  recordDefaultProfileChange(profileId: string | null, context?: Record<string, unknown>): void;
+  getPackIdForProfile(profileId: string): string | null;
+  getSummary(): LicenseCommercializationSummary;
+  addUpdateListener(listener: (summary: LicenseCommercializationSummary) => void): () => void;
+  removeUpdateListener(listener: (summary: LicenseCommercializationSummary) => void): void;
+}
+
+export interface LicenseCommercializationSnapshotQueryOptions {
+  limit?: number;
+  withSummary?: boolean;
+}
+
+export interface LicenseCommercializationSnapshotExportOptions {
+  format?: 'object' | 'json' | 'csv';
+  includeSummary?: boolean;
+  pretty?: boolean;
+}
+
+export class LicenseCommercializationSnapshotStore {
+  constructor(options?: LicenseCommercializationSnapshotStoreOptions);
+  recordSnapshot(summary: LicenseCommercializationSummary | LicenseCommercializationReporter, context?: Record<string, unknown>): LicenseCommercializationSnapshot;
+  getSnapshots(options?: LicenseCommercializationSnapshotQueryOptions): LicenseCommercializationSnapshot[];
+  getLatestSnapshot(): LicenseCommercializationSnapshot | null;
+  getKpiReport(options?: { limit?: number }): LicenseCommercializationKpiReport;
+  exportForBi(options?: LicenseCommercializationSnapshotExportOptions): string | Record<string, unknown> | null;
+  clearSnapshots(): void;
+  whenReady(): Promise<LicenseCommercializationSnapshot[]>;
+}
+
+export function createInMemoryCommercializationSnapshotStorage(initial?: LicenseCommercializationSnapshot[]): LicenseCommercializationSnapshotStorage;
+
+export function createCommercializationSnapshotRemoteStorage(
+  options: CommercializationSnapshotRemoteStorageOptions
+): LicenseCommercializationSnapshotStorage;
+
+export function createSignedS3CommercializationSnapshotStorage(
+  options: SignedS3CommercializationSnapshotStorageOptions
+): LicenseCommercializationSnapshotStorage;
+
+export function createLogBrokerCommercializationSnapshotStorage(
+  options: LogBrokerCommercializationSnapshotStorageOptions
+): LicenseCommercializationSnapshotStorage;
+
+export function createCommercializationSnapshotPayload(
+  snapshots: LicenseCommercializationSnapshot[],
+  context?: Record<string, unknown>
+): Record<string, unknown>;
+
+declare module './src/core/AdaptiveSDK.js' {
+  export function createAdaptiveSDK(config?: AdaptiveSDKConfig): AdaptiveSDK;
+}
+
+declare module '../src/core/AdaptiveSDK.js' {
+  export function createAdaptiveSDK(config?: AdaptiveSDKConfig): AdaptiveSDK;
+}
+
+declare module './src/ui/components/ConsentPanel.js' {
+  export function createConsentPanel(options?: ConsentPanelOptions): ConsentPanelApi;
+}
+
+declare module '../src/ui/components/ConsentPanel.js' {
+  export function createConsentPanel(options?: ConsentPanelOptions): ConsentPanelApi;
+}
+
+declare module './src/ui/adaptive/renderers/LayoutBlueprintRenderer.js' {
+  export {
+    LayoutBlueprintRenderer,
+    createLayoutBlueprintRenderer,
+    buildLayoutBlueprint,
+    LayoutBlueprintRendererOptions,
+    LayoutBlueprint,
+    LayoutBlueprintZoneSummary,
+    LayoutBlueprintMotion,
+    LayoutBlueprintMotionBias,
+  };
+}
+
+declare module '../src/ui/adaptive/renderers/LayoutBlueprintRenderer.js' {
+  export {
+    LayoutBlueprintRenderer,
+    createLayoutBlueprintRenderer,
+    buildLayoutBlueprint,
+    LayoutBlueprintRendererOptions,
+    LayoutBlueprint,
+    LayoutBlueprintZoneSummary,
+    LayoutBlueprintMotion,
+    LayoutBlueprintMotionBias,
+  };
+}
+
+declare module './src/ui/adaptive/renderers/ProjectionFieldComposer.js' {
+  export {
+    ProjectionFieldComposer,
+    createProjectionFieldComposer,
+    composeProjectionField,
+    ProjectionFieldComposerOptions,
+    ProjectionFieldComposition,
+    ProjectionFieldFocusHalo,
+    ProjectionFieldDepthBand,
+    ProjectionFieldGestureContour,
+    ProjectionFieldInteractionLobe,
+    ProjectionFieldAnnotationSummary,
+    ProjectionComposerOptions,
+  };
+}
+
+declare module '../src/ui/adaptive/renderers/ProjectionFieldComposer.js' {
+  export {
+    ProjectionFieldComposer,
+    createProjectionFieldComposer,
+    composeProjectionField,
+    ProjectionFieldComposerOptions,
+    ProjectionFieldComposition,
+    ProjectionFieldFocusHalo,
+    ProjectionFieldDepthBand,
+    ProjectionFieldGestureContour,
+    ProjectionFieldInteractionLobe,
+    ProjectionFieldAnnotationSummary,
+    ProjectionComposerOptions,
+  };
+}
+
+declare module './src/ui/adaptive/simulators/ProjectionScenarioSimulator.js' {
+  export {
+    ProjectionScenarioSimulator,
+    ProjectionScenarioSimulatorOptions,
+    ProjectionScenarioDescriptor,
+    ProjectionScenarioFrame,
+    ProjectionScenarioFrameAnchor,
+    ProjectionScenarioModulation,
+    ProjectionScenarioBlueprintModulation,
+    ProjectionScenarioContextModulation,
+    ProjectionScenarioAnchor,
+  };
+}
+
+declare module '../src/ui/adaptive/simulators/ProjectionScenarioSimulator.js' {
+  export {
+    ProjectionScenarioSimulator,
+    ProjectionScenarioSimulatorOptions,
+    ProjectionScenarioDescriptor,
+    ProjectionScenarioFrame,
+    ProjectionScenarioFrameAnchor,
+    ProjectionScenarioModulation,
+    ProjectionScenarioBlueprintModulation,
+    ProjectionScenarioContextModulation,
+    ProjectionScenarioAnchor,
+  };
+}
+
+declare module './src/product/telemetry/storage/RemoteStorageAdapters.js' {
+  export function createSignedS3StorageAdapter(options: SignedS3StorageAdapterOptions): RemoteStorageAdapter;
+  export function createLogBrokerStorageAdapter(options: LogBrokerStorageAdapterOptions): RemoteStorageAdapter;
+}
+
+declare module '../src/product/telemetry/storage/RemoteStorageAdapters.js' {
+  export function createSignedS3StorageAdapter(options: SignedS3StorageAdapterOptions): RemoteStorageAdapter;
+  export function createLogBrokerStorageAdapter(options: LogBrokerStorageAdapterOptions): RemoteStorageAdapter;
+}
+
+declare module './src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js' {
+  export {
+    createCommercializationSnapshotRemoteStorage,
+    createSignedS3CommercializationSnapshotStorage,
+    createLogBrokerCommercializationSnapshotStorage,
+    createCommercializationSnapshotPayload,
+    CommercializationSnapshotRemoteStorageOptions,
+    SignedS3CommercializationSnapshotStorageOptions,
+    LogBrokerCommercializationSnapshotStorageOptions,
+    CommercializationSnapshotTransform,
+    CommercializationSnapshotTransformContext
+  };
+}
+
+declare module '../src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js' {
+  export {
+    createCommercializationSnapshotRemoteStorage,
+    createSignedS3CommercializationSnapshotStorage,
+    createLogBrokerCommercializationSnapshotStorage,
+    createCommercializationSnapshotPayload,
+    CommercializationSnapshotRemoteStorageOptions,
+    SignedS3CommercializationSnapshotStorageOptions,
+    LogBrokerCommercializationSnapshotStorageOptions,
+    CommercializationSnapshotTransform,
+    CommercializationSnapshotTransformContext
+  };
+}
+
+declare module './src/product/licensing/LicenseManager.js' {
+  export {
+    LicenseManager,
+    LicenseManagerOptions,
+    LicenseStatus,
+    LicenseDetails,
+    LicenseValidator,
+    RemoteLicenseAttestor,
+    RemoteLicenseAttestorOptions,
+    RemoteLicenseAttestationSummary,
+    RemoteLicenseAttestorBindingOptions,
+    LicenseAttestationProfileRegistry,
+    LicenseAttestationProfile,
+    LicenseAttestationProfileBindingResult,
+    LicenseAttestationProfileSLA,
+    LicenseAttestorProfileOverrides,
+    LicenseAttestationProfilePackOptions,
+    LicenseAttestationProfilePackDescriptor,
+    LicenseAttestationProfilePackConfig,
+    LicenseAttestationProfilePackResult,
+    LicenseCommercializationReporter,
+    LicenseCommercializationSummary,
+    LicenseCommercializationOptions,
+    LicenseCommercializationReporterOptions,
+    LicenseCommercializationPackSummary,
+    LicenseCommercializationProfileSummary,
+    LicenseCommercializationSegmentSummary,
+    LicenseCommercializationRegionSummary,
+    LicenseCommercializationSLASummary,
+    LicenseCommercializationMetricSummary,
+    LicenseCommercializationSnapshot,
+    LicenseCommercializationSnapshotKpis,
+    LicenseCommercializationKpiReport,
+    LicenseCommercializationSnapshotQueryOptions,
+    LicenseCommercializationSnapshotExportOptions,
+    LicenseCommercializationSnapshotStore,
+    LicenseCommercializationSnapshotStoreOptions,
+    LicenseCommercializationSnapshotStorage,
+    CommercializationSnapshotRemoteStorageOptions,
+    SignedS3CommercializationSnapshotStorageOptions,
+    LogBrokerCommercializationSnapshotStorageOptions,
+    CommercializationSnapshotTransform,
+    CommercializationSnapshotTransformContext,
+    createInMemoryCommercializationSnapshotStorage,
+    createCommercializationSnapshotRemoteStorage,
+    createSignedS3CommercializationSnapshotStorage,
+    createLogBrokerCommercializationSnapshotStorage,
+    createCommercializationSnapshotPayload
+  };
+}
+
+declare module '../src/product/licensing/LicenseManager.js' {
+  export {
+    LicenseManager,
+    LicenseManagerOptions,
+    LicenseStatus,
+    LicenseDetails,
+    LicenseValidator,
+    RemoteLicenseAttestor,
+    RemoteLicenseAttestorOptions,
+    RemoteLicenseAttestationSummary,
+    RemoteLicenseAttestorBindingOptions,
+    LicenseAttestationProfileRegistry,
+    LicenseAttestationProfile,
+    LicenseAttestationProfileBindingResult,
+    LicenseAttestationProfileSLA,
+    LicenseAttestorProfileOverrides,
+    LicenseAttestationProfilePackOptions,
+    LicenseAttestationProfilePackDescriptor,
+    LicenseAttestationProfilePackConfig,
+    LicenseAttestationProfilePackResult,
+    LicenseCommercializationReporter,
+    LicenseCommercializationSummary,
+    LicenseCommercializationOptions,
+    LicenseCommercializationReporterOptions,
+    LicenseCommercializationPackSummary,
+    LicenseCommercializationProfileSummary,
+    LicenseCommercializationSegmentSummary,
+    LicenseCommercializationRegionSummary,
+    LicenseCommercializationSLASummary,
+    LicenseCommercializationMetricSummary,
+    LicenseCommercializationSnapshot,
+    LicenseCommercializationSnapshotKpis,
+    LicenseCommercializationKpiReport,
+    LicenseCommercializationSnapshotQueryOptions,
+    LicenseCommercializationSnapshotExportOptions,
+    LicenseCommercializationSnapshotStore,
+    LicenseCommercializationSnapshotStoreOptions,
+    LicenseCommercializationSnapshotStorage,
+    CommercializationSnapshotRemoteStorageOptions,
+    SignedS3CommercializationSnapshotStorageOptions,
+    LogBrokerCommercializationSnapshotStorageOptions,
+    CommercializationSnapshotTransform,
+    CommercializationSnapshotTransformContext,
+    createInMemoryCommercializationSnapshotStorage,
+    createCommercializationSnapshotRemoteStorage,
+    createSignedS3CommercializationSnapshotStorage,
+    createLogBrokerCommercializationSnapshotStorage,
+    createCommercializationSnapshotPayload
+  };
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/vitest/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html']
+    }
+  }
+});

--- a/wearable-designer.html
+++ b/wearable-designer.html
@@ -1,0 +1,1568 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VIB34D Adaptive Wearable Designer</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: radial-gradient(circle at 20% 20%, #101826, #04060b 65%);
+            --panel-bg: rgba(12, 18, 32, 0.85);
+            --accent: #4c9fff;
+            --muted: rgba(255, 255, 255, 0.55);
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Inter', system-ui;
+            background: var(--bg);
+            color: #f5f7fb;
+            height: 100vh;
+            display: grid;
+            grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.6fr);
+        }
+
+        .canvas-stack {
+            position: relative;
+            display: grid;
+            place-items: center;
+            overflow: hidden;
+        }
+
+        .canvas-stack canvas {
+            position: absolute;
+            width: 88vmin;
+            height: 88vmin;
+            max-width: 880px;
+            max-height: 880px;
+            border-radius: 28px;
+            backdrop-filter: blur(20px);
+        }
+
+        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.35; }
+        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.45; }
+        .canvas-stack canvas:nth-child(3) { mix-blend-mode: normal; }
+        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.6; }
+        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.8; }
+
+        aside {
+            padding: 32px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            background: linear-gradient(160deg, rgba(8, 10, 20, 0.9), rgba(12, 18, 32, 0.75));
+            border-left: 1px solid rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(24px);
+        }
+
+        .panel {
+            background: var(--panel-bg);
+            border-radius: 20px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            box-shadow: 0 20px 40px rgba(10, 20, 40, 0.35);
+        }
+
+        .panel h2 {
+            font-size: 1rem;
+            letter-spacing: 0.08em;
+            margin: 0 0 12px;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .metric-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .metric {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            background: rgba(255, 255, 255, 0.03);
+            padding: 12px 14px;
+            border-radius: 14px;
+        }
+
+        .metric span:first-child {
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+            color: var(--muted);
+        }
+
+        .metric span:last-child {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        .blueprint-metrics {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .blueprint-metric {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .blueprint-metric span:first-child {
+            font-size: 0.7rem;
+            letter-spacing: 0.06em;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .blueprint-metric span:last-child {
+            font-size: 1rem;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.92);
+        }
+
+        .blueprint-zone-list {
+            display: grid;
+            gap: 10px;
+            margin: 0 0 16px;
+            padding: 0;
+            list-style: none;
+        }
+
+        .blueprint-zone {
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 12px;
+            padding: 10px 12px;
+        }
+
+        .blueprint-zone strong {
+            display: block;
+            font-size: 0.82rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.76);
+        }
+
+        .blueprint-zone span {
+            display: block;
+            font-size: 0.7rem;
+            color: rgba(255, 255, 255, 0.55);
+            margin-top: 4px;
+            letter-spacing: 0.03em;
+        }
+
+        .meta-line {
+            font-size: 0.68rem;
+            letter-spacing: 0.08em;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+        }
+
+        .empty-state {
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.55);
+            padding: 12px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.03);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .pack-list {
+            display: grid;
+            gap: 12px;
+            margin-top: 14px;
+        }
+
+        .pack-card {
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 14px;
+            padding: 14px 16px;
+            display: grid;
+            gap: 6px;
+        }
+
+        .pack-card h3 {
+            margin: 0;
+            font-size: 0.95rem;
+            color: #fff;
+        }
+
+        .pack-card p {
+            margin: 0;
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.65);
+        }
+
+        .pack-card .meta {
+            font-size: 0.68rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.5);
+        }
+
+        .snapshot-controls {
+            display: flex;
+            gap: 8px;
+            margin-top: 18px;
+        }
+
+        .snapshot-controls button {
+            flex: 1;
+            background: rgba(76, 159, 255, 0.15);
+            border: 1px solid rgba(76, 159, 255, 0.45);
+            color: #f5f7fb;
+            border-radius: 12px;
+            padding: 10px 14px;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            cursor: pointer;
+        }
+
+        .snapshot-controls button:hover {
+            background: rgba(76, 159, 255, 0.3);
+        }
+
+        .kpi-summary {
+            margin-top: 16px;
+            display: grid;
+            gap: 8px;
+        }
+
+        .snapshot-list {
+            margin-top: 16px;
+            display: grid;
+            gap: 8px;
+        }
+
+        .remote-storage {
+            margin-top: 20px;
+            padding: 14px 16px;
+            border-radius: 16px;
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            display: grid;
+            gap: 12px;
+        }
+
+        .remote-storage .remote-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+        }
+
+        .remote-storage h3 {
+            margin: 0;
+            font-size: 0.9rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .remote-log {
+            display: grid;
+            gap: 8px;
+        }
+
+        .remote-log-entry {
+            background: rgba(12, 20, 34, 0.65);
+            border-radius: 12px;
+            padding: 10px 12px;
+            display: grid;
+            gap: 4px;
+            border: 1px solid rgba(76, 159, 255, 0.18);
+        }
+
+        .remote-log-entry strong {
+            font-size: 0.78rem;
+            letter-spacing: 0.05em;
+        }
+
+        .remote-log-entry span {
+            font-size: 0.72rem;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .remote-log-entry--error {
+            border-color: rgba(255, 90, 90, 0.45);
+            background: rgba(38, 12, 18, 0.7);
+        }
+
+        .remote-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        .remote-actions button {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            border-radius: 10px;
+            padding: 8px 12px;
+            color: #f5f7fb;
+            font-size: 0.7rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            cursor: pointer;
+        }
+
+        .remote-actions button:hover {
+            background: rgba(255, 255, 255, 0.12);
+        }
+
+        .snapshot-item {
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 12px;
+            padding: 10px 12px;
+            display: grid;
+            gap: 4px;
+        }
+
+        .snapshot-item strong {
+            font-size: 0.78rem;
+            letter-spacing: 0.05em;
+        }
+
+        .snapshot-item span {
+            font-size: 0.7rem;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .pattern-card {
+            display: grid;
+            gap: 12px;
+        }
+
+        .pattern-card h3 {
+            margin: 0;
+            font-size: 1.2rem;
+        }
+
+        .pattern-card p {
+            margin: 0;
+            color: rgba(255, 255, 255, 0.65);
+            line-height: 1.4;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            padding: 6px 10px;
+            border-radius: 999px;
+            background: rgba(76, 159, 255, 0.1);
+            color: var(--accent);
+        }
+
+        button {
+            background: rgba(76, 159, 255, 0.1);
+            border: 1px solid rgba(76, 159, 255, 0.3);
+            color: var(--accent);
+            padding: 12px 16px;
+            border-radius: 14px;
+            font-size: 0.85rem;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: rgba(76, 159, 255, 0.2);
+        }
+
+        .variation-controls {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .variation-controls input[type="range"] {
+            width: 100%;
+        }
+
+        .consent-grid {
+            display: grid;
+            gap: 12px;
+        }
+
+        .consent-toggle {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            background: rgba(255, 255, 255, 0.03);
+            padding: 12px 14px;
+            border-radius: 14px;
+        }
+
+        .consent-toggle div {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .consent-toggle span {
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .consent-toggle small {
+            font-size: 0.7rem;
+            color: rgba(255, 255, 255, 0.5);
+            letter-spacing: 0.03em;
+        }
+
+        .consent-toggle input[type="checkbox"] {
+            width: 20px;
+            height: 20px;
+            accent-color: var(--accent);
+        }
+
+        .consent-status {
+            margin-top: 14px;
+            font-size: 0.78rem;
+            color: rgba(255, 255, 255, 0.65);
+            line-height: 1.5;
+        }
+
+        .consent-status strong {
+            color: var(--accent);
+        }
+
+        .compliance-log {
+            list-style: none;
+            margin: 18px 0 0;
+            padding: 0;
+            display: grid;
+            gap: 10px;
+        }
+
+        .compliance-log li {
+            background: rgba(255, 255, 255, 0.03);
+            padding: 10px 12px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.78);
+        }
+
+        .compliance-log li span {
+            display: block;
+            margin-top: 4px;
+            font-size: 0.68rem;
+            color: rgba(255, 255, 255, 0.5);
+            letter-spacing: 0.04em;
+        }
+
+        .panel button.secondary {
+            background: rgba(255, 255, 255, 0.05);
+            border-color: rgba(255, 255, 255, 0.12);
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .panel button.secondary:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+
+        .projection-stack {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            margin-bottom: 16px;
+            border-radius: 16px;
+            background: rgba(255, 255, 255, 0.02);
+            overflow: hidden;
+            border: 1px solid rgba(255, 255, 255, 0.04);
+        }
+
+        .projection-stack canvas {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .projection-metrics {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+            margin-bottom: 14px;
+        }
+
+        .projection-metric {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            background: rgba(255, 255, 255, 0.03);
+            padding: 10px 12px;
+            border-radius: 12px;
+        }
+
+        .projection-metric span:first-child {
+            font-size: 0.7rem;
+            letter-spacing: 0.05em;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .projection-metric span:last-child {
+            font-size: 1rem;
+            font-weight: 600;
+            color: rgba(76, 159, 255, 0.9);
+        }
+
+        .projection-controls {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 14px;
+        }
+
+        .projection-controls select {
+            flex: 1;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            color: rgba(255, 255, 255, 0.9);
+            border-radius: 12px;
+            padding: 8px 10px;
+            font-size: 0.85rem;
+        }
+
+        .projection-controls button {
+            white-space: nowrap;
+        }
+
+        .projection-legend {
+            display: grid;
+            gap: 10px;
+        }
+
+        .projection-legend-item {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .projection-legend-item strong {
+            font-size: 0.78rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.76);
+        }
+
+        .projection-legend-item span {
+            font-size: 0.7rem;
+            color: rgba(255, 255, 255, 0.55);
+            letter-spacing: 0.03em;
+        }
+    </style>
+</head>
+<body>
+    <div class="canvas-stack" id="canvasStack">
+        <canvas id="background-canvas"></canvas>
+        <canvas id="shadow-canvas"></canvas>
+        <canvas id="content-canvas"></canvas>
+        <canvas id="highlight-canvas"></canvas>
+        <canvas id="accent-canvas"></canvas>
+    </div>
+    <aside>
+        <section class="panel">
+            <h2>Adaptive Intent</h2>
+            <div class="metric-grid" id="intentMetrics">
+                <div class="metric"><span>Focus</span><span id="focusMetric">0.50</span></div>
+                <div class="metric"><span>Engagement</span><span id="engagementMetric">0.40</span></div>
+                <div class="metric"><span>Velocity</span><span id="velocityMetric">0.00</span></div>
+                <div class="metric"><span>Stress</span><span id="stressMetric">0.20</span></div>
+            </div>
+        </section>
+        <section class="panel">
+            <h2>Pattern Activation</h2>
+            <div class="pattern-card">
+                <span class="tag" id="patternTier">STARTER</span>
+                <h3 id="patternName">Neuro Glance Feed</h3>
+                <p id="patternDescription">Micro-summaries that respond to attention bursts and biometric calmness.</p>
+                <div class="tag" id="integrationTag">Figma: vib34d-neuro-glance-feed</div>
+            </div>
+        </section>
+        <section class="panel">
+            <h2>Adaptive Blueprint</h2>
+            <div class="blueprint-metrics">
+                <div class="blueprint-metric"><span>Intensity</span><span id="blueprintIntensity">0.50</span></div>
+                <div class="blueprint-metric"><span>Velocity</span><span id="blueprintVelocity">0.00</span></div>
+                <div class="blueprint-metric"><span>Engagement</span><span id="blueprintEngagement">0.40</span></div>
+                <div class="blueprint-metric"><span>Stress</span><span id="blueprintStress">0.20</span></div>
+            </div>
+            <ul class="blueprint-zone-list" id="blueprintZoneList"></ul>
+            <button class="secondary" id="downloadBlueprintBtn" type="button">Download Blueprint</button>
+        </section>
+        <section class="panel" id="projectionPanel">
+            <h2>4D Projection Field</h2>
+            <div class="projection-stack" id="projectionStack">
+                <canvas id="projection-base"></canvas>
+                <canvas id="projection-bands"></canvas>
+                <canvas id="projection-halo"></canvas>
+                <canvas id="projection-contours"></canvas>
+            </div>
+            <div class="projection-metrics">
+                <div class="projection-metric"><span>Halo Radius</span><span id="projectionHaloRadius">--</span></div>
+                <div class="projection-metric"><span>Depth Bias</span><span id="projectionDepthBias">--</span></div>
+                <div class="projection-metric"><span>Contours</span><span id="projectionContourCount">--</span></div>
+                <div class="projection-metric"><span>Field Density</span><span id="projectionFieldDensity">--</span></div>
+            </div>
+            <div class="projection-controls">
+                <select id="projectionScenarioSelect" aria-label="Projection scenario"></select>
+                <button id="projectionSimulateBtn" type="button">Advance Cycle</button>
+            </div>
+            <div class="projection-legend" id="projectionLegend"></div>
+        </section>
+        <section class="panel">
+            <h2>Variations</h2>
+            <div class="variation-controls">
+                <input type="range" min="0" max="99" value="0" id="variationSlider">
+                <button id="randomizeBtn">Randomize</button>
+            </div>
+            <p style="margin-top: 12px; color: rgba(255,255,255,0.6); font-size: 0.85rem;" id="variationLabel">1 - TETRAHEDRON LATTICE</p>
+        </section>
+        <section class="panel" id="telemetryConsentPanel"></section>
+        <section class="panel" id="commercializationPanel">
+            <h2>Commercialization Coverage</h2>
+            <p class="meta-line" id="commercializationUpdated" style="margin: 0 0 12px;"></p>
+            <div class="metric-grid" id="segmentCoverageGrid"></div>
+            <div class="metric-grid" id="regionCoverageGrid" style="margin-top: 12px;"></div>
+            <div class="pack-list" id="commercializationPackList"></div>
+            <div class="snapshot-controls">
+                <button id="captureSnapshotBtn" type="button">Capture Snapshot</button>
+                <button id="exportSnapshotsBtn" type="button">Download KPI Export</button>
+            </div>
+            <div class="kpi-summary" id="commercializationKpiSummary"></div>
+            <div class="snapshot-list" id="commercializationSnapshotList"></div>
+            <div class="remote-storage" id="commercializationRemoteStatus">
+                <div class="remote-header">
+                    <h3>Remote Persistence</h3>
+                    <span class="meta-line" id="commercializationRemoteLastUpload">No remote uploads yet</span>
+                </div>
+                <div class="remote-log" id="commercializationRemoteLog"></div>
+                <div class="remote-actions">
+                    <button id="clearRemoteLogBtn" type="button">Reset Remote Log</button>
+                </div>
+            </div>
+        </section>
+    </aside>
+
+    <script type="module">
+        import { createAdaptiveSDK } from './src/core/AdaptiveSDK.js';
+        import { LayoutAnnotation } from './src/ui/adaptive/annotations/LayoutAnnotation.js';
+        import { ComplianceVaultTelemetryProvider } from './src/product/telemetry/ComplianceVaultTelemetryProvider.js';
+        import { createConsentPanel } from './src/ui/components/ConsentPanel.js';
+        import { createCommercializationSnapshotRemoteStorage } from './src/product/licensing/storage/CommercializationSnapshotStorageAdapters.js';
+        import { createLayoutBlueprintRenderer, buildLayoutBlueprint } from './src/ui/adaptive/renderers/LayoutBlueprintRenderer.js';
+
+        const complianceVaultProvider = new ComplianceVaultTelemetryProvider({ maxRecords: 24 });
+        let consentPanel;
+
+        const segmentCoverageGrid = document.getElementById('segmentCoverageGrid');
+        const regionCoverageGrid = document.getElementById('regionCoverageGrid');
+        const commercializationPackList = document.getElementById('commercializationPackList');
+        const commercializationUpdated = document.getElementById('commercializationUpdated');
+        const captureSnapshotBtn = document.getElementById('captureSnapshotBtn');
+        const exportSnapshotsBtn = document.getElementById('exportSnapshotsBtn');
+        const snapshotList = document.getElementById('commercializationSnapshotList');
+        const commercializationKpiSummary = document.getElementById('commercializationKpiSummary');
+        const remoteLastUpload = document.getElementById('commercializationRemoteLastUpload');
+        const remoteLogContainer = document.getElementById('commercializationRemoteLog');
+        const clearRemoteLogBtn = document.getElementById('clearRemoteLogBtn');
+        const blueprintIntensity = document.getElementById('blueprintIntensity');
+        const blueprintVelocity = document.getElementById('blueprintVelocity');
+        const blueprintEngagement = document.getElementById('blueprintEngagement');
+        const blueprintStress = document.getElementById('blueprintStress');
+        const blueprintZoneList = document.getElementById('blueprintZoneList');
+        const downloadBlueprintBtn = document.getElementById('downloadBlueprintBtn');
+        const projectionHaloRadius = document.getElementById('projectionHaloRadius');
+        const projectionDepthBias = document.getElementById('projectionDepthBias');
+        const projectionContourCount = document.getElementById('projectionContourCount');
+        const projectionFieldDensity = document.getElementById('projectionFieldDensity');
+        const projectionScenarioSelect = document.getElementById('projectionScenarioSelect');
+        const projectionSimulateBtn = document.getElementById('projectionSimulateBtn');
+        const projectionLegend = document.getElementById('projectionLegend');
+
+        let adaptiveSDKRef;
+        let stopSnapshotSchedule = null;
+
+        const remoteUploadLog = [];
+        let latestBlueprint = null;
+        let latestProjectionComposition = null;
+        let activeProjectionScenario = '__realtime__';
+
+        const formatTime = (value) => {
+            if (!value) return 'unknown';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return 'unknown';
+            return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        };
+
+        const formatDateTime = (value) => {
+            if (!value) return 'unknown';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return 'unknown';
+            return date.toLocaleString([], { hour: '2-digit', minute: '2-digit' });
+        };
+
+        function renderRemoteStorageStatus() {
+            if (!remoteLogContainer || !remoteLastUpload) {
+                return;
+            }
+
+            if (remoteUploadLog.length === 0) {
+                remoteLastUpload.textContent = 'No remote uploads yet';
+                remoteLogContainer.innerHTML = '<div class="empty-state">Remote storage will sync after the next KPI capture</div>';
+                return;
+            }
+
+            const latestUpload = remoteUploadLog.find(entry => entry.type === 'upload');
+            if (latestUpload) {
+                remoteLastUpload.textContent = `Last remote upload ${formatTime(latestUpload.exportedAt)}`;
+            } else {
+                const latest = remoteUploadLog[0];
+                remoteLastUpload.textContent = `Last remote attempt ${formatTime(latest.exportedAt || latest.occurredAt)}`;
+            }
+
+            remoteLogContainer.innerHTML = '';
+            for (const entry of remoteUploadLog) {
+                const card = document.createElement('div');
+                card.className = `remote-log-entry remote-log-entry--${entry.type}`;
+
+                const title = document.createElement('strong');
+                if (entry.type === 'upload') {
+                    title.textContent = `Uploaded ${entry.recordCount} snapshot${entry.recordCount === 1 ? '' : 's'}`;
+                } else {
+                    title.textContent = 'Upload error';
+                }
+                card.appendChild(title);
+
+                const meta = document.createElement('span');
+                meta.className = 'meta-line';
+                meta.textContent = formatDateTime(entry.exportedAt || entry.occurredAt);
+                card.appendChild(meta);
+
+                if (entry.type === 'upload' && entry.snapshotIds?.length) {
+                    const detail = document.createElement('span');
+                    detail.textContent = `Snapshots: ${entry.snapshotIds.join(', ')}`;
+                    card.appendChild(detail);
+                } else if (entry.type === 'error' && entry.message) {
+                    const detail = document.createElement('span');
+                    detail.textContent = entry.message;
+                    card.appendChild(detail);
+                }
+
+                remoteLogContainer.appendChild(card);
+            }
+        }
+
+        function pushRemoteLog(entry) {
+            remoteUploadLog.unshift(entry);
+            if (remoteUploadLog.length > 6) {
+                remoteUploadLog.length = 6;
+            }
+            renderRemoteStorageStatus();
+        }
+
+        const remoteStorageAdapter = {
+            async write(records) {
+                await new Promise(resolve => setTimeout(resolve, 80));
+                const snapshotIds = Array.isArray(records) ? records.map(item => item.id) : [];
+                pushRemoteLog({
+                    type: 'upload',
+                    exportedAt: new Date().toISOString(),
+                    recordCount: snapshotIds.length,
+                    snapshotIds
+                });
+            },
+            async clear() {
+                remoteUploadLog.length = 0;
+                renderRemoteStorageStatus();
+            }
+        };
+
+        const commercializationRemoteStorage = createCommercializationSnapshotRemoteStorage({
+            adapter: remoteStorageAdapter,
+            includeSummary: false,
+            redactContextKeys: ['licenseKey'],
+            onError: error => {
+                pushRemoteLog({
+                    type: 'error',
+                    message: error?.message || 'Remote upload failed',
+                    occurredAt: new Date().toISOString()
+                });
+            }
+        });
+
+        clearRemoteLogBtn?.addEventListener('click', () => {
+            remoteStorageAdapter.clear?.();
+        });
+
+        renderRemoteStorageStatus();
+
+        const blueprintRenderer = createLayoutBlueprintRenderer({
+            layers: {
+                background: document.getElementById('background-canvas'),
+                shadow: document.getElementById('shadow-canvas'),
+                content: document.getElementById('content-canvas'),
+                highlight: document.getElementById('highlight-canvas'),
+                accent: document.getElementById('accent-canvas')
+            }
+        });
+
+        blueprintRenderer.resize();
+        window.addEventListener('resize', () => blueprintRenderer.resize());
+
+        renderBlueprintPanel(null);
+
+        const projectionComposer = adaptiveSDKRef?.projectionComposer || adaptiveSDK.projectionComposer;
+        const projectionBaseCanvas = document.getElementById('projection-base');
+        const projectionBandCanvas = document.getElementById('projection-bands');
+        const projectionHaloCanvas = document.getElementById('projection-halo');
+        const projectionContourCanvas = document.getElementById('projection-contours');
+
+        projectionComposer.attachLayer('base', projectionBaseCanvas);
+        projectionComposer.attachLayer('bands', projectionBandCanvas);
+        projectionComposer.attachLayer('halo', projectionHaloCanvas);
+        projectionComposer.attachLayer('contours', projectionContourCanvas);
+        projectionComposer.observeResize?.();
+        projectionComposer.resize();
+        window.addEventListener('resize', () => projectionComposer.resize());
+
+        renderProjectionPanel(null);
+        initializeProjectionScenarios();
+
+        const formatLabel = (value) => {
+            if (!value) return 'Unspecified';
+            return value.split(/[-_]/g).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+        };
+
+        const clamp = (value, min = 0, max = 1) => {
+            const numeric = Number(value);
+            const resolved = Number.isFinite(numeric) ? numeric : min;
+            return Math.min(max, Math.max(min, resolved));
+        };
+
+        const formatPercent = (value) => `${Math.round(clamp(value, 0, 1) * 100)}%`;
+
+        function renderBlueprintPanel(blueprint) {
+            if (!blueprint) {
+                if (blueprintIntensity) blueprintIntensity.textContent = '--';
+                if (blueprintVelocity) blueprintVelocity.textContent = '--';
+                if (blueprintEngagement) blueprintEngagement.textContent = '--';
+                if (blueprintStress) blueprintStress.textContent = '--';
+                if (blueprintZoneList) {
+                    blueprintZoneList.innerHTML = '<li class="blueprint-zone"><span>Awaiting adaptive update</span></li>';
+                }
+                return;
+            }
+
+            blueprintIntensity.textContent = blueprint.intensity.toFixed(2);
+            blueprintVelocity.textContent = blueprint.motion.velocity.toFixed(2);
+            blueprintEngagement.textContent = blueprint.engagementLevel.toFixed(2);
+            blueprintStress.textContent = blueprint.biometricStress.toFixed(2);
+
+            if (!blueprintZoneList) return;
+            blueprintZoneList.innerHTML = '';
+            if (!Array.isArray(blueprint.zones) || blueprint.zones.length === 0) {
+                blueprintZoneList.innerHTML = '<li class="blueprint-zone"><span>No layout zones registered</span></li>';
+                return;
+            }
+
+            for (const zone of blueprint.zones) {
+                const item = document.createElement('li');
+                item.className = 'blueprint-zone';
+
+                const title = document.createElement('strong');
+                title.textContent = formatLabel(zone.id || 'zone');
+                item.appendChild(title);
+
+                const components = Array.isArray(zone.components) && zone.components.length
+                    ? zone.components.join(', ')
+                    : 'None';
+                const componentLine = document.createElement('span');
+                componentLine.textContent = `Components: ${components}`;
+                item.appendChild(componentLine);
+
+                const metricsLine = document.createElement('span');
+                metricsLine.textContent = `Occupancy ${formatPercent(zone.occupancy)} · Surface ${Math.round(zone.surfaceScore * 100)}`;
+                item.appendChild(metricsLine);
+
+                blueprintZoneList.appendChild(item);
+            }
+        }
+
+        function computeFieldDensity(matrix) {
+            if (!Array.isArray(matrix) || matrix.length === 0) {
+                return 0;
+            }
+            let total = 0;
+            let count = 0;
+            for (const row of matrix) {
+                if (!Array.isArray(row)) continue;
+                for (const value of row) {
+                    total += Number(value) || 0;
+                    count += 1;
+                }
+            }
+            return count === 0 ? 0 : total / count;
+        }
+
+        function renderProjectionPanel(composition, metadata = {}) {
+            latestProjectionComposition = composition || null;
+
+            if (!composition) {
+                if (projectionHaloRadius) projectionHaloRadius.textContent = '--';
+                if (projectionDepthBias) projectionDepthBias.textContent = '--';
+                if (projectionContourCount) projectionContourCount.textContent = '--';
+                if (projectionFieldDensity) projectionFieldDensity.textContent = '--';
+                if (projectionLegend) {
+                    projectionLegend.innerHTML = '<div class="projection-legend-item"><span>Projection field will populate after the next adaptive update.</span></div>';
+                }
+                return;
+            }
+
+            const haloRadius = Number(composition.focusHalo?.radius ?? 0).toFixed(2);
+            const deepestBand = Array.isArray(composition.depthBands) && composition.depthBands.length
+                ? composition.depthBands.reduce((prev, band) => band.depth > prev.depth ? band : prev, composition.depthBands[0])
+                : null;
+            const depthBias = deepestBand ? deepestBand.depth.toFixed(2) : '0.00';
+            const contourCount = Array.isArray(composition.gestureContours) ? composition.gestureContours.length : 0;
+            const density = computeFieldDensity(composition.activationMatrix).toFixed(2);
+
+            if (projectionHaloRadius) projectionHaloRadius.textContent = haloRadius;
+            if (projectionDepthBias) projectionDepthBias.textContent = depthBias;
+            if (projectionContourCount) projectionContourCount.textContent = String(contourCount);
+            if (projectionFieldDensity) projectionFieldDensity.textContent = density;
+
+            if (!projectionLegend) {
+                return;
+            }
+
+            projectionLegend.innerHTML = '';
+
+            const header = document.createElement('div');
+            header.className = 'projection-legend-item';
+            const title = document.createElement('strong');
+            if (metadata.mode === 'scenario') {
+                const progress = Math.round((metadata.progress ?? 0) * 100);
+                title.textContent = `${metadata.scenario || 'Scenario'} · ${progress}%`;
+            } else {
+                title.textContent = 'Realtime Field';
+            }
+            header.appendChild(title);
+
+            const detail = document.createElement('span');
+            if (metadata.mode === 'scenario' && metadata.description) {
+                detail.textContent = metadata.description;
+            } else {
+                detail.textContent = 'Live projection derived from adaptive layout + sensor synthesis.';
+            }
+            header.appendChild(detail);
+            projectionLegend.appendChild(header);
+
+            if (!Array.isArray(composition.interactionLobes) || composition.interactionLobes.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'projection-legend-item';
+                empty.innerHTML = '<span>No interaction lobes detected.</span>';
+                projectionLegend.appendChild(empty);
+                return;
+            }
+
+            const lobes = composition.interactionLobes.slice(0, 4);
+            for (const lobe of lobes) {
+                const item = document.createElement('div');
+                item.className = 'projection-legend-item';
+
+                const label = document.createElement('strong');
+                label.textContent = (lobe.id || 'lobe').toUpperCase();
+                item.appendChild(label);
+
+                const detailLine = document.createElement('span');
+                detailLine.textContent = `Volume ${lobe.volume.toFixed(2)} · Depth ${lobe.layeringDepth.toFixed(2)} · Visibility ${Math.round(lobe.visibility * 100)}%`;
+                item.appendChild(detailLine);
+
+                projectionLegend.appendChild(item);
+            }
+        }
+
+        function initializeProjectionScenarios() {
+            if (!projectionScenarioSelect) {
+                return;
+            }
+
+            const scenarios = [
+                {
+                    id: 'focus-handoff',
+                    name: 'Focus Handoff',
+                    description: 'Gaze shifts from primary to peripheral halo while gestures intensify.',
+                    cycleMs: 9000,
+                    modulation: {
+                        blueprint: {
+                            focusX: { start: 0.45, end: 0.62, easing: 'ease-in-out' },
+                            focusY: { start: 0.48, end: 0.38, easing: 'ease-in-out' },
+                            focusDepth: { start: 0.28, end: 0.46, easing: 'ease-out' },
+                            intensity: { start: 0.42, end: 0.76, easing: 'ease-in' },
+                            zoneOccupancy: [
+                                { id: 'primary', start: 0.55, end: 0.38, easing: 'ease-out' },
+                                { id: 'peripheral', start: 0.32, end: 0.56, easing: 'ease-in' }
+                            ]
+                        },
+                        context: {
+                            gestureIntensity: { start: 0.35, end: 0.68, easing: 'ease-in-out' },
+                            neuralCoherence: { start: 0.42, end: 0.6, easing: 'ease-in' }
+                        }
+                    },
+                    anchors: [
+                        { id: 'entry', label: 'Engage' },
+                        { id: 'handoff', label: 'Peripheral Handoff' },
+                        { id: 'stabilize', label: 'Stabilize' }
+                    ]
+                },
+                {
+                    id: 'calm-recovery',
+                    name: 'Calm Recovery',
+                    description: 'Stress recovery wave that contracts halo radius and redistributes lobes.',
+                    cycleMs: 10500,
+                    modulation: {
+                        blueprint: {
+                            biometricStress: { start: 0.26, end: 0.12, easing: 'ease-out' },
+                            engagementLevel: { start: 0.48, end: 0.64, easing: 'ease-in' },
+                            focusDepth: { start: 0.44, end: 0.3, easing: 'ease-in-out' }
+                        },
+                        context: {
+                            gazeVelocity: { start: 0.48, end: 0.24, easing: 'ease-out' },
+                            hapticFeedback: { start: 0.4, end: 0.22, easing: 'ease-out' },
+                            gestureIntensity: { start: 0.28, end: 0.18, easing: 'ease-out' }
+                        },
+                        composerOptions: { haloFalloff: 0.72 }
+                    },
+                    anchors: [
+                        { id: 'spike', label: 'Stress Spike' },
+                        { id: 'release', label: 'Release' },
+                        { id: 'stability', label: 'Stability' }
+                    ]
+                }
+            ];
+
+            projectionScenarioSelect.innerHTML = '';
+            const realtimeOption = document.createElement('option');
+            realtimeOption.value = '__realtime__';
+            realtimeOption.textContent = 'Realtime Field';
+            projectionScenarioSelect.appendChild(realtimeOption);
+
+            for (const scenario of scenarios) {
+                adaptiveSDK.registerProjectionScenario(scenario);
+                const option = document.createElement('option');
+                option.value = scenario.id;
+                option.textContent = scenario.name;
+                projectionScenarioSelect.appendChild(option);
+            }
+
+            projectionScenarioSelect.value = activeProjectionScenario;
+
+            projectionScenarioSelect.addEventListener('change', event => {
+                activeProjectionScenario = event.target.value || '__realtime__';
+                if (activeProjectionScenario === '__realtime__') {
+                    return;
+                }
+                adaptiveSDK.setActiveProjectionScenario(activeProjectionScenario);
+            });
+
+            projectionSimulateBtn?.addEventListener('click', () => {
+                if (!latestBlueprint) {
+                    return;
+                }
+                if (activeProjectionScenario === '__realtime__') {
+                    const projectionContext = buildProjectionContextFromAdaptive(adaptiveSDK.engine?.sensoryBridge?.getSnapshot?.());
+                    const composition = adaptiveSDK.composeProjectionField(latestBlueprint, null, projectionContext);
+                    adaptiveSDK.projectionComposer.render(latestBlueprint, projectionContext);
+                    renderProjectionPanel(composition, { mode: 'realtime' });
+                    return;
+                }
+                const frame = adaptiveSDK.stepProjectionSimulation({});
+                if (frame?.composition) {
+                    adaptiveSDK.projectionComposer.render(frame.blueprint, frame.context);
+                    renderProjectionPanel(frame.composition, {
+                        mode: 'scenario',
+                        scenario: frame.name,
+                        progress: frame.progress,
+                        description: scenarios.find(item => item.id === frame.id)?.description
+                    });
+                }
+            });
+        }
+
+        function buildProjectionContextFromAdaptive(context = {}) {
+            return {
+                gazeVelocity: context?.focus?.velocity ?? context?.eyeTracking?.velocity ?? 0.35,
+                neuralCoherence: context?.intention?.confidence ?? context?.neural?.coherence ?? 0.4,
+                hapticFeedback: context?.gesture?.haptic ?? 0.32,
+                ambientVariance: context?.environment?.motion ?? 0.28,
+                gestureIntent: {
+                    intensity: context?.gesture?.intensity ?? 0.3,
+                    vector: {
+                        x: context?.gesture?.vector?.x ?? context?.focus?.x ?? 0.5,
+                        y: context?.gesture?.vector?.y ?? context?.focus?.y ?? 0.5,
+                        z: context?.gesture?.vector?.z ?? context?.focus?.depth ?? 0.4
+                    }
+                }
+            };
+        }
+
+        function renderMetricGrid(container, entries, formatter) {
+            container.innerHTML = '';
+            if (entries.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'Awaiting attestation coverage';
+                container.appendChild(empty);
+                return;
+            }
+
+            for (const [key, data] of entries) {
+                const metric = document.createElement('div');
+                metric.className = 'metric';
+                const { primary, secondary } = formatter(key, data);
+                const label = document.createElement('span');
+                label.textContent = primary;
+                const value = document.createElement('span');
+                value.textContent = secondary;
+                metric.appendChild(label);
+                metric.appendChild(value);
+                container.appendChild(metric);
+            }
+        }
+
+        function renderCommercializationSummary(summary) {
+            if (!summary) {
+                renderMetricGrid(segmentCoverageGrid, [], () => ({ primary: '', secondary: '' }));
+                renderMetricGrid(regionCoverageGrid, [], () => ({ primary: '', secondary: '' }));
+                commercializationPackList.innerHTML = '';
+                commercializationKpiSummary.innerHTML = '';
+                snapshotList.innerHTML = '';
+                commercializationUpdated.textContent = 'No commercialization activity yet';
+                if (adaptiveSDKRef) {
+                    refreshCommercializationSnapshots();
+                }
+                return;
+            }
+
+            const segmentEntries = Object.entries(summary.segments || {});
+            renderMetricGrid(segmentCoverageGrid, segmentEntries, (segment, data) => ({
+                primary: formatLabel(segment),
+                secondary: `${data.profileCount} profiles · ${data.adoptionCount} adoptions`
+            }));
+
+            const regionEntries = Object.entries(summary.regions || {});
+            renderMetricGrid(regionCoverageGrid, regionEntries, (region, data) => ({
+                primary: formatLabel(region),
+                secondary: `${data.profileCount} profiles · ${data.adoptionCount} adoptions`
+            }));
+
+            const profileMap = new Map((summary.profiles || []).map(profile => [profile.id, profile]));
+            commercializationPackList.innerHTML = '';
+            const packs = summary.packs || [];
+            if (packs.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'No commercialization packs registered yet';
+                commercializationPackList.appendChild(empty);
+            } else {
+                for (const pack of packs) {
+                    const card = document.createElement('div');
+                    card.className = 'pack-card';
+
+                    const headline = document.createElement('span');
+                    headline.className = 'meta-line';
+                    headline.textContent = pack.metadata?.segment ? `${formatLabel(pack.metadata.segment)} Segment` : 'Custom Pack';
+                    card.appendChild(headline);
+
+                    const title = document.createElement('h3');
+                    title.textContent = pack.name || formatLabel(pack.id);
+                    card.appendChild(title);
+
+                    if (pack.description) {
+                        const description = document.createElement('p');
+                        description.textContent = pack.description;
+                        card.appendChild(description);
+                    }
+
+                    const stats = document.createElement('p');
+                    const profileCount = Array.isArray(pack.profileIds) ? pack.profileIds.length : 0;
+                    stats.textContent = `Profiles: ${profileCount} · Adoptions: ${pack.adoptionCount}`;
+                    card.appendChild(stats);
+
+                    const defaultProfile = pack.defaultProfileId ? profileMap.get(pack.defaultProfileId) : null;
+                    const defaultLine = document.createElement('p');
+                    defaultLine.className = 'meta-line';
+                    defaultLine.textContent = defaultProfile
+                        ? `Default Profile: ${defaultProfile.name}`
+                        : 'Default Profile: None';
+                    card.appendChild(defaultLine);
+
+                    commercializationPackList.appendChild(card);
+                }
+            }
+
+            if (summary.lastUpdated) {
+                const timestamp = new Date(summary.lastUpdated);
+                commercializationUpdated.textContent = `Updated ${timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+            } else {
+                commercializationUpdated.textContent = 'No commercialization activity yet';
+            }
+
+            if (adaptiveSDKRef) {
+                refreshCommercializationSnapshots();
+            }
+        }
+
+        function renderKpiSummary(report) {
+            commercializationKpiSummary.innerHTML = '';
+            if (!report || !report.latest) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'No KPI snapshots yet';
+                commercializationKpiSummary.appendChild(empty);
+                return;
+            }
+
+            const metrics = [
+                { label: 'Total Adoption', value: report.latest.kpis?.totalAdoption ?? 0, delta: report.deltas?.totalAdoption },
+                { label: 'Active Packs', value: report.latest.kpis?.activePacks ?? 0, delta: report.deltas?.activePacks },
+                { label: 'Active Profiles', value: report.latest.kpis?.activeProfiles ?? 0, delta: report.deltas?.activeProfiles }
+            ];
+
+            for (const metric of metrics) {
+                const item = document.createElement('div');
+                item.className = 'snapshot-item';
+
+                const title = document.createElement('strong');
+                title.textContent = metric.label;
+                item.appendChild(title);
+
+                const value = document.createElement('span');
+                value.textContent = `${metric.value}`;
+                value.style.fontSize = '1.1rem';
+                value.style.fontWeight = '600';
+                value.style.color = 'var(--accent)';
+                item.appendChild(value);
+
+                let deltaText = 'NO CHANGE VS LAST';
+                if (typeof metric.delta === 'number') {
+                    if (metric.delta > 0) {
+                        deltaText = `+${metric.delta} VS LAST SNAPSHOT`;
+                    } else if (metric.delta < 0) {
+                        deltaText = `${metric.delta} VS LAST SNAPSHOT`;
+                    }
+                }
+                const delta = document.createElement('span');
+                delta.className = 'meta-line';
+                delta.textContent = deltaText;
+                item.appendChild(delta);
+
+                commercializationKpiSummary.appendChild(item);
+            }
+        }
+
+        function renderSnapshotHistory(snapshots) {
+            snapshotList.innerHTML = '';
+            if (!snapshots || snapshots.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'No commercialization snapshots yet';
+                snapshotList.appendChild(empty);
+                return;
+            }
+
+            for (const snapshot of snapshots) {
+                const item = document.createElement('div');
+                item.className = 'snapshot-item';
+
+                const capturedAt = document.createElement('strong');
+                const timestamp = new Date(snapshot.capturedAt);
+                capturedAt.textContent = timestamp.toLocaleString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+                item.appendChild(capturedAt);
+
+                const coverage = document.createElement('span');
+                coverage.textContent = `Adoption ${snapshot.kpis?.totalAdoption ?? 0} · Packs ${snapshot.kpis?.activePacks ?? 0}/${snapshot.kpis?.totalPacks ?? 0}`;
+                item.appendChild(coverage);
+
+                const contextBits = [];
+                if (snapshot.context?.trigger) {
+                    contextBits.push(String(snapshot.context.trigger));
+                }
+                if (snapshot.context?.capturedBy) {
+                    contextBits.push(String(snapshot.context.capturedBy));
+                }
+                if (contextBits.length > 0) {
+                    const meta = document.createElement('span');
+                    meta.className = 'meta-line';
+                    meta.textContent = contextBits.join(' · ');
+                    item.appendChild(meta);
+                }
+
+                snapshotList.appendChild(item);
+            }
+        }
+
+        function refreshCommercializationSnapshots() {
+            if (!adaptiveSDKRef) {
+                commercializationKpiSummary.innerHTML = '';
+                snapshotList.innerHTML = '';
+                return;
+            }
+            const snapshots = adaptiveSDKRef.getLicenseCommercializationSnapshots({ limit: 5, withSummary: false });
+            renderSnapshotHistory(snapshots);
+            const kpiReport = adaptiveSDKRef.getLicenseCommercializationKpiReport();
+            renderKpiSummary(kpiReport);
+        }
+
+        const adaptiveSDK = (adaptiveSDKRef = createAdaptiveSDK({
+            telemetry: {
+                enabled: true,
+                defaultConsent: { analytics: false, biometric: false },
+                onConsentDecision: (snapshot, metadata) => {
+                    consentPanel?.handleConsentDecision(snapshot, metadata);
+                },
+                commercialization: {
+                    onUpdate: renderCommercializationSummary,
+                    snapshotStoreOptions: {
+                        storage: commercializationRemoteStorage,
+                        onChange: () => renderRemoteStorageStatus()
+                    },
+                    snapshotIntervalMs: 3600000
+                }
+            },
+            telemetryProviders: [complianceVaultProvider],
+            marketplaceHooks: {
+                onPatternChange: updatePatternPanel,
+                onAdaptiveUpdate: handleAdaptiveUpdate
+            }
+        }));
+
+        const {
+            engine,
+            registerLayoutAnnotation,
+            updateTelemetryConsent,
+            getTelemetryConsent,
+            getTelemetryAuditTrail,
+            getLicenseCommercializationSummary,
+            setLicenseAttestorFromProfile,
+            registerLicenseAttestationProfilePack
+        } = adaptiveSDK;
+
+        const telemetryHarness = adaptiveSDK.telemetry;
+
+        captureSnapshotBtn?.addEventListener('click', () => {
+            adaptiveSDKRef?.captureLicenseCommercializationSnapshot({
+                trigger: 'demo-manual',
+                capturedBy: 'wearable-designer'
+            });
+            refreshCommercializationSnapshots();
+        });
+
+        exportSnapshotsBtn?.addEventListener('click', () => {
+            if (!adaptiveSDKRef) return;
+            const exportPayload = adaptiveSDKRef.exportLicenseCommercializationSnapshots({
+                format: 'json',
+                includeSummary: false
+            });
+            if (!exportPayload) return;
+            const blob = new Blob([exportPayload], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `vib34d-commercialization-${Date.now()}.json`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        });
+
+        downloadBlueprintBtn?.addEventListener('click', () => {
+            if (!latestBlueprint) return;
+            const payload = JSON.stringify(latestBlueprint, null, 2);
+            const blob = new Blob([payload], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `vib34d-blueprint-${Date.now()}.json`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        });
+
+        registerLayoutAnnotation(new class extends LayoutAnnotation {
+            constructor() {
+                super({ id: 'demo-insight', priority: 5 });
+            }
+
+            shouldApply({ layout }) {
+                return layout.intensity > 0.7;
+            }
+
+            build({ layout }) {
+                return {
+                    type: 'insight',
+                    message: `High intent detected (${layout.intensity.toFixed(2)})`
+                };
+            }
+        }());
+
+        window.vib34dEngine = engine;
+        window.vib34dComplianceVault = complianceVaultProvider;
+
+        const enterprisePack = registerLicenseAttestationProfilePack('enterprise-saas', { applyDefault: true });
+        const studioPack = registerLicenseAttestationProfilePack('studio-collab', {
+            applyDefault: false,
+            collaborationId: 'aura-labs'
+        });
+
+        window.vib34dEnterprisePack = enterprisePack;
+        window.vib34dStudioPack = studioPack;
+
+        if (enterprisePack?.defaultProfileId) {
+            setLicenseAttestorFromProfile(enterprisePack.defaultProfileId);
+        }
+
+        renderCommercializationSummary(getLicenseCommercializationSummary());
+        refreshCommercializationSnapshots();
+
+        const snapshotStore = adaptiveSDKRef.getLicenseCommercializationSnapshotStore?.();
+        snapshotStore?.whenReady?.().then(() => {
+            refreshCommercializationSnapshots();
+            renderRemoteStorageStatus();
+        });
+
+        if (typeof adaptiveSDKRef?.startLicenseCommercializationSnapshotSchedule === 'function') {
+            stopSnapshotSchedule = adaptiveSDKRef.startLicenseCommercializationSnapshotSchedule(60000, {
+                trigger: 'demo-schedule',
+                capturedBy: 'wearable-designer'
+            }) || null;
+        }
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof stopSnapshotSchedule === 'function') {
+                stopSnapshotSchedule();
+            }
+        });
+
+        const variationSlider = document.getElementById('variationSlider');
+        const randomizeBtn = document.getElementById('randomizeBtn');
+        const variationLabel = document.getElementById('variationLabel');
+        const focusMetric = document.getElementById('focusMetric');
+        const engagementMetric = document.getElementById('engagementMetric');
+        const velocityMetric = document.getElementById('velocityMetric');
+        const stressMetric = document.getElementById('stressMetric');
+        const consentPanelContainer = document.getElementById('telemetryConsentPanel');
+
+        consentPanel = createConsentPanel({
+            container: consentPanelContainer,
+            consentOptions: [
+                {
+                    classification: 'system',
+                    title: 'System Diagnostics',
+                    description: 'Required for runtime health and adapter lifecycle.'
+                },
+                {
+                    classification: 'compliance',
+                    title: 'Compliance & Audit',
+                    description: 'Records schema issues and consent changes.'
+                },
+                {
+                    classification: 'interaction',
+                    title: 'Interaction Feedback',
+                    description: 'Tracks gestures and adaptive layout reactions.'
+                },
+                {
+                    classification: 'analytics',
+                    title: 'Analytics',
+                    description: 'Enables aggregated layout performance telemetry.'
+                },
+                {
+                    classification: 'biometric',
+                    title: 'Biometric Streams',
+                    description: 'Includes heart rate and stress telemetry.'
+                }
+            ],
+            getTelemetryConsent,
+            getComplianceRecords: () => complianceVaultProvider.getRecords(),
+            getTelemetryAuditTrail,
+            refreshInterval: 6000,
+            downloadFileNamePrefix: 'vib34d-compliance-log',
+            onConsentToggle: (classification, enabled) => {
+                updateTelemetryConsent({ [classification]: enabled }, { source: 'wearable-designer-ui' });
+            },
+            trackConsentToggle: (classification, enabled) => {
+                telemetryHarness.track('privacy.consent.ui_toggle', { classification, enabled }, { classification: 'compliance' });
+            }
+        }).mount();
+
+        variationSlider.addEventListener('input', (event) => {
+            const value = Number(event.target.value);
+            engine.setVariation(value);
+            variationLabel.textContent = `${value + 1} - ${engine.variationManager.getVariationName(value)}`;
+        });
+
+        randomizeBtn.addEventListener('click', () => {
+            engine.randomVariation();
+            variationSlider.value = engine.currentVariation;
+            variationLabel.textContent = `${engine.currentVariation + 1} - ${engine.variationManager.getVariationName(engine.currentVariation)}`;
+        });
+
+        function updatePatternPanel(spec) {
+            document.getElementById('patternTier').textContent = spec.monetization.tier.toUpperCase();
+            document.getElementById('patternName').textContent = spec.pattern?.name || 'Adaptive Pattern';
+            document.getElementById('patternDescription').textContent = spec.pattern?.description || 'Dynamic mapping ready for commercialization.';
+            document.getElementById('integrationTag').textContent = `Figma: ${spec.integration.figmaPlugin}`;
+        }
+
+        function handleAdaptiveUpdate({ context, layout, design }) {
+            focusMetric.textContent = context.focusVector.x.toFixed(2);
+            engagementMetric.textContent = context.engagementLevel.toFixed(2);
+            velocityMetric.textContent = layout.motion.velocity.toFixed(2);
+            stressMetric.textContent = context.biometricStress.toFixed(2);
+
+            blueprintRenderer.render(layout, design, context);
+            latestBlueprint = buildLayoutBlueprint(layout, design, context);
+            renderBlueprintPanel(latestBlueprint);
+
+            const projectionContext = buildProjectionContextFromAdaptive(context);
+            const projectionComposition = adaptiveSDK.composeProjectionField(layout, design, projectionContext);
+            if (projectionComposition) {
+                adaptiveSDK.projectionComposer.render(projectionComposition.blueprint, projectionContext);
+                if (activeProjectionScenario === '__realtime__') {
+                    renderProjectionPanel(projectionComposition, { mode: 'realtime' });
+                }
+            }
+        }
+
+        document.addEventListener('pointermove', event => {
+            const x = event.clientX / window.innerWidth;
+            const y = event.clientY / window.innerHeight;
+            engine.sensoryBridge.ingest('eye-tracking', { x, y, depth: 0.25 + 0.15 * Math.sin(x * Math.PI) }, 0.9);
+            engine.sensoryBridge.ingest('neural-intent', { x: (x - 0.5) * 0.8, y: (0.5 - y) * 0.8, engagement: 0.5 + (0.5 - Math.abs(0.5 - x)) * 0.3 }, 0.7);
+        });
+
+        setInterval(() => {
+            const stress = 0.15 + Math.random() * 0.15;
+            engine.sensoryBridge.ingest('biometric', { stress, heartRate: 70 + Math.random() * 6 }, 0.6);
+            engine.sensoryBridge.ingest('ambient', { luminance: 0.4 + Math.random() * 0.2, motion: Math.random() * 0.3 }, 0.5);
+        }, 2400);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add environment normalization to the base VIB34D engine so headless SDK consumers can skip visualization and DOM bootstrapping while guarding gallery/export helpers
- expose the new environment options through the Adaptive SDK factory, types, and Vitest coverage, and update planning/docs to capture the headless track
- document headless usage in the README and session tracker while ensuring the wearable demo still boots normally in browser mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e42c1a9cbc83298976ba15f587c766