### PR TITLE
Stabilize audio engine lifecycle and toggle synchronization

### DIFF
--- a/js/controls/ui-handlers.js
+++ b/js/controls/ui-handlers.js
@@ -5,8 +5,8 @@
  */
 
 // Global state variables
-let audioEnabled = window.audioEnabled || false;
-let interactivityEnabled = false;
+let interactivityEnabled = window.interactivityEnabled !== false;
+window.interactivityEnabled = interactivityEnabled;
 
 /**
  * Main parameter update function - CRITICAL for all visualizers
@@ -278,26 +278,41 @@ window.openViewer = function() {
  */
 window.toggleInteractivity = function() {
     interactivityEnabled = !interactivityEnabled;
-    
+    window.interactivityEnabled = interactivityEnabled;
+
     // Update interactivity button visual state
     const interactBtn = document.getElementById('interactivityToggle') || document.querySelector('[onclick="toggleInteractivity()"]');
     if (interactBtn) {
-        if (interactivityEnabled) {
-            interactBtn.classList.add('active');
-        } else {
-            interactBtn.classList.remove('active');
-        }
+        interactBtn.classList.toggle('active', interactivityEnabled);
         interactBtn.title = `Interactive Control: ${interactivityEnabled ? 'ON' : 'OFF'}`;
     }
-    
+
+    // Synchronize ReactivityManager if available
+    if (window.reactivityManager && typeof window.reactivityManager.setEnabled === 'function') {
+        window.reactivityManager.setEnabled(interactivityEnabled);
+        console.log(`🎛️ ReactivityManager synced: ${interactivityEnabled}`);
+    }
+
     console.log(`🎛️ Mouse/Touch Interactions: ${interactivityEnabled ? 'ENABLED' : 'DISABLED'}`);
     console.log('🔷 Faceted: Mouse tracking', interactivityEnabled ? '✅' : '❌');
-    console.log('🌌 Quantum: Enhanced interactions', interactivityEnabled ? '✅' : '❌'); 
+    console.log('🌌 Quantum: Enhanced interactions', interactivityEnabled ? '✅' : '❌');
     console.log('✨ Holographic: Touch interactions', interactivityEnabled ? '✅' : '❌');
     console.log('🔮 Polychora: 4D precision tracking', interactivityEnabled ? '✅' : '❌');
-    
-    // Show status overlay
-    showInteractivityStatus();
+
+    if (typeof window.synchronizeEngineStates === 'function') {
+        try {
+            const maybePromise = window.synchronizeEngineStates();
+            if (maybePromise && typeof maybePromise.then === 'function') {
+                maybePromise.catch(error => {
+                    console.warn('⚠️ Synchronization failed after interactivity toggle:', error?.message || error);
+                });
+            }
+        } catch (error) {
+            console.warn('⚠️ Synchronization threw after interactivity toggle:', error?.message || error);
+        }
+    } else {
+        showInteractivityStatus();
+    }
 };
 
 /**
@@ -488,6 +503,9 @@ function updateUIParameter(param, value) {
  * Show interactivity status overlay
  */
 function showInteractivityStatus() {
+    const audioState = window.audioEnabled === true;
+    const interactivityState = window.interactivityEnabled !== false;
+
     // Create floating overlay for interactivity status
     let overlay = document.getElementById('reactivity-status-overlay');
     if (!overlay) {
@@ -515,8 +533,8 @@ function showInteractivityStatus() {
         <div style="color: #00ffff; font-weight: bold; margin-bottom: 10px;">
             🎛️ REACTIVITY STATUS
         </div>
-        <div>🎵 Audio: ${audioEnabled ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
-        <div>🖱️ Interactions: ${interactivityEnabled ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
+        <div>🎵 Audio: ${audioState ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
+        <div>🖱️ Interactions: ${interactivityState ? '<span style="color: #00ff00">ON</span>' : '<span style="color: #ff4444">OFF</span>'}</div>
     `;
     
     // Auto-hide after 3 seconds
@@ -584,6 +602,9 @@ function showAudioReactivityStatus() {
 function showInteractivityOverlay() {
     showInteractivityStatus();
 }
+
+// Expose status helpers for cross-module synchronization
+window.showInteractivityStatus = showInteractivityStatus;
 
 // Keyboard shortcuts
 document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- add single-flight initialization, media stream teardown, and API checks to the audio engine
- gate the global audio toggle with a busy guard, await synchronization, and report failures
- await audio reactivation inside synchronizeEngineStates and harden callers against async rejections

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e85b31a3fc8329b12f66a62effb94c