### PR TITLE
Implement wearable adapters and composite schema handling

### DIFF
--- a/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
+++ b/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
@@ -1,0 +1,134 @@
+# Wearables Development – Phase Zero Execution Plan
+
+This plan establishes the concrete engineering path for taking the adaptive VIB34D wearables stack from Phase 0 (prototype) into sustained development. It scopes only the **wearables runtime and hardware integration lane**—the UI/web experience team will operate a parallel track and consume the telemetry/licensing foundations already delivered in this repository.
+
+## 1. Current Baseline
+
+- Adaptive runtime, telemetry, licensing, commercialization analytics, and projection/blueprint tooling already exist inside the SDK surface (`src/core`, `src/product`, `src/ui/adaptive`).
+- `wearable-designer.html` remains a monolithic demo shell demonstrating the features but is not yet modular or hardware-backed.
+- Telemetry, consent, licensing attestation, commercialization snapshotting, and projection scenario infrastructure are implemented and validated through Vitest + Playwright smoke coverage.
+- No production-grade wearable device adapters, schema-enforced sensor payload bridges, or deployment automation for wearable firmware/app containers exist.
+
+## 2. Phase Zero Objectives & Exit Criteria
+
+| Objective | Description | Exit Criteria |
+|-----------|-------------|---------------|
+| Establish Wearable Device Integration Foundations | Deliver reference adapters, schema validation, and telemetry routing for real sensor inputs. | Sensor schema registry covers real device payloads, adapters stream data into `SensoryInputBridge`, hardware smoke tests execute on CI rig. |
+| Modularize Wearable Runtime Package | Decouple the adaptive engine usage from the demo shell and expose reusable modules for firmware/app integrators. | `AdaptiveSDK` publishes wearable presets, modular samples replace demo wiring, API surface documented in `types/adaptive-sdk.d.ts`. |
+| Align with Telemetry/Licensing Track | Ensure wearables lane consumes and exercises telemetry, consent, licensing, commercialization flows owned by the web/UI team. | Shared acceptance tests confirm telemetry gating/licensing attestation triggered from hardware adapters; audit/compliance exports include wearable-origin metadata. |
+| Delivery Governance | Lock sprint cadence, tooling, and automation so Phase 1+ can scale. | Phase Zero completion review, tracker entries updated, automated smoke lane for hardware registered in CI. |
+
+Phase Zero concludes once real wearable signals hydrate the adaptive engine end-to-end (including telemetry/licensing flows), modular runtime packages ship with documentation, and repeatable automation validates integrations.
+
+## 3. Workstreams & Tasks
+
+### 3.1 Hardware & Sensor Integration
+
+1. **Device Inventory & Payload Mapping**
+   - Catalogue initial wearable targets (AR visor, neural band, biometric wrist device).
+   - Extract data formats, sampling rates, consent requirements.
+   - Update `SensorSchemaRegistry` with concrete schema definitions and tolerance ranges.
+2. **Adapter Development**
+   - Implement `src/ui/adaptive/sensors/adapters/<device>.js` for each device with normalization logic feeding `SensoryInputBridge`.
+   - Provide mock adapter implementations for local development and automated tests.
+3. **Hardware Smoke Bench**
+   - Script Playwright/Vitest-compatible harness to replay recorded sensor streams.
+   - Automate on-device smoke test recipe (e.g., Node bridge + WebSocket feed) to validate integration before firmware drops.
+4. **Telemetry Hook-Up**
+   - Ensure adapters flag telemetry classifications via `ProductTelemetryHarness`.
+   - Confirm licensing profiles (e.g., `wearables-pro`, `wearables-enterprise`) gate sensor activation.
+
+### 3.2 Adaptive Runtime Hardening
+
+1. **Runtime Profiles**
+   - Package wearable presets inside `AdaptiveSDK` (synthesizer strategies, annotations, projection packs).
+   - Document DI entry points for firmware/app teams.
+2. **Blueprint & Projection Validation**
+   - Add automated checks ensuring `LayoutBlueprintRenderer` and `ProjectionFieldComposer` operate within hardware constraints (FOV, refresh windows, energy budgets).
+   - Extend validator outputs with device-specific warnings.
+3. **Commercialization Touchpoints**
+   - Preconfigure commercialization snapshot/store adapters for wearable SKUs.
+   - Verify commercialization KPIs remain accurate when signals originate from hardware adapters.
+
+### 3.3 Packaging & Distribution
+
+1. **Module Extraction**
+   - Break down `wearable-designer.html` dependencies into reusable modules (awaiting B-05 but begin with runtime packaging).
+   - Publish reference implementations under `packages/wearables-kit` (or similar) with bundler config, typings, and quickstart README.
+2. **Firmware/Companion App SDK**
+   - Provide minimal Node/TypeScript wrapper for wearable firmware teams to embed adaptive runtime via WebView or native bridge.
+   - Document telemetry/licensing handshake requirements for companion apps.
+3. **Release Automation**
+   - Set up semantic versioning, changelog generation, and artifact publishing (internal registry) for wearables kit.
+
+### 3.4 Governance & Collaboration
+
+1. **Phase Zero Sprints**
+   - Sprint 0: Inventory + schema updates, finalize adapter scaffolding.
+   - Sprint 1: Implement first hardware adapter + mock harness; integrate telemetry/licensing flows.
+   - Sprint 2: Runtime presets, commercialization validation, documentation draft.
+   - Sprint 3: Packaging, release automation, cross-track demo review.
+2. **Cross-Track Agreements**
+   - Weekly sync with UI/web track to share telemetry/licensing API changes.
+   - Shared definition of done referencing compliance exports and commercialization dashboards.
+3. **Documentation Deliverables**
+   - Update `DOCS/ADAPTIVE_SDK_DEVELOPER_HANDOFF_GUIDE.md` with wearable hardware lane.
+   - Produce hardware integration cookbook (per device) and troubleshooting FAQ.
+
+## 4. Dependencies & Interfaces
+
+- **Telemetry/Licensing:** Consume existing providers (`ProductTelemetryHarness`, `LicenseManager`, `LicenseAttestationProfileRegistry`). Hardware adapters must emit consent state and licensing context; UI/web track owns dashboards/export visualization.
+- **Testing Stack:** Reuse Vitest for unit coverage, Playwright for consent/licensing flows, extend to include sensor stream replays. Consider integrating hardware lab harness via GitHub Actions self-hosted runner.
+- **Types & SDK Surface:** Continue expanding `types/adaptive-sdk.d.ts` for new adapter interfaces; ensure module packaging emits types for firmware teams.
+
+## 5. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Hardware availability delays | Blocks adapter validation and telemetry handshake. | Maintain recorded sensor traces; use emulators until devices arrive; schedule early vendor engagement. |
+| Drift between wearables kit and UI/web telemetry contract | Broken dashboards, inconsistent compliance exports. | Shared schema contract repo; automated contract tests run across both tracks. |
+| Performance constraints on low-power devices | Latency in adaptive layout/projection rendering. | Profile runtime on reference hardware; expose configuration knobs for throttling strategies; implement watchdog telemetry to flag overruns. |
+| Licensing/attestation mismatches | Sensor activation blocked or untracked monetization usage. | Pre-register wearables profiles in catalog; add integration tests for attestation flows triggered via adapters. |
+
+## 6. Deliverables Checklist
+
+- [ ] Updated sensor schema definitions + adapter scaffolding checked in.
+- [ ] Wearable device adapters streaming real data through `SensoryInputBridge`.
+- [ ] Automated harness replaying sensor traces in CI.
+- [ ] Adaptive runtime wearable presets packaged and documented.
+- [ ] Commercialization telemetry validated with hardware-origin signals.
+- [ ] Wearables kit packaging + release automation operational.
+- [ ] Cross-track demo review demonstrating end-to-end telemetry, licensing, commercialization, and adaptive visualization with live wearable input.
+
+## 7. Milestones, Staffing, and Reporting Cadence
+
+### 7.1 Sprint-by-Sprint Commitments
+
+| Sprint | Focus | Primary Deliverables |
+|--------|-------|----------------------|
+| Sprint 0 | Device discovery & schema foundation | Finalized device inventory, signed-off payload schemas, adapter scaffolding merged, mock sensor capture repository established. |
+| Sprint 1 | First hardware path live | AR visor adapter + mock harness replay in CI, telemetry/licensing contract tests green, firmware handoff notes published. |
+| Sprint 2 | Runtime + commercialization alignment | Wearable presets available via `AdaptiveSDK`, commercialization validation scripts automated, documentation walkthrough recorded. |
+| Sprint 3 | Packaging & release readiness | Wearables kit package published to internal registry, release automation validated, cross-track end-to-end demo executed. |
+
+### 7.2 Staffing & RACI Snapshot
+
+| Role | Lead | Accountable Areas |
+|------|------|-------------------|
+| Wearables Integration Lead | Embedded systems engineer | Device inventory, adapter implementation, hardware smoke bench upkeep. |
+| Adaptive Runtime Architect | Core runtime engineer | Preset packaging, performance profiling, commercialization checks. |
+| Telemetry/Licensing Liaison | Shared with UI/web track | Schema alignment, consent/licensing validation, compliance exports. |
+| DevOps & Release Owner | Platform engineer | CI hardware lane, semantic versioning, artifact publishing. |
+| Program Manager | Delivery coordinator | Sprint ceremonies, risk tracking, stakeholder comms, exit review facilitation. |
+
+### 7.3 Reporting Rhythm
+
+- **Daily**: Async stand-up updates in shared channel with blockers escalated within 2 hours.
+- **Twice Weekly**: Hardware adapter test report (device status, telemetry/licensing assertions, trace replay results).
+- **Weekly**: Cross-track sync with UI/web lane to reconcile API changes, licensing catalog updates, and commercialization dashboards.
+- **Sprint Reviews**: Joint demo including live wearable feed, telemetry/licensing dashboards, and commercialization snapshots.
+- **Sprint Retros**: Capture process improvements and feed into governance backlog ahead of Phase One scale-up.
+
+---
+
+**Next Action:** Kick off Sprint 0 by formalizing device inventory interviews, capturing payload specifications, and preparing schema updates within the existing adaptive runtime repositories.

--- a/src/ui/adaptive/sensors/SensorSchemaRegistry.js
+++ b/src/ui/adaptive/sensors/SensorSchemaRegistry.js
@@ -198,6 +198,8 @@ export class SensorSchemaRegistry {
             },
             fallback: { intent: null, vector: { x: 0, y: 0, z: 0 } }
         });
+
+        this.registerWearableDeviceDefaults();
     }
 
     loadCustomSchemas(schemas) {
@@ -279,5 +281,783 @@ export class SensorSchemaRegistry {
             y: this.ensureNumber(base.y, { field: `${field}.y`, min, max, defaultValue, issues }),
             z: this.ensureNumber(base.z, { field: `${field}.z`, min, max, defaultValue, issues })
         };
+    }
+
+    appendIssues(target, prefix, nestedIssues) {
+        if (!Array.isArray(nestedIssues) || nestedIssues.length === 0) {
+            return;
+        }
+
+        for (const issue of nestedIssues) {
+            const field = issue.field && issue.field !== '*'
+                ? `${prefix}.${issue.field}`
+                : prefix;
+            target.push({ ...issue, field });
+        }
+    }
+
+    ensureBoolean(value, { field, defaultValue = false, issues }) {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+
+        if (value == null) {
+            issues?.push({ field, code: 'type', message: 'Expected boolean value.' });
+            return defaultValue;
+        }
+
+        if (value === '1' || value === 1 || value === 'true') {
+            issues?.push({ field, code: 'coerce', message: 'Coerced truthy value to boolean true.' });
+            return true;
+        }
+
+        if (value === '0' || value === 0 || value === 'false') {
+            issues?.push({ field, code: 'coerce', message: 'Coerced falsy value to boolean false.' });
+            return false;
+        }
+
+        issues?.push({ field, code: 'coerce', message: 'Coerced value to boolean.' });
+        return Boolean(value);
+    }
+
+    ensureQuaternion(value, { field, defaultValue = { x: 0, y: 0, z: 0, w: 1 }, issues }) {
+        const base = value && typeof value === 'object' ? value : {};
+        const defaults = defaultValue || {};
+        return {
+            x: this.ensureNumber(base.x, { field: `${field}.x`, min: -1, max: 1, defaultValue: defaults.x ?? 0, issues }),
+            y: this.ensureNumber(base.y, { field: `${field}.y`, min: -1, max: 1, defaultValue: defaults.y ?? 0, issues }),
+            z: this.ensureNumber(base.z, { field: `${field}.z`, min: -1, max: 1, defaultValue: defaults.z ?? 0, issues }),
+            w: this.ensureNumber(base.w, { field: `${field}.w`, min: -1, max: 1, defaultValue: defaults.w ?? 1, issues })
+        };
+    }
+
+    normalizeWearableChannel(channelType, raw, options = {}) {
+        const {
+            schemaType = channelType,
+            defaultConfidence = 0.75,
+            confidenceField,
+            required = false,
+            confidence,
+            issues = [],
+            missingConfidence = 0
+        } = options;
+
+        if (!raw && !required) {
+            return null;
+        }
+
+        const payloadRaw = raw?.payload ?? raw ?? {};
+        const result = this.validate(schemaType, payloadRaw);
+        this.appendIssues(issues, `channels.${channelType}`, result.issues);
+
+        const fallbackConfidence = raw ? defaultConfidence : missingConfidence;
+        const normalizedConfidence = this.ensureNumber(
+            raw?.confidence ?? confidence,
+            {
+                field: confidenceField || `channels.${channelType}.confidence`,
+                min: 0,
+                max: 1,
+                defaultValue: fallbackConfidence,
+                issues
+            }
+        );
+
+        if (!raw && required) {
+            issues.push({
+                field: `channels.${channelType}`,
+                code: 'missing',
+                message: `${channelType} payload is required.`
+            });
+        }
+
+        return {
+            confidence: normalizedConfidence,
+            payload: result.payload
+        };
+    }
+
+    registerWearableDeviceDefaults() {
+        this.register('wearable.ar-visor', {
+            normalize: payload => {
+                const issues = [];
+                const safe = payload && typeof payload === 'object' ? payload : {};
+                const metadataSource = safe.metadata && typeof safe.metadata === 'object' ? safe.metadata : {};
+                const channelSource = safe.channels && typeof safe.channels === 'object' ? safe.channels : {};
+
+                const eyeSource = channelSource['eye-tracking'] ?? safe.gaze ?? null;
+                const ambientSource = channelSource.ambient ?? safe.environment ?? null;
+                const gestureSource = channelSource.gesture ?? safe.gesture ?? null;
+
+                const channels = {};
+
+                const eyeChannel = this.normalizeWearableChannel('eye-tracking', eyeSource, {
+                    schemaType: 'eye-tracking',
+                    defaultConfidence: 0.82,
+                    missingConfidence: 0,
+                    confidence: safe.focusConfidence ?? safe.quality?.focus,
+                    issues,
+                    required: true,
+                    confidenceField: 'channels.eye-tracking.confidence'
+                });
+                if (eyeChannel) {
+                    if (eyeSource && typeof eyeSource === 'object') {
+                        if ('vergence' in eyeSource) {
+                            eyeChannel.payload.vergence = this.ensureNumber(eyeSource.vergence, {
+                                field: 'channels.eye-tracking.vergence',
+                                min: 0,
+                                max: 5,
+                                defaultValue: 0,
+                                precision: 2,
+                                issues
+                            });
+                        }
+                        if ('stability' in eyeSource) {
+                            eyeChannel.payload.stability = this.ensureNumber(eyeSource.stability, {
+                                field: 'channels.eye-tracking.stability',
+                                min: 0,
+                                max: 1,
+                                defaultValue: 0.5,
+                                precision: 2,
+                                issues
+                            });
+                        }
+                        if ('blinkRate' in eyeSource) {
+                            eyeChannel.payload.blinkRate = this.ensureNumber(eyeSource.blinkRate, {
+                                field: 'channels.eye-tracking.blinkRate',
+                                min: 0,
+                                max: 2.5,
+                                defaultValue: 0.2,
+                                precision: 2,
+                                issues
+                            });
+                        }
+                    }
+                    channels['eye-tracking'] = eyeChannel;
+                }
+
+                const ambientChannel = this.normalizeWearableChannel('ambient', ambientSource, {
+                    schemaType: 'ambient',
+                    defaultConfidence: 0.65,
+                    confidence: safe.quality?.environment,
+                    issues,
+                    confidenceField: 'channels.ambient.confidence'
+                });
+                if (ambientChannel) {
+                    if (ambientSource && typeof ambientSource === 'object' && 'temperature' in ambientSource) {
+                        ambientChannel.payload.temperature = this.ensureNumber(ambientSource.temperature, {
+                            field: 'channels.ambient.temperature',
+                            min: -20,
+                            max: 60,
+                            defaultValue: 22,
+                            precision: 1,
+                            issues
+                        });
+                    }
+                    channels.ambient = ambientChannel;
+                }
+
+                const gestureChannel = this.normalizeWearableChannel('gesture', gestureSource, {
+                    schemaType: 'gesture',
+                    defaultConfidence: 0.58,
+                    confidence: safe.quality?.gesture ?? safe.quality?.focus,
+                    issues,
+                    confidenceField: 'channels.gesture.confidence'
+                });
+                if (gestureChannel) {
+                    const vector = gestureChannel.payload.vector || {};
+                    gestureChannel.payload.vector = {
+                        x: this.ensureNumber(vector.x, { field: 'channels.gesture.vector.x', min: -1, max: 1, defaultValue: 0, issues }),
+                        y: this.ensureNumber(vector.y, { field: 'channels.gesture.vector.y', min: -1, max: 1, defaultValue: 0, issues }),
+                        z: this.ensureNumber(vector.z, { field: 'channels.gesture.vector.z', min: -1, max: 1, defaultValue: 0, issues })
+                    };
+                    if (gestureSource && typeof gestureSource === 'object' && 'intentStrength' in gestureSource) {
+                        gestureChannel.payload.intentStrength = this.ensureNumber(gestureSource.intentStrength, {
+                            field: 'channels.gesture.intentStrength',
+                            min: 0,
+                            max: 1,
+                            defaultValue: 0,
+                            precision: 2,
+                            issues
+                        });
+                    }
+                    channels.gesture = gestureChannel;
+                }
+
+                const metadata = {};
+                const batterySource = safe.batteryLevel ?? metadataSource.batteryLevel;
+                if (batterySource !== undefined) {
+                    metadata.batteryLevel = this.ensureNumber(batterySource, {
+                        field: 'metadata.batteryLevel',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 1,
+                        precision: 2,
+                        issues
+                    });
+                }
+
+                const deviceTemperatureSource = safe.deviceTemperature
+                    ?? safe.temperature
+                    ?? metadataSource.deviceTemperature
+                    ?? ambientSource?.temperature;
+                if (deviceTemperatureSource !== undefined) {
+                    metadata.deviceTemperature = this.ensureNumber(deviceTemperatureSource, {
+                        field: 'metadata.deviceTemperature',
+                        min: 10,
+                        max: 65,
+                        defaultValue: 32,
+                        precision: 1,
+                        issues
+                    });
+                }
+
+                const uptimeSource = safe.uptimeSeconds ?? metadataSource.uptimeSeconds;
+                if (uptimeSource !== undefined) {
+                    metadata.uptimeSeconds = this.ensureNumber(uptimeSource, {
+                        field: 'metadata.uptimeSeconds',
+                        min: 0,
+                        max: 604800,
+                        defaultValue: 0,
+                        issues
+                    });
+                }
+
+                const poseSource = safe.pose && typeof safe.pose === 'object' ? safe.pose : metadataSource.pose;
+                if (poseSource) {
+                    metadata.pose = {
+                        orientation: this.ensureQuaternion(poseSource.orientation, {
+                            field: 'metadata.pose.orientation',
+                            issues
+                        }),
+                        position: this.ensureVector(poseSource.position, {
+                            field: 'metadata.pose.position',
+                            min: -5,
+                            max: 5,
+                            defaultValue: 0,
+                            issues
+                        })
+                    };
+                }
+
+                const fieldOfViewSource = safe.fieldOfView && typeof safe.fieldOfView === 'object'
+                    ? safe.fieldOfView
+                    : metadataSource.fieldOfView;
+                if (fieldOfViewSource) {
+                    metadata.fieldOfView = {
+                        horizontal: this.ensureNumber(fieldOfViewSource.horizontal, {
+                            field: 'metadata.fieldOfView.horizontal',
+                            min: 40,
+                            max: 140,
+                            defaultValue: 96,
+                            precision: 1,
+                            issues
+                        }),
+                        vertical: this.ensureNumber(fieldOfViewSource.vertical, {
+                            field: 'metadata.fieldOfView.vertical',
+                            min: 35,
+                            max: 120,
+                            defaultValue: 89,
+                            precision: 1,
+                            issues
+                        })
+                    };
+
+                    if (fieldOfViewSource.diagonal !== undefined) {
+                        metadata.fieldOfView.diagonal = this.ensureNumber(fieldOfViewSource.diagonal, {
+                            field: 'metadata.fieldOfView.diagonal',
+                            min: 60,
+                            max: 170,
+                            defaultValue: 110,
+                            precision: 1,
+                            issues
+                        });
+                    }
+                }
+
+                if (safe.optics && typeof safe.optics === 'object') {
+                    metadata.optics = {
+                        ipd: this.ensureNumber(safe.optics.ipd, {
+                            field: 'metadata.optics.ipd',
+                            min: 50,
+                            max: 80,
+                            defaultValue: 63,
+                            precision: 1,
+                            issues
+                        }),
+                        calibrationState: this.ensureString(safe.optics.calibrationState, {
+                            field: 'metadata.optics.calibrationState',
+                            allowEmpty: false,
+                            fallback: 'unknown',
+                            issues
+                        })
+                    };
+                }
+
+                const metadataEntries = Object.entries(metadata)
+                    .filter(([, value]) => value !== undefined && value !== null
+                        && (!(typeof value === 'object') || Object.keys(value).length > 0));
+                const normalizedMetadata = metadataEntries.length ? Object.fromEntries(metadataEntries) : {};
+
+                const firmwareVersion = this.ensureString(safe.firmwareVersion ?? metadataSource.firmwareVersion, {
+                    field: 'firmwareVersion',
+                    allowEmpty: true,
+                    fallback: null,
+                    issues
+                });
+
+                const deviceId = this.ensureString(safe.deviceId ?? metadataSource.deviceId, {
+                    field: 'deviceId',
+                    allowEmpty: false,
+                    fallback: 'wearable.ar-visor',
+                    issues
+                }) || 'wearable.ar-visor';
+
+                const confidence = this.ensureNumber(
+                    safe.confidence ?? safe.quality?.overall,
+                    {
+                        field: 'confidence',
+                        min: 0,
+                        max: 1,
+                        defaultValue: eyeChannel?.confidence ?? 0.8,
+                        issues
+                    }
+                );
+
+                return {
+                    payload: {
+                        deviceId,
+                        firmwareVersion,
+                        channels,
+                        metadata: normalizedMetadata
+                    },
+                    issues
+                };
+            },
+            fallback: {
+                deviceId: 'wearable.ar-visor',
+                firmwareVersion: null,
+                channels: {
+                    'eye-tracking': { confidence: 0, payload: { x: 0.5, y: 0.5, depth: 0.3 } },
+                    ambient: { confidence: 0, payload: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 } },
+                    gesture: { confidence: 0, payload: { intent: null, vector: { x: 0, y: 0, z: 0 } } }
+                },
+                metadata: {}
+            }
+        });
+
+        this.register('wearable.neural-band', {
+            normalize: payload => {
+                const issues = [];
+                const safe = payload && typeof payload === 'object' ? payload : {};
+                const metadataSource = safe.metadata && typeof safe.metadata === 'object' ? safe.metadata : {};
+                const channelSource = safe.channels && typeof safe.channels === 'object' ? safe.channels : {};
+
+                const intentSource = channelSource['neural-intent'] ?? safe.intent ?? safe.signal ?? null;
+                const gestureSource = channelSource.gesture ?? safe.gesture ?? null;
+
+                const channels = {};
+
+                const intentChannel = this.normalizeWearableChannel('neural-intent', intentSource, {
+                    schemaType: 'neural-intent',
+                    defaultConfidence: 0.7,
+                    missingConfidence: 0,
+                    confidence: safe.quality?.intent ?? safe.signalQuality?.overall,
+                    issues,
+                    required: true,
+                    confidenceField: 'channels.neural-intent.confidence'
+                });
+                if (intentChannel) {
+                    if (intentSource && typeof intentSource === 'object') {
+                        if ('signalToNoise' in intentSource) {
+                            intentChannel.payload.signalToNoise = this.ensureNumber(intentSource.signalToNoise, {
+                                field: 'channels.neural-intent.signalToNoise',
+                                min: 0,
+                                max: 40,
+                                defaultValue: 12,
+                                precision: 1,
+                                issues
+                            });
+                        }
+                        if ('bandwidth' in intentSource) {
+                            intentChannel.payload.bandwidth = this.ensureNumber(intentSource.bandwidth, {
+                                field: 'channels.neural-intent.bandwidth',
+                                min: 0,
+                                max: 100,
+                                defaultValue: 24,
+                                precision: 1,
+                                issues
+                            });
+                        }
+                    }
+                    channels['neural-intent'] = intentChannel;
+                }
+
+                const gestureChannel = this.normalizeWearableChannel('gesture', gestureSource, {
+                    schemaType: 'gesture',
+                    defaultConfidence: 0.55,
+                    confidence: safe.quality?.gesture,
+                    issues,
+                    confidenceField: 'channels.gesture.confidence'
+                });
+                if (gestureChannel) {
+                    const vector = gestureChannel.payload.vector || {};
+                    gestureChannel.payload.vector = {
+                        x: this.ensureNumber(vector.x, { field: 'channels.gesture.vector.x', min: -1, max: 1, defaultValue: 0, issues }),
+                        y: this.ensureNumber(vector.y, { field: 'channels.gesture.vector.y', min: -1, max: 1, defaultValue: 0, issues }),
+                        z: this.ensureNumber(vector.z, { field: 'channels.gesture.vector.z', min: -1, max: 1, defaultValue: 0, issues })
+                    };
+                    channels.gesture = gestureChannel;
+                }
+
+                const metadata = {};
+                if (safe.signalQuality && typeof safe.signalQuality === 'object') {
+                    metadata.signalQuality = {
+                        overall: this.ensureNumber(safe.signalQuality.overall, {
+                            field: 'metadata.signalQuality.overall',
+                            min: 0,
+                            max: 1,
+                            defaultValue: 0.6,
+                            precision: 2,
+                            issues
+                        }),
+                        contacts: this.ensureNumber(safe.signalQuality.contacts, {
+                            field: 'metadata.signalQuality.contacts',
+                            min: 0,
+                            max: 1,
+                            defaultValue: 0.5,
+                            precision: 2,
+                            issues
+                        })
+                    };
+                }
+
+                if (safe.impedance || metadataSource.impedance) {
+                    const impedanceSource = safe.impedance ?? metadataSource.impedance;
+                    metadata.impedance = {
+                        average: this.ensureNumber(impedanceSource?.average, {
+                            field: 'metadata.impedance.average',
+                            min: 0,
+                            max: 5000,
+                            defaultValue: 1200,
+                            issues
+                        }),
+                        variance: this.ensureNumber(impedanceSource?.variance, {
+                            field: 'metadata.impedance.variance',
+                            min: 0,
+                            max: 5000,
+                            defaultValue: 400,
+                            issues
+                        })
+                    };
+                }
+
+                if (safe.contactState !== undefined || metadataSource.contactState !== undefined) {
+                    const contactState = safe.contactState ?? metadataSource.contactState;
+                    metadata.contact = {
+                        state: this.ensureString(contactState, {
+                            field: 'metadata.contact.state',
+                            allowEmpty: false,
+                            fallback: 'unknown',
+                            issues
+                        }),
+                        electrodes: Array.isArray(safe.electrodes)
+                            ? safe.electrodes.map((value, index) => this.ensureNumber(value, {
+                                field: `metadata.contact.electrodes[${index}]`,
+                                min: 0,
+                                max: 1,
+                                defaultValue: 0,
+                                precision: 2,
+                                issues
+                            }))
+                            : undefined
+                    };
+                }
+
+                if (safe.band && typeof safe.band === 'object') {
+                    metadata.band = {
+                        firmware: this.ensureString(safe.band.firmware, {
+                            field: 'metadata.band.firmware',
+                            allowEmpty: true,
+                            fallback: metadataSource.band?.firmware ?? null,
+                            issues
+                        }),
+                        hardwareRevision: this.ensureString(safe.band.hardwareRevision, {
+                            field: 'metadata.band.hardwareRevision',
+                            allowEmpty: true,
+                            fallback: metadataSource.band?.hardwareRevision ?? null,
+                            issues
+                        })
+                    };
+                }
+
+                if (safe.temperature !== undefined) {
+                    metadata.deviceTemperature = this.ensureNumber(safe.temperature, {
+                        field: 'metadata.deviceTemperature',
+                        min: 20,
+                        max: 55,
+                        defaultValue: 32,
+                        precision: 1,
+                        issues
+                    });
+                }
+
+                const metadataEntries = Object.entries(metadata)
+                    .filter(([, value]) => value !== undefined && value !== null
+                        && (!(typeof value === 'object') || Object.keys(value).length > 0));
+                const normalizedMetadata = metadataEntries.length ? Object.fromEntries(metadataEntries) : {};
+
+                const firmwareVersion = this.ensureString(safe.firmwareVersion ?? metadataSource.firmwareVersion, {
+                    field: 'firmwareVersion',
+                    allowEmpty: true,
+                    fallback: null,
+                    issues
+                });
+
+                const deviceId = this.ensureString(safe.deviceId ?? metadataSource.deviceId, {
+                    field: 'deviceId',
+                    allowEmpty: false,
+                    fallback: 'wearable.neural-band',
+                    issues
+                }) || 'wearable.neural-band';
+
+                const confidence = this.ensureNumber(
+                    safe.confidence ?? safe.signalQuality?.overall,
+                    {
+                        field: 'confidence',
+                        min: 0,
+                        max: 1,
+                        defaultValue: intentChannel?.confidence ?? 0.7,
+                        issues
+                    }
+                );
+
+                return {
+                    payload: {
+                        deviceId,
+                        firmwareVersion,
+                        channels,
+                        metadata: normalizedMetadata
+                    },
+                    issues
+                };
+            },
+            fallback: {
+                deviceId: 'wearable.neural-band',
+                firmwareVersion: null,
+                channels: {
+                    'neural-intent': { confidence: 0, payload: { x: 0, y: 0, z: 0, w: 0, engagement: 0.4 } },
+                    gesture: { confidence: 0, payload: { intent: null, vector: { x: 0, y: 0, z: 0 } } }
+                },
+                metadata: {}
+            }
+        });
+
+        this.register('wearable.biometric-wrist', {
+            normalize: payload => {
+                const issues = [];
+                const safe = payload && typeof payload === 'object' ? payload : {};
+                const metadataSource = safe.metadata && typeof safe.metadata === 'object' ? safe.metadata : {};
+                const channelSource = safe.channels && typeof safe.channels === 'object' ? safe.channels : {};
+
+                const vitalsSource = channelSource.biometric ?? safe.vitals ?? safe.biometric ?? null;
+                const ambientSource = channelSource.ambient ?? safe.environment ?? null;
+
+                const channels = {};
+
+                const vitalsChannel = this.normalizeWearableChannel('biometric', vitalsSource, {
+                    schemaType: 'biometric',
+                    defaultConfidence: 0.78,
+                    missingConfidence: 0,
+                    confidence: safe.quality?.vitals ?? safe.quality?.overall,
+                    issues,
+                    required: true,
+                    confidenceField: 'channels.biometric.confidence'
+                });
+                if (vitalsChannel) {
+                    if (vitalsSource && typeof vitalsSource === 'object') {
+                        if ('oxygen' in vitalsSource) {
+                            vitalsChannel.payload.oxygen = this.ensureNumber(vitalsSource.oxygen, {
+                                field: 'channels.biometric.oxygen',
+                                min: 0,
+                                max: 1,
+                                defaultValue: 0.97,
+                                precision: 2,
+                                issues
+                            });
+                        }
+                        if ('hrv' in vitalsSource) {
+                            vitalsChannel.payload.hrv = this.ensureNumber(vitalsSource.hrv, {
+                                field: 'channels.biometric.hrv',
+                                min: 0,
+                                max: 250,
+                                defaultValue: 42,
+                                precision: 1,
+                                issues
+                            });
+                        }
+                    }
+                    channels.biometric = vitalsChannel;
+                }
+
+                const ambientChannel = this.normalizeWearableChannel('ambient', ambientSource, {
+                    schemaType: 'ambient',
+                    defaultConfidence: 0.6,
+                    confidence: safe.quality?.environment ?? safe.quality?.motion,
+                    issues,
+                    confidenceField: 'channels.ambient.confidence'
+                });
+                if (ambientChannel) {
+                    if (ambientSource && typeof ambientSource === 'object') {
+                        if ('humidity' in ambientSource) {
+                            ambientChannel.payload.humidity = this.ensureNumber(ambientSource.humidity, {
+                                field: 'channels.ambient.humidity',
+                                min: 0,
+                                max: 1,
+                                defaultValue: 0.45,
+                                precision: 2,
+                                issues
+                            });
+                        }
+                        if ('temperature' in ambientSource) {
+                            ambientChannel.payload.temperature = this.ensureNumber(ambientSource.temperature, {
+                                field: 'channels.ambient.temperature',
+                                min: -10,
+                                max: 50,
+                                defaultValue: 22,
+                                precision: 1,
+                                issues
+                            });
+                        }
+                    }
+                    channels.ambient = ambientChannel;
+                }
+
+                const metadata = {};
+                const batterySource = safe.batteryLevel ?? metadataSource.batteryLevel;
+                if (batterySource !== undefined) {
+                    metadata.batteryLevel = this.ensureNumber(batterySource, {
+                        field: 'metadata.batteryLevel',
+                        min: 0,
+                        max: 1,
+                        defaultValue: 1,
+                        precision: 2,
+                        issues
+                    });
+                }
+
+                const contactSource = safe.skinContact ?? metadataSource.skinContact;
+                if (contactSource !== undefined) {
+                    metadata.skinContact = this.ensureBoolean(contactSource, {
+                        field: 'metadata.skinContact',
+                        defaultValue: true,
+                        issues
+                    });
+                }
+
+                const lastSyncSource = safe.lastSync ?? metadataSource.lastSync;
+                if (lastSyncSource) {
+                    const syncDate = new Date(lastSyncSource);
+                    metadata.lastSync = Number.isNaN(syncDate.getTime()) ? null : syncDate.toISOString();
+                    if (metadata.lastSync === null) {
+                        issues.push({
+                            field: 'metadata.lastSync',
+                            code: 'invalid',
+                            message: 'lastSync is not a valid timestamp.'
+                        });
+                    }
+                }
+
+                if (safe.motion && typeof safe.motion === 'object') {
+                    metadata.motion = {
+                        acceleration: {
+                            x: this.ensureNumber(safe.motion.acceleration?.x, {
+                                field: 'metadata.motion.acceleration.x',
+                                min: -16,
+                                max: 16,
+                                defaultValue: 0,
+                                precision: 2,
+                                issues
+                            }),
+                            y: this.ensureNumber(safe.motion.acceleration?.y, {
+                                field: 'metadata.motion.acceleration.y',
+                                min: -16,
+                                max: 16,
+                                defaultValue: 0,
+                                precision: 2,
+                                issues
+                            }),
+                            z: this.ensureNumber(safe.motion.acceleration?.z, {
+                                field: 'metadata.motion.acceleration.z',
+                                min: -16,
+                                max: 16,
+                                defaultValue: 0,
+                                precision: 2,
+                                issues
+                            })
+                        }
+                    };
+                }
+
+                if (safe.deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = this.ensureNumber(safe.deviceTemperature, {
+                        field: 'metadata.deviceTemperature',
+                        min: 20,
+                        max: 50,
+                        defaultValue: 32,
+                        precision: 1,
+                        issues
+                    });
+                }
+
+                const metadataEntries = Object.entries(metadata)
+                    .filter(([, value]) => value !== undefined && value !== null
+                        && (!(typeof value === 'object') || Object.keys(value).length > 0));
+                const normalizedMetadata = metadataEntries.length ? Object.fromEntries(metadataEntries) : {};
+
+                const firmwareVersion = this.ensureString(safe.firmwareVersion ?? metadataSource.firmwareVersion, {
+                    field: 'firmwareVersion',
+                    allowEmpty: true,
+                    fallback: null,
+                    issues
+                });
+
+                const deviceId = this.ensureString(safe.deviceId ?? metadataSource.deviceId, {
+                    field: 'deviceId',
+                    allowEmpty: false,
+                    fallback: 'wearable.biometric-wrist',
+                    issues
+                }) || 'wearable.biometric-wrist';
+
+                const confidence = this.ensureNumber(
+                    safe.confidence ?? safe.quality?.overall,
+                    {
+                        field: 'confidence',
+                        min: 0,
+                        max: 1,
+                        defaultValue: vitalsChannel?.confidence ?? 0.78,
+                        issues
+                    }
+                );
+
+                return {
+                    payload: {
+                        deviceId,
+                        firmwareVersion,
+                        channels,
+                        metadata: normalizedMetadata
+                    },
+                    issues
+                };
+            },
+            fallback: {
+                deviceId: 'wearable.biometric-wrist',
+                firmwareVersion: null,
+                channels: {
+                    biometric: { confidence: 0, payload: { stress: 0.2, heartRate: 68, temperature: 36.4 } },
+                    ambient: { confidence: 0, payload: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 } }
+                },
+                metadata: {}
+            }
+        });
     }
 }

--- a/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
@@ -1,0 +1,124 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const vectorFromHeadset = (source = {}) => ({
+    x: Number.isFinite(source.x) ? source.x : 0,
+    y: Number.isFinite(source.y) ? source.y : 0,
+    z: Number.isFinite(source.z) ? source.z : 0
+});
+
+const merge = (...sources) => {
+    const output = {};
+    for (const source of sources) {
+        if (!source || typeof source !== 'object') continue;
+        for (const [key, value] of Object.entries(source)) {
+            if (value === undefined) continue;
+            output[key] = value;
+        }
+    }
+    return output;
+};
+
+export class ARVisorWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.ar-visor',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-ar-visor',
+            defaultConfidence: options.defaultConfidence ?? 0.82,
+            ...options
+        });
+
+        this.defaultFieldOfView = options.defaultFieldOfView || { horizontal: 96, vertical: 89 };
+    }
+
+    normalizeSample(raw = {}) {
+        const channels = {};
+        const metadata = {};
+
+        const gaze = raw.gaze || raw.focus || raw.channels?.['eye-tracking'] || null;
+        if (gaze) {
+            channels['eye-tracking'] = {
+                confidence: gaze.confidence ?? raw.focusConfidence ?? raw.quality?.focus,
+                payload: {
+                    x: gaze.x,
+                    y: gaze.y,
+                    depth: gaze.depth,
+                    vergence: gaze.vergence,
+                    stability: gaze.stability,
+                    blinkRate: gaze.blinkRate,
+                    fixation: gaze.fixation
+                }
+            };
+        }
+
+        const environment = raw.environment || raw.channels?.ambient || null;
+        if (environment) {
+            channels.ambient = {
+                confidence: environment.confidence ?? raw.quality?.environment,
+                payload: {
+                    luminance: environment.luminance,
+                    noiseLevel: environment.noiseLevel,
+                    motion: environment.motion,
+                    temperature: environment.temperature
+                }
+            };
+        }
+
+        const gesture = raw.gesture || raw.channels?.gesture || null;
+        if (gesture) {
+            const vector = gesture.vector || gesture.orientation || gesture.head || {};
+            channels.gesture = {
+                confidence: gesture.confidence ?? raw.quality?.gesture ?? raw.quality?.focus,
+                payload: {
+                    intent: gesture.intent ?? gesture.type ?? null,
+                    vector: vectorFromHeadset(vector),
+                    intentStrength: gesture.intentStrength
+                }
+            };
+        }
+
+        const pose = raw.pose || {};
+        if (pose.orientation || pose.position) {
+            metadata.pose = {
+                orientation: merge({ x: 0, y: 0, z: 0, w: 1 }, pose.orientation),
+                position: merge({ x: 0, y: 0, z: 0 }, pose.position)
+            };
+        }
+
+        const fieldOfView = merge(this.defaultFieldOfView, raw.fieldOfView, raw.metadata?.fieldOfView);
+        if (Object.keys(fieldOfView).length) {
+            metadata.fieldOfView = fieldOfView;
+        }
+
+        if (raw.optics) {
+            metadata.optics = { ...raw.optics };
+        }
+
+        const batteryLevel = raw.batteryLevel ?? raw.metadata?.batteryLevel;
+        if (batteryLevel !== undefined) {
+            metadata.batteryLevel = batteryLevel;
+        }
+
+        const deviceTemperature = raw.deviceTemperature ?? raw.metadata?.deviceTemperature ?? environment?.temperature;
+        if (deviceTemperature !== undefined) {
+            metadata.deviceTemperature = deviceTemperature;
+        }
+
+        const uptimeSeconds = raw.uptimeSeconds ?? raw.metadata?.uptimeSeconds;
+        if (uptimeSeconds !== undefined) {
+            metadata.uptimeSeconds = uptimeSeconds;
+        }
+
+        const firmwareVersion = raw.firmwareVersion ?? raw.metadata?.firmwareVersion;
+
+        return {
+            confidence: raw.confidence ?? raw.quality?.overall ?? channels['eye-tracking']?.confidence,
+            payload: {
+                deviceId: raw.deviceId,
+                firmwareVersion,
+                channels,
+                metadata
+            }
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
@@ -1,0 +1,335 @@
+const clamp = (value, min, max) => {
+    if (!Number.isFinite(value)) return value;
+    if (typeof min === 'number' && value < min) return min;
+    if (typeof max === 'number' && value > max) return max;
+    return value;
+};
+
+const clampConfidence = (value, fallback = 0.75) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return clamp(fallback, 0, 1);
+    }
+    return clamp(numeric, 0, 1);
+};
+
+const clone = value => {
+    if (value == null || typeof value !== 'object') {
+        return value ?? null;
+    }
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(value);
+        } catch (error) {
+            // Fall back to JSON copy below
+        }
+    }
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+        return { ...value };
+    }
+};
+
+const compactObject = value => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return value;
+    }
+    const entries = Object.entries(value)
+        .map(([key, entryValue]) => {
+            if (entryValue == null) {
+                return null;
+            }
+            if (typeof entryValue === 'object' && !Array.isArray(entryValue)) {
+                const compacted = compactObject(entryValue);
+                if (compacted == null) {
+                    return null;
+                }
+                if (typeof compacted === 'object' && Object.keys(compacted).length === 0) {
+                    return null;
+                }
+                return [key, compacted];
+            }
+            if (Array.isArray(entryValue) && entryValue.length === 0) {
+                return null;
+            }
+            return [key, entryValue];
+        })
+        .filter(Boolean);
+
+    if (entries.length === 0) {
+        return null;
+    }
+
+    return Object.fromEntries(entries);
+};
+
+const compactChannels = (channels, fallbackConfidence) => {
+    if (!channels || typeof channels !== 'object') {
+        return {};
+    }
+    const normalized = {};
+    for (const [type, channel] of Object.entries(channels)) {
+        if (!channel) continue;
+        const payload = channel.payload && typeof channel.payload === 'object'
+            ? { ...channel.payload }
+            : (channel.payload ?? {});
+        normalized[type] = {
+            payload,
+            confidence: clampConfidence(channel.confidence, fallbackConfidence)
+        };
+    }
+    return normalized;
+};
+
+const summarizeMetadata = metadata => {
+    if (!metadata || typeof metadata !== 'object') {
+        return undefined;
+    }
+    const summary = {};
+    if (metadata.batteryLevel !== undefined) summary.batteryLevel = metadata.batteryLevel;
+    if (metadata.deviceTemperature !== undefined) summary.deviceTemperature = metadata.deviceTemperature;
+    if (metadata.skinContact !== undefined) summary.skinContact = metadata.skinContact;
+    if (metadata.signalQuality) summary.signalQuality = metadata.signalQuality;
+    if (metadata.uptimeSeconds !== undefined) summary.uptimeSeconds = metadata.uptimeSeconds;
+    if (metadata.fieldOfView) summary.fieldOfView = metadata.fieldOfView;
+    return Object.keys(summary).length > 0 ? summary : undefined;
+};
+
+export class BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        const {
+            deviceId = 'wearable-device',
+            firmwareVersion = null,
+            telemetry = null,
+            telemetryScope = 'sensors.adapter',
+            telemetryClassification = 'system',
+            licenseManager = null,
+            requiredLicenseFeature = null,
+            schemaType = 'wearable.generic',
+            defaultConfidence = 0.75,
+            sampleProvider,
+            transport = null,
+            trace,
+            traceLoop = true,
+            recordTelemetryMetadata = true
+        } = options;
+
+        this.deviceId = deviceId;
+        this.firmwareVersion = firmwareVersion;
+        this.telemetry = telemetry;
+        this.telemetryScope = telemetryScope;
+        this.telemetryClassification = telemetryClassification;
+        this.licenseManager = licenseManager;
+        this.requiredLicenseFeature = requiredLicenseFeature;
+        this.schemaType = schemaType;
+        this.defaultConfidence = defaultConfidence;
+        this.transport = transport || null;
+        this.recordTelemetryMetadata = recordTelemetryMetadata;
+
+        this.trace = Array.isArray(trace) ? [...trace] : null;
+        this.traceLoop = traceLoop !== false;
+        this.traceIndex = 0;
+
+        this.sampleProvider = typeof sampleProvider === 'function'
+            ? sampleProvider
+            : this.createDefaultSampleProvider();
+
+        this.connected = false;
+        this.lastLicenseBlock = null;
+    }
+
+    createDefaultSampleProvider() {
+        if (this.transport) {
+            return async () => {
+                if (typeof this.transport.nextSample === 'function') {
+                    return this.transport.nextSample();
+                }
+                if (typeof this.transport.read === 'function') {
+                    return this.transport.read();
+                }
+                return null;
+            };
+        }
+
+        if (!this.trace) {
+            return async () => null;
+        }
+
+        return async () => {
+            if (!this.trace.length) {
+                return null;
+            }
+            if (this.traceIndex >= this.trace.length) {
+                if (!this.traceLoop) {
+                    return null;
+                }
+                this.traceIndex = 0;
+            }
+            const entry = this.trace[this.traceIndex++];
+            if (typeof entry === 'function') {
+                return entry();
+            }
+            if (!entry || typeof entry !== 'object') {
+                return entry ?? null;
+            }
+            return clone(entry);
+        };
+    }
+
+    async connect() {
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return;
+        }
+
+        if (this.transport?.connect) {
+            await this.transport.connect();
+        }
+
+        this.resetTrace();
+        this.connected = true;
+        this.track('connected', { status: 'connected' });
+    }
+
+    async disconnect() {
+        if (this.transport?.disconnect) {
+            await this.transport.disconnect();
+        }
+        this.connected = false;
+        this.track('disconnected', { status: 'disconnected' });
+    }
+
+    async read() {
+        if (!this.connected) {
+            await this.connect();
+            if (!this.connected) {
+                return null;
+            }
+        }
+
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return null;
+        }
+
+        const raw = await this.sampleProvider();
+        if (!raw) {
+            return null;
+        }
+
+        const normalized = this.normalizeSample(raw);
+        if (!normalized || typeof normalized !== 'object') {
+            return null;
+        }
+
+        const confidence = clampConfidence(normalized.confidence, this.defaultConfidence);
+        const payload = this.decoratePayload(normalized.payload || {});
+
+        this.track('sample', {
+            confidence,
+            channels: Object.keys(payload.channels || {}),
+            metadata: this.recordTelemetryMetadata ? summarizeMetadata(payload.metadata) : undefined
+        });
+
+        return { confidence, payload };
+    }
+
+    normalizeSample(raw) {
+        return {
+            confidence: this.defaultConfidence,
+            payload: raw
+        };
+    }
+
+    decoratePayload(payload) {
+        const base = payload && typeof payload === 'object' ? { ...payload } : {};
+        if (!base.deviceId) {
+            base.deviceId = this.deviceId;
+        }
+        if (base.firmwareVersion == null && this.firmwareVersion != null) {
+            base.firmwareVersion = this.firmwareVersion;
+        }
+        if (base.channels) {
+            base.channels = compactChannels(base.channels, this.defaultConfidence);
+        }
+        if (base.metadata) {
+            const compacted = compactObject(base.metadata);
+            base.metadata = compacted || {};
+        }
+        return base;
+    }
+
+    async ensureLicense() {
+        if (!this.licenseManager) {
+            return true;
+        }
+
+        const status = typeof this.licenseManager.getStatus === 'function'
+            ? this.licenseManager.getStatus()
+            : null;
+
+        if (!status || status.state !== 'valid') {
+            this.noteLicenseBlock('status', status);
+            return false;
+        }
+
+        if (this.requiredLicenseFeature && typeof this.licenseManager.hasFeature === 'function') {
+            if (!this.licenseManager.hasFeature(this.requiredLicenseFeature)) {
+                this.noteLicenseBlock('feature', status);
+                return false;
+            }
+        }
+
+        this.lastLicenseBlock = null;
+        return true;
+    }
+
+    noteLicenseBlock(reason, status) {
+        const snapshot = JSON.stringify({ reason, status });
+        if (snapshot === this.lastLicenseBlock) {
+            return;
+        }
+        this.lastLicenseBlock = snapshot;
+        this.recordAudit('license_blocked', { reason, status });
+    }
+
+    recordAudit(eventSuffix, payload) {
+        if (!this.telemetry?.recordAudit) {
+            return;
+        }
+        this.telemetry.recordAudit(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            }
+        );
+    }
+
+    track(eventSuffix, payload) {
+        if (!this.telemetry?.track) {
+            return;
+        }
+        this.telemetry.track(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            },
+            { classification: this.telemetryClassification }
+        );
+    }
+
+    resetTrace() {
+        this.traceIndex = 0;
+        if (this.transport?.reset) {
+            this.transport.reset();
+        }
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
@@ -1,0 +1,94 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const normalizeAcceleration = source => ({
+    x: source?.x ?? 0,
+    y: source?.y ?? 0,
+    z: source?.z ?? 0
+});
+
+export class BiometricWristWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.biometric-wrist',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-biometric',
+            defaultConfidence: options.defaultConfidence ?? 0.78,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const channels = {};
+        const metadata = {};
+
+        const vitals = raw.vitals || raw.biometric || raw.channels?.biometric || null;
+        if (vitals) {
+            channels.biometric = {
+                confidence: vitals.confidence ?? raw.quality?.vitals ?? raw.quality?.overall,
+                payload: {
+                    stress: vitals.stress,
+                    heartRate: vitals.heartRate,
+                    temperature: vitals.temperature,
+                    oxygen: vitals.oxygen,
+                    hrv: vitals.hrv
+                }
+            };
+        }
+
+        const environment = raw.environment || raw.channels?.ambient || null;
+        if (environment) {
+            channels.ambient = {
+                confidence: environment.confidence ?? raw.quality?.environment ?? raw.quality?.motion,
+                payload: {
+                    luminance: environment.luminance,
+                    noiseLevel: environment.noiseLevel,
+                    motion: environment.motion,
+                    temperature: environment.temperature,
+                    humidity: environment.humidity
+                }
+            };
+        }
+
+        const batteryLevel = raw.batteryLevel ?? raw.metadata?.batteryLevel;
+        if (batteryLevel !== undefined) {
+            metadata.batteryLevel = batteryLevel;
+        }
+
+        const skinContact = raw.skinContact ?? raw.metadata?.skinContact;
+        if (skinContact !== undefined) {
+            metadata.skinContact = skinContact;
+        }
+
+        const lastSync = raw.lastSync ?? raw.metadata?.lastSync;
+        if (lastSync) {
+            metadata.lastSync = lastSync;
+        }
+
+        if (raw.motion) {
+            metadata.motion = {
+                acceleration: normalizeAcceleration(raw.motion.acceleration || raw.motion)
+            };
+        }
+
+        const deviceTemperature = raw.deviceTemperature ?? raw.metadata?.deviceTemperature;
+        if (deviceTemperature !== undefined) {
+            metadata.deviceTemperature = deviceTemperature;
+        }
+
+        if (raw.alerts) {
+            metadata.alerts = Array.isArray(raw.alerts) ? [...raw.alerts] : [raw.alerts];
+        }
+
+        const firmwareVersion = raw.firmwareVersion ?? raw.metadata?.firmwareVersion;
+
+        return {
+            confidence: raw.confidence ?? raw.quality?.overall ?? channels.biometric?.confidence,
+            payload: {
+                deviceId: raw.deviceId,
+                firmwareVersion,
+                channels,
+                metadata
+            }
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
@@ -1,0 +1,101 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const normalizeElectrode = value => {
+    if (!Array.isArray(value)) return undefined;
+    return value.map((entry, index) => {
+        const numeric = Number(entry);
+        if (!Number.isFinite(numeric)) {
+            return index % 2 === 0 ? 0.48 : 0.52;
+        }
+        return numeric;
+    });
+};
+
+export class NeuralBandWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.neural-band',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-neural-band',
+            defaultConfidence: options.defaultConfidence ?? 0.7,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const channels = {};
+        const metadata = {};
+
+        const intent = raw.intent || raw.signal || raw.channels?.['neural-intent'] || null;
+        if (intent) {
+            channels['neural-intent'] = {
+                confidence: intent.confidence ?? raw.signalQuality?.overall ?? raw.quality?.intent,
+                payload: {
+                    x: intent.x,
+                    y: intent.y,
+                    z: intent.z,
+                    w: intent.w,
+                    engagement: intent.engagement,
+                    signalToNoise: intent.signalToNoise,
+                    bandwidth: intent.bandwidth
+                }
+            };
+        }
+
+        const gesture = raw.gesture || raw.channels?.gesture || null;
+        if (gesture) {
+            channels.gesture = {
+                confidence: gesture.confidence ?? raw.quality?.gesture,
+                payload: {
+                    intent: gesture.intent ?? null,
+                    vector: gesture.vector || gesture.direction || { x: 0, y: 0, z: 0 }
+                }
+            };
+        }
+
+        if (raw.signalQuality) {
+            metadata.signalQuality = {
+                overall: raw.signalQuality.overall,
+                contacts: raw.signalQuality.contacts
+            };
+        }
+
+        if (raw.impedance || raw.metadata?.impedance) {
+            const impedance = raw.impedance || raw.metadata?.impedance;
+            metadata.impedance = {
+                average: impedance.average,
+                variance: impedance.variance
+            };
+        }
+
+        if (raw.contactState !== undefined || raw.metadata?.contactState !== undefined) {
+            metadata.contact = {
+                state: raw.contactState ?? raw.metadata?.contactState,
+                electrodes: normalizeElectrode(raw.electrodes || raw.metadata?.electrodes)
+            };
+        }
+
+        if (raw.band || raw.metadata?.band) {
+            metadata.band = {
+                firmware: raw.band?.firmware ?? raw.metadata?.band?.firmware,
+                hardwareRevision: raw.band?.hardwareRevision ?? raw.metadata?.band?.hardwareRevision
+            };
+        }
+
+        if (raw.temperature !== undefined) {
+            metadata.deviceTemperature = raw.temperature;
+        }
+
+        const firmwareVersion = raw.firmwareVersion ?? raw.metadata?.firmwareVersion;
+
+        return {
+            confidence: raw.confidence ?? raw.signalQuality?.overall ?? channels['neural-intent']?.confidence,
+            payload: {
+                deviceId: raw.deviceId,
+                firmwareVersion,
+                channels,
+                metadata
+            }
+        };
+    }
+}
+

--- a/tests/vitest/wearables-adapters.test.js
+++ b/tests/vitest/wearables-adapters.test.js
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { SensorSchemaRegistry } from '../../src/ui/adaptive/sensors/SensorSchemaRegistry.js';
+import { SensoryInputBridge } from '../../src/ui/adaptive/SensoryInputBridge.js';
+import { BiometricWristWearableAdapter } from '../../src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js';
+import { LicenseManager } from '../../src/product/licensing/LicenseManager.js';
+
+describe('Wearable sensor schemas', () => {
+    let registry;
+
+    beforeEach(() => {
+        registry = new SensorSchemaRegistry();
+    });
+
+    it('normalizes AR visor payloads with clamping and metadata synthesis', () => {
+        const result = registry.validate('wearable.ar-visor', {
+            deviceId: 'visor-alpha',
+            firmwareVersion: '1.2.0-beta',
+            gaze: { x: 1.4, y: -0.3, depth: 2, vergence: 6, stability: -0.5, blinkRate: 4.2 },
+            environment: { luminance: 1.5, noiseLevel: -0.3, motion: 0.4, temperature: 82 },
+            gesture: { intent: 'swipe-right', vector: { x: 1.4, y: -1.2, z: 0.8 }, intentStrength: 1.4 },
+            fieldOfView: { horizontal: 180, vertical: 20, diagonal: 210 },
+            batteryLevel: 1.3,
+            deviceTemperature: 72,
+            uptimeSeconds: -45,
+            pose: {
+                orientation: { x: 1.4, y: -1.8, z: 0.6, w: 2 },
+                position: { x: 8, y: -7, z: 0.6 }
+            },
+            quality: { focus: 0.92, environment: 0.31, gesture: 0.55 }
+        });
+
+        const eye = result.payload.channels['eye-tracking'];
+        expect(eye.payload.x).toBeCloseTo(1, 5);
+        expect(eye.payload.y).toBeCloseTo(0, 5);
+        expect(eye.payload.depth).toBeCloseTo(1, 5);
+        expect(eye.payload.vergence).toBeCloseTo(5, 5);
+        expect(eye.payload.stability).toBeCloseTo(0, 5);
+
+        const ambient = result.payload.channels.ambient;
+        expect(ambient.payload.luminance).toBeLessThanOrEqual(1);
+        expect(ambient.payload.noiseLevel).toBeGreaterThanOrEqual(0);
+        expect(ambient.payload.temperature).toBeLessThanOrEqual(60);
+
+        const gesture = result.payload.channels.gesture;
+        expect(gesture.payload.vector.x).toBeLessThanOrEqual(1);
+        expect(gesture.payload.vector.y).toBeGreaterThanOrEqual(-1);
+
+        const metadata = result.payload.metadata;
+        expect(metadata.fieldOfView.horizontal).toBeCloseTo(140, 5);
+        expect(metadata.fieldOfView.vertical).toBeCloseTo(35, 5);
+        expect(metadata.batteryLevel).toBeCloseTo(1, 5);
+        expect(metadata.deviceTemperature).toBeCloseTo(65, 5);
+        expect(metadata.uptimeSeconds).toBe(0);
+
+        expect(result.issues.length).toBeGreaterThan(0);
+        expect(result.payload.deviceId).toBe('visor-alpha');
+        expect(result.payload.firmwareVersion).toBe('1.2.0-beta');
+    });
+});
+
+describe('SensoryInputBridge wearable multiplexing', () => {
+    it('routes wearable composite payloads into semantic channels and emits metadata events', () => {
+        const bridge = new SensoryInputBridge({ autoConnectAdapters: false });
+        let metadataEvent = null;
+        bridge.subscribe('wearable.ar-visor:metadata', event => {
+            metadataEvent = event;
+        });
+
+        const payload = {
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            channels: {
+                'eye-tracking': { confidence: 0.9, payload: { x: 0.35, y: 0.62, depth: 0.42 } },
+                ambient: { confidence: 0.5, payload: { luminance: 0.58, noiseLevel: 0.24, motion: 0.16 } },
+                gesture: { confidence: 0.61, payload: { intent: 'tap', vector: { x: 0.1, y: 0.2, z: -0.05 } } }
+            },
+            metadata: { batteryLevel: 0.82 }
+        };
+
+        bridge.processSample('wearable.ar-visor', { confidence: 0.94, payload });
+
+        const snapshot = bridge.getSnapshot();
+        const expectedFocusX = 0.5 + (0.35 - 0.5) * 0.9;
+        const expectedFocusY = 0.5 + (0.62 - 0.5) * 0.9;
+        const expectedLuminance = 0.5 + (0.58 - 0.5) * 0.5;
+        expect(snapshot.focusVector.x).toBeCloseTo(expectedFocusX, 5);
+        expect(snapshot.focusVector.y).toBeCloseTo(expectedFocusY, 5);
+        expect(snapshot.environment.luminance).toBeCloseTo(expectedLuminance, 5);
+        expect(snapshot.gestureIntent).toBe('tap');
+
+        expect(metadataEvent).toEqual({
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            metadata: { batteryLevel: 0.82 },
+            confidence: 0.94,
+            timestamp: expect.any(Number)
+        });
+    });
+});
+
+describe('Wearable adapters', () => {
+    it('enforces licensing before streaming biometric wrist samples', async () => {
+        const telemetry = {
+            track: vi.fn(),
+            recordAudit: vi.fn()
+        };
+        const licenseManager = new LicenseManager();
+
+        const adapter = new BiometricWristWearableAdapter({
+            telemetry,
+            licenseManager,
+            deviceId: 'wrist-01',
+            trace: [
+                {
+                    vitals: { stress: 0.44, heartRate: 72, temperature: 37.4, oxygen: 0.97, hrv: 54 },
+                    environment: { luminance: 0.32, noiseLevel: 0.18, motion: 0.2, temperature: 24, humidity: 0.41 },
+                    quality: { overall: 0.91, vitals: 0.9, environment: 0.6 },
+                    batteryLevel: 0.76,
+                    skinContact: true
+                }
+            ]
+        });
+
+        const blocked = await adapter.read();
+        expect(blocked).toBeNull();
+        expect(telemetry.recordAudit).toHaveBeenCalled();
+        const [eventName, auditPayload] = telemetry.recordAudit.mock.calls[0];
+        expect(eventName).toContain('wearable.biometric-wrist.license_blocked');
+        expect(auditPayload).toMatchObject({ reason: 'status' });
+
+        telemetry.recordAudit.mockClear();
+
+        licenseManager.setLicense({ key: 'valid-key', features: ['wearables-biometric'] });
+        await licenseManager.validate();
+
+        const sample = await adapter.read();
+        expect(sample?.payload.channels.biometric).toBeDefined();
+        expect(sample?.payload.channels.biometric.payload.heartRate).toBe(72);
+        expect(telemetry.track).toHaveBeenCalled();
+        const trackCall = telemetry.track.mock.calls.find(([event]) => event.includes('wearable.biometric-wrist.sample'));
+        expect(trackCall).toBeDefined();
+        expect(trackCall[1].channels).toContain('biometric');
+        expect(trackCall[2]).toEqual({ classification: 'system' });
+        expect(telemetry.recordAudit).not.toHaveBeenCalled();
+    });
+});
+


### PR DESCRIPTION
## Summary
- extend the sensor schema registry with wearable-specific normalization helpers and device schemas
- add a reusable wearable device adapter base class plus AR visor, neural band, and biometric wrist implementations that stream telemetry-aware samples
- update the sensory bridge to multiplex wearable payloads, publish metadata, and document the new adapters in the SDK types with dedicated Vitest coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e947fe80b883299276fde55e59b349