### PR TITLE
Synchronize toggle states with engine subsystems

### DIFF
--- a/js/controls/ui-handlers.js
+++ b/js/controls/ui-handlers.js
@@ -5,8 +5,8 @@
  */
 
 // Global state variables
-let audioEnabled = window.audioEnabled || false;
-let interactivityEnabled = false;
+let interactivityEnabled = window.interactivityEnabled !== false;
+window.interactivityEnabled = interactivityEnabled;
 
 /**
  * Main parameter update function - CRITICAL for all visualizers
@@ -278,26 +278,32 @@ window.openViewer = function() {
  */
 window.toggleInteractivity = function() {
     interactivityEnabled = !interactivityEnabled;
-    
+    window.interactivityEnabled = interactivityEnabled;
+
     // Update interactivity button visual state
     const interactBtn = document.getElementById('interactivityToggle') || document.querySelector('[onclick="toggleInteractivity()"]');
     if (interactBtn) {
-        if (interactivityEnabled) {
-            interactBtn.classList.add('active');
-        } else {
-            interactBtn.classList.remove('active');
-        }
+        interactBtn.classList.toggle('active', interactivityEnabled);
         interactBtn.title = `Interactive Control: ${interactivityEnabled ? 'ON' : 'OFF'}`;
     }
-    
+
+    // Synchronize ReactivityManager if available
+    if (window.reactivityManager && typeof window.reactivityManager.setEnabled === 'function') {
+        window.reactivityManager.setEnabled(interactivityEnabled);
+        console.log(`🎛️ ReactivityManager synced: ${interactivityEnabled}`);
+    }
+
     console.log(`🎛️ Mouse/Touch Interactions: ${interactivityEnabled ? 'ENABLED' : 'DISABLED'}`);
     console.log('🔷 Faceted: Mouse tracking', interactivityEnabled ? '✅' : '❌');
-    console.log('🌌 Quantum: Enhanced interactions', interactivityEnabled ? '✅' : '❌'); 
+    console.log('🌌 Quantum: Enhanced interactions', interactivityEnabled ? '✅' : '❌');
     console.log('✨ Holographic: Touch interactions', interactivityEnabled ? '✅' : '❌');
     console.log('🔮 Polychora: 4D precision tracking', interactivityEnabled ? '✅' : '❌');
-    
-    // Show status overlay
-    showInteractivityStatus();
+
+    if (typeof window.synchronizeEngineStates === 'function') {
+        window.synchronizeEngineStates();
+    } else {
+        showInteractivityStatus();
+    }
 };
 
 /**
@@ -488,6 +494,9 @@ function updateUIParameter(param, value) {
  * Show interactivity status overlay
  */
 function showInteractivityStatus() {
+    const audioState = window.audioEnabled === true;
+    const interactivityState = window.interactivityEnabled !== false;
+
     // Create floating overlay for interactivity status
     let overlay = document.getElementById('reactivity-status-overlay');
     if (!overlay) {
@@ -515,8 +524,8 @@ function showInteractivityStatus() {
         <div style="color: #00ffff; font-weight: bold; margin-bottom: 10px;">
             🎛️ REACTIVITY STATUS
         </div>
-        <div>🎵 Audio: ${audioEnabled ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
-        <div>🖱️ Interactions: ${interactivityEnabled ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
+        <div>🎵 Audio: ${audioState ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
+        <div>🖱️ Interactions: ${interactivityState ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
     `;
     
     // Auto-hide after 3 seconds
@@ -584,6 +593,9 @@ function showAudioReactivityStatus() {
 function showInteractivityOverlay() {
     showInteractivityStatus();
 }
+
+// Expose status helpers for cross-module synchronization
+window.showInteractivityStatus = showInteractivityStatus;
 
 // Keyboard shortcuts
 document.addEventListener('keydown', (e) => {

--- a/js/core/app.js
+++ b/js/core/app.js
@@ -55,6 +55,13 @@ export class VIB34DApp {
                         setTimeout(() => {
                             window.applyParametersCoordinated(system, newEngine);
                         }, 60);
+
+                        // Re-sync engine integrations with toggle states after parameters settle
+                        setTimeout(() => {
+                            if (typeof window.synchronizeEngineStates === 'function') {
+                                window.synchronizeEngineStates();
+                            }
+                        }, 260);
                         
                         // Update UI buttons
                         document.querySelectorAll('.system-btn').forEach(btn => {
@@ -240,6 +247,71 @@ export class VIB34DApp {
                 }
             }
         };
+
+        // Synchronize engine states with global toggle flags
+        window.synchronizeEngineStates = () => {
+            console.log('🔄 Synchronizing engine states with toggle flags...');
+
+            const interactivityState = window.interactivityEnabled !== false;
+            const audioState = window.audioEnabled === true;
+
+            // Update interactivity button state
+            const interactBtn = document.getElementById('interactivityToggle') || document.querySelector('[onclick="toggleInteractivity()"]');
+            if (interactBtn) {
+                interactBtn.classList.toggle('active', interactivityState);
+                interactBtn.title = `Interactive Control: ${interactivityState ? 'ON' : 'OFF'}`;
+            }
+
+            if (window.reactivityManager && typeof window.reactivityManager.setEnabled === 'function') {
+                window.reactivityManager.setEnabled(interactivityState);
+            }
+
+            if (window.interactivityMenu?.isVisible && typeof window.interactivityMenu.updateInputSources === 'function') {
+                setTimeout(() => window.interactivityMenu.updateInputSources(), 0);
+            }
+
+            // Update audio button + engine state
+            const audioBtn = document.getElementById('audioToggle') || document.querySelector('[onclick="toggleAudio()"]');
+            if (audioBtn) {
+                audioBtn.classList.toggle('active', audioState);
+                audioBtn.title = `Audio Reactivity: ${audioState ? 'ON' : 'OFF'}`;
+            }
+
+            if (window.audioEngine) {
+                const audioIsActive = typeof window.audioEngine.isAudioActive === 'function'
+                    ? window.audioEngine.isAudioActive()
+                    : window.audioEngine.isActive;
+
+                if (audioState && !audioIsActive) {
+                    setTimeout(() => {
+                        if (window.audioEngine) {
+                            window.audioEngine.init().catch(error => {
+                                console.warn('⚠️ Failed to reinitialize audio engine during sync:', error?.message || error);
+                            });
+                        }
+                    }, 100);
+                } else if (!audioState && audioIsActive) {
+                    if (typeof window.audioEngine.stop === 'function') {
+                        window.audioEngine.stop();
+                    } else {
+                        window.audioEngine.isActive = false;
+                    }
+                }
+            }
+
+            if (window.deviceTiltHandler?.isEnabled && typeof window.deviceTiltHandler.updateBaseRotation === 'function') {
+                const currentParams = window.getCurrentUIParameterState ? window.getCurrentUIParameterState() : {};
+                window.deviceTiltHandler.updateBaseRotation(
+                    currentParams.rot4dXW || 0,
+                    currentParams.rot4dYW || 0,
+                    currentParams.rot4dZW || 0
+                );
+            }
+
+            if (typeof window.showInteractivityStatus === 'function') {
+                window.showInteractivityStatus();
+            }
+        };
         
         // Device Tilt Functions for 4D Rotation Control
         window.toggleDeviceTilt = async () => {
@@ -287,6 +359,13 @@ export class VIB34DApp {
                 );
             }
         };
+
+        // Ensure UI toggle states match stored globals on first paint
+        setTimeout(() => {
+            if (typeof window.synchronizeEngineStates === 'function') {
+                window.synchronizeEngineStates();
+            }
+        }, 0);
     }
 
     // Initialize the application


### PR DESCRIPTION
## Summary
- ensure the interactivity toggle updates the global flag, reactivity manager, and UI status overlays
- harden the audio toggle to reinitialize or stop the audio engine and surface current state to the UI
- add a synchronizeEngineStates helper so system switches and startup reapply toggle-driven integrations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e85b31a3fc8329b12f66a62effb94c