### PR TITLE
Add wearable device manager and bridge history tracking

### DIFF
--- a/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
+++ b/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
@@ -1,0 +1,134 @@
+# Wearables Development – Phase Zero Execution Plan
+
+This plan establishes the concrete engineering path for taking the adaptive VIB34D wearables stack from Phase 0 (prototype) into sustained development. It scopes only the **wearables runtime and hardware integration lane**—the UI/web experience team will operate a parallel track and consume the telemetry/licensing foundations already delivered in this repository.
+
+## 1. Current Baseline
+
+- Adaptive runtime, telemetry, licensing, commercialization analytics, and projection/blueprint tooling already exist inside the SDK surface (`src/core`, `src/product`, `src/ui/adaptive`).
+- `wearable-designer.html` remains a monolithic demo shell demonstrating the features but is not yet modular or hardware-backed.
+- Telemetry, consent, licensing attestation, commercialization snapshotting, and projection scenario infrastructure are implemented and validated through Vitest + Playwright smoke coverage.
+- No production-grade wearable device adapters, schema-enforced sensor payload bridges, or deployment automation for wearable firmware/app containers exist.
+
+## 2. Phase Zero Objectives & Exit Criteria
+
+| Objective | Description | Exit Criteria |
+|-----------|-------------|---------------|
+| Establish Wearable Device Integration Foundations | Deliver reference adapters, schema validation, and telemetry routing for real sensor inputs. | Sensor schema registry covers real device payloads, adapters stream data into `SensoryInputBridge`, hardware smoke tests execute on CI rig. |
+| Modularize Wearable Runtime Package | Decouple the adaptive engine usage from the demo shell and expose reusable modules for firmware/app integrators. | `AdaptiveSDK` publishes wearable presets, modular samples replace demo wiring, API surface documented in `types/adaptive-sdk.d.ts`. |
+| Align with Telemetry/Licensing Track | Ensure wearables lane consumes and exercises telemetry, consent, licensing, commercialization flows owned by the web/UI team. | Shared acceptance tests confirm telemetry gating/licensing attestation triggered from hardware adapters; audit/compliance exports include wearable-origin metadata. |
+| Delivery Governance | Lock sprint cadence, tooling, and automation so Phase 1+ can scale. | Phase Zero completion review, tracker entries updated, automated smoke lane for hardware registered in CI. |
+
+Phase Zero concludes once real wearable signals hydrate the adaptive engine end-to-end (including telemetry/licensing flows), modular runtime packages ship with documentation, and repeatable automation validates integrations.
+
+## 3. Workstreams & Tasks
+
+### 3.1 Hardware & Sensor Integration
+
+1. **Device Inventory & Payload Mapping**
+   - Catalogue initial wearable targets (AR visor, neural band, biometric wrist device).
+   - Extract data formats, sampling rates, consent requirements.
+   - Update `SensorSchemaRegistry` with concrete schema definitions and tolerance ranges.
+2. **Adapter Development**
+   - Implement `src/ui/adaptive/sensors/adapters/<device>.js` for each device with normalization logic feeding `SensoryInputBridge`.
+   - Provide mock adapter implementations for local development and automated tests.
+3. **Hardware Smoke Bench**
+   - Script Playwright/Vitest-compatible harness to replay recorded sensor streams.
+   - Automate on-device smoke test recipe (e.g., Node bridge + WebSocket feed) to validate integration before firmware drops.
+4. **Telemetry Hook-Up**
+   - Ensure adapters flag telemetry classifications via `ProductTelemetryHarness`.
+   - Confirm licensing profiles (e.g., `wearables-pro`, `wearables-enterprise`) gate sensor activation.
+
+### 3.2 Adaptive Runtime Hardening
+
+1. **Runtime Profiles**
+   - Package wearable presets inside `AdaptiveSDK` (synthesizer strategies, annotations, projection packs).
+   - Document DI entry points for firmware/app teams.
+2. **Blueprint & Projection Validation**
+   - Add automated checks ensuring `LayoutBlueprintRenderer` and `ProjectionFieldComposer` operate within hardware constraints (FOV, refresh windows, energy budgets).
+   - Extend validator outputs with device-specific warnings.
+3. **Commercialization Touchpoints**
+   - Preconfigure commercialization snapshot/store adapters for wearable SKUs.
+   - Verify commercialization KPIs remain accurate when signals originate from hardware adapters.
+
+### 3.3 Packaging & Distribution
+
+1. **Module Extraction**
+   - Break down `wearable-designer.html` dependencies into reusable modules (awaiting B-05 but begin with runtime packaging).
+   - Publish reference implementations under `packages/wearables-kit` (or similar) with bundler config, typings, and quickstart README.
+2. **Firmware/Companion App SDK**
+   - Provide minimal Node/TypeScript wrapper for wearable firmware teams to embed adaptive runtime via WebView or native bridge.
+   - Document telemetry/licensing handshake requirements for companion apps.
+3. **Release Automation**
+   - Set up semantic versioning, changelog generation, and artifact publishing (internal registry) for wearables kit.
+
+### 3.4 Governance & Collaboration
+
+1. **Phase Zero Sprints**
+   - Sprint 0: Inventory + schema updates, finalize adapter scaffolding.
+   - Sprint 1: Implement first hardware adapter + mock harness; integrate telemetry/licensing flows.
+   - Sprint 2: Runtime presets, commercialization validation, documentation draft.
+   - Sprint 3: Packaging, release automation, cross-track demo review.
+2. **Cross-Track Agreements**
+   - Weekly sync with UI/web track to share telemetry/licensing API changes.
+   - Shared definition of done referencing compliance exports and commercialization dashboards.
+3. **Documentation Deliverables**
+   - Update `DOCS/ADAPTIVE_SDK_DEVELOPER_HANDOFF_GUIDE.md` with wearable hardware lane.
+   - Produce hardware integration cookbook (per device) and troubleshooting FAQ.
+
+## 4. Dependencies & Interfaces
+
+- **Telemetry/Licensing:** Consume existing providers (`ProductTelemetryHarness`, `LicenseManager`, `LicenseAttestationProfileRegistry`). Hardware adapters must emit consent state and licensing context; UI/web track owns dashboards/export visualization.
+- **Testing Stack:** Reuse Vitest for unit coverage, Playwright for consent/licensing flows, extend to include sensor stream replays. Consider integrating hardware lab harness via GitHub Actions self-hosted runner.
+- **Types & SDK Surface:** Continue expanding `types/adaptive-sdk.d.ts` for new adapter interfaces; ensure module packaging emits types for firmware teams.
+
+## 5. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Hardware availability delays | Blocks adapter validation and telemetry handshake. | Maintain recorded sensor traces; use emulators until devices arrive; schedule early vendor engagement. |
+| Drift between wearables kit and UI/web telemetry contract | Broken dashboards, inconsistent compliance exports. | Shared schema contract repo; automated contract tests run across both tracks. |
+| Performance constraints on low-power devices | Latency in adaptive layout/projection rendering. | Profile runtime on reference hardware; expose configuration knobs for throttling strategies; implement watchdog telemetry to flag overruns. |
+| Licensing/attestation mismatches | Sensor activation blocked or untracked monetization usage. | Pre-register wearables profiles in catalog; add integration tests for attestation flows triggered via adapters. |
+
+## 6. Deliverables Checklist
+
+- [ ] Updated sensor schema definitions + adapter scaffolding checked in.
+- [ ] Wearable device adapters streaming real data through `SensoryInputBridge`.
+- [ ] Automated harness replaying sensor traces in CI.
+- [ ] Adaptive runtime wearable presets packaged and documented.
+- [ ] Commercialization telemetry validated with hardware-origin signals.
+- [ ] Wearables kit packaging + release automation operational.
+- [ ] Cross-track demo review demonstrating end-to-end telemetry, licensing, commercialization, and adaptive visualization with live wearable input.
+
+## 7. Milestones, Staffing, and Reporting Cadence
+
+### 7.1 Sprint-by-Sprint Commitments
+
+| Sprint | Focus | Primary Deliverables |
+|--------|-------|----------------------|
+| Sprint 0 | Device discovery & schema foundation | Finalized device inventory, signed-off payload schemas, adapter scaffolding merged, mock sensor capture repository established. |
+| Sprint 1 | First hardware path live | AR visor adapter + mock harness replay in CI, telemetry/licensing contract tests green, firmware handoff notes published. |
+| Sprint 2 | Runtime + commercialization alignment | Wearable presets available via `AdaptiveSDK`, commercialization validation scripts automated, documentation walkthrough recorded. |
+| Sprint 3 | Packaging & release readiness | Wearables kit package published to internal registry, release automation validated, cross-track end-to-end demo executed. |
+
+### 7.2 Staffing & RACI Snapshot
+
+| Role | Lead | Accountable Areas |
+|------|------|-------------------|
+| Wearables Integration Lead | Embedded systems engineer | Device inventory, adapter implementation, hardware smoke bench upkeep. |
+| Adaptive Runtime Architect | Core runtime engineer | Preset packaging, performance profiling, commercialization checks. |
+| Telemetry/Licensing Liaison | Shared with UI/web track | Schema alignment, consent/licensing validation, compliance exports. |
+| DevOps & Release Owner | Platform engineer | CI hardware lane, semantic versioning, artifact publishing. |
+| Program Manager | Delivery coordinator | Sprint ceremonies, risk tracking, stakeholder comms, exit review facilitation. |
+
+### 7.3 Reporting Rhythm
+
+- **Daily**: Async stand-up updates in shared channel with blockers escalated within 2 hours.
+- **Twice Weekly**: Hardware adapter test report (device status, telemetry/licensing assertions, trace replay results).
+- **Weekly**: Cross-track sync with UI/web lane to reconcile API changes, licensing catalog updates, and commercialization dashboards.
+- **Sprint Reviews**: Joint demo including live wearable feed, telemetry/licensing dashboards, and commercialization snapshots.
+- **Sprint Retros**: Capture process improvements and feed into governance backlog ahead of Phase One scale-up.
+
+---
+
+**Next Action:** Kick off Sprint 0 by formalizing device inventory interviews, capturing payload specifications, and preparing schema updates within the existing adaptive runtime repositories.

--- a/src/ui/adaptive/sensors/SensorSchemaRegistry.js
+++ b/src/ui/adaptive/sensors/SensorSchemaRegistry.js
@@ -1,4 +1,13 @@
 /**
+ * SensorSchemaRegistry
+ * ------------------------------------------------------------
+ * Normalizes heterogeneous sensor payloads before they are applied to
+ * higher-level adaptive behaviours. The registry ships with baseline schemas
+ * for the core focus/intent/biometric channels and can be extended at runtime
+ * with wearables-specific composite payloads.
+ */
+
+/**
  * @typedef {Object} SensorSchemaIssue
  * @property {string} field
  * @property {string} code
@@ -15,15 +24,171 @@
  * @typedef {{ normalize(payload: Record<string, any>, registry: SensorSchemaRegistry): SensorSchemaResult | Record<string, any>; fallback?: Record<string, any>; }} SensorSchemaDefinition
  */
 
-const clamp = (value, min, max) => {
-    if (typeof min === 'number' && value < min) {
-        return min;
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = Array.isArray(path) ? path : String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
     }
-    if (typeof max === 'number' && value > max) {
-        return max;
-    }
-    return value;
+    return current;
 };
+
+const firstPresent = values => {
+    for (const value of values) {
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const compactObject = value => {
+    if (!isPlainObject(value)) return undefined;
+    const entries = Object.entries(value)
+        .filter(([, entry]) => entry !== undefined && entry !== null);
+    if (entries.length === 0) {
+        return undefined;
+    }
+    return Object.fromEntries(entries);
+};
+
+const sanitizeNumberArray = (registry, source, field, options = {}) => {
+    if (!Array.isArray(source) || source.length === 0) {
+        return undefined;
+    }
+    const sanitized = source.map((entry, index) => registry.ensureNumber(entry, {
+        ...options,
+        field: `${field}.${index}`
+    }));
+    return sanitized.length ? sanitized : undefined;
+};
+
+const createWearableCompositeSchema = config => ({
+    normalize(payload = {}, registry) {
+        const issues = [];
+        const safe = isPlainObject(payload) ? payload : {};
+
+        const deviceId = registry.ensureString(
+            firstPresent([
+                safe.deviceId,
+                config.defaultDeviceId
+            ]),
+            {
+                field: 'deviceId',
+                allowEmpty: false,
+                defaultValue: config.defaultDeviceId || 'wearable-device',
+                issues
+            }
+        );
+
+        const firmwareVersion = registry.ensureOptionalString(
+            firstPresent([
+                safe.firmwareVersion,
+                getPath(safe, 'metadata.firmwareVersion')
+            ]),
+            {
+                field: 'firmwareVersion',
+                defaultValue: null,
+                issues
+            }
+        );
+
+        const channels = {};
+        for (const channelConfig of config.channels || []) {
+            const rawSource = channelConfig.fromRaw
+                ? channelConfig.fromRaw(safe)
+                : firstPresent((channelConfig.sources || []).map(source => getPath(safe, source)));
+
+            if (!rawSource) {
+                if (channelConfig.required) {
+                    issues.push({
+                        field: `channels.${channelConfig.channel}`,
+                        code: 'missing',
+                        message: `${channelConfig.channel} channel is required.`
+                    });
+                }
+                continue;
+            }
+
+            const sourcePayload = isPlainObject(rawSource.payload)
+                ? rawSource.payload
+                : (isPlainObject(rawSource) ? rawSource : {});
+
+            const { payload: channelPayload, issues: channelIssues } = registry.validate(
+                channelConfig.schema,
+                sourcePayload
+            );
+
+            if (Array.isArray(channelIssues) && channelIssues.length) {
+                for (const issue of channelIssues) {
+                    issues.push({
+                        field: issue.field && issue.field !== '*'
+                            ? `channels.${channelConfig.channel}.${issue.field}`
+                            : `channels.${channelConfig.channel}`,
+                        code: issue.code,
+                        message: issue.message
+                    });
+                }
+            }
+
+            if (typeof channelConfig.extend === 'function') {
+                channelConfig.extend(channelPayload, rawSource, { registry, issues });
+            }
+
+            const confidenceCandidates = [];
+            if (Array.isArray(channelConfig.confidencePaths)) {
+                for (const path of channelConfig.confidencePaths) {
+                    confidenceCandidates.push(getPath({ source: rawSource, root: safe }, path));
+                }
+            } else if (typeof channelConfig.confidence === 'function') {
+                confidenceCandidates.push(channelConfig.confidence(rawSource, safe));
+            } else if (channelConfig.confidence !== undefined) {
+                confidenceCandidates.push(channelConfig.confidence);
+            } else {
+                confidenceCandidates.push(rawSource.confidence);
+            }
+
+            const confidence = registry.ensureNumber(
+                firstPresent(confidenceCandidates),
+                {
+                    field: `channels.${channelConfig.channel}.confidence`,
+                    min: 0,
+                    max: 1,
+                    defaultValue: channelConfig.defaultConfidence ?? 1,
+                    issues
+                }
+            );
+
+            channels[channelConfig.channel] = {
+                payload: channelPayload,
+                confidence
+            };
+        }
+
+        let metadata;
+        if (typeof config.metadata === 'function') {
+            metadata = compactObject(config.metadata(safe, { registry, issues }, config));
+        }
+
+        const normalized = {
+            deviceId,
+            firmwareVersion,
+            channels
+        };
+
+        if (metadata && Object.keys(metadata).length) {
+            normalized.metadata = metadata;
+        }
+
+        return { payload: normalized, issues };
+    }
+});
 
 export class SensorSchemaRegistry {
     constructor(options = {}) {
@@ -56,6 +221,26 @@ export class SensorSchemaRegistry {
         this.schemas.set(type, normalizedSchema);
     }
 
+    loadCustomSchemas(schemas) {
+        if (Array.isArray(schemas)) {
+            for (const entry of schemas) {
+                if (!entry) continue;
+                if (Array.isArray(entry) && entry.length === 2) {
+                    this.register(entry[0], entry[1]);
+                } else if (typeof entry === 'object' && entry.type && entry.schema) {
+                    this.register(entry.type, entry.schema);
+                }
+            }
+            return;
+        }
+
+        if (isPlainObject(schemas)) {
+            for (const [type, schema] of Object.entries(schemas)) {
+                this.register(type, schema);
+            }
+        }
+    }
+
     /**
      * @param {string} type
      * @param {Record<string, any>} payload
@@ -70,7 +255,10 @@ export class SensorSchemaRegistry {
         try {
             const result = schema.normalize(payload ?? {}, this);
             if (!result || typeof result !== 'object') {
-                return { payload: {}, issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }] };
+                return {
+                    payload: {},
+                    issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }]
+                };
             }
 
             if ('payload' in result) {
@@ -84,7 +272,7 @@ export class SensorSchemaRegistry {
         } catch (error) {
             return {
                 payload: schema.fallback ?? {},
-                issues: [{ field: '*', code: 'schema-error', message: error.message }]
+                issues: [{ field: '*', code: 'schema-error', message: error?.message || 'Schema normalization failed.' }]
             };
         }
     }
@@ -93,29 +281,26 @@ export class SensorSchemaRegistry {
         this.register('eye-tracking', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    x: this.ensureNumber(payload.x, {
-                        field: 'x',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.5,
-                        issues
-                    }),
-                    y: this.ensureNumber(payload.y, {
-                        field: 'y',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.5,
-                        issues
-                    }),
-                    depth: this.ensureNumber(payload.depth, {
-                        field: 'depth',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.3,
-                        issues
-                    })
+                    x: this.ensureNumber(safe.x, { field: 'x', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    y: this.ensureNumber(safe.y, { field: 'y', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    depth: this.ensureNumber(safe.depth, { field: 'depth', min: 0, max: 1, defaultValue: 0.3, precision: 3, issues })
                 };
+
+                if (safe.vergence !== undefined) {
+                    normalized.vergence = this.ensureNumber(safe.vergence, { field: 'vergence', min: 0, max: 5, defaultValue: 0, precision: 2, issues });
+                }
+                if (safe.stability !== undefined) {
+                    normalized.stability = this.ensureNumber(safe.stability, { field: 'stability', min: 0, max: 1, defaultValue: 0.5, precision: 2, issues });
+                }
+                if (safe.blinkRate !== undefined) {
+                    normalized.blinkRate = this.ensureNumber(safe.blinkRate, { field: 'blinkRate', min: 0, max: 2.5, defaultValue: 0.2, precision: 2, issues });
+                }
+                if (safe.fixation !== undefined) {
+                    normalized.fixation = this.ensureNumber(safe.fixation, { field: 'fixation', min: 0, max: 1, defaultValue: 0, precision: 3, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { x: 0.5, y: 0.5, depth: 0.3 }
@@ -124,19 +309,22 @@ export class SensorSchemaRegistry {
         this.register('neural-intent', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    x: this.ensureNumber(payload.x, { field: 'x', min: -1, max: 1, defaultValue: 0, issues }),
-                    y: this.ensureNumber(payload.y, { field: 'y', min: -1, max: 1, defaultValue: 0, issues }),
-                    z: this.ensureNumber(payload.z, { field: 'z', min: -1, max: 1, defaultValue: 0, issues }),
-                    w: this.ensureNumber(payload.w, { field: 'w', min: -1, max: 1, defaultValue: 0, issues }),
-                    engagement: this.ensureNumber(payload.engagement, {
-                        field: 'engagement',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.4,
-                        issues
-                    })
+                    x: this.ensureNumber(safe.x, { field: 'x', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    y: this.ensureNumber(safe.y, { field: 'y', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    z: this.ensureNumber(safe.z, { field: 'z', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    w: this.ensureNumber(safe.w, { field: 'w', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    engagement: this.ensureNumber(safe.engagement, { field: 'engagement', min: 0, max: 1, defaultValue: 0.4, precision: 3, issues })
                 };
+
+                if (safe.signalToNoise !== undefined) {
+                    normalized.signalToNoise = this.ensureNumber(safe.signalToNoise, { field: 'signalToNoise', min: 0, max: 60, defaultValue: 0, precision: 2, issues });
+                }
+                if (safe.bandwidth !== undefined) {
+                    normalized.bandwidth = this.ensureNumber(safe.bandwidth, { field: 'bandwidth', min: 0, max: 200, defaultValue: 0, precision: 2, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { x: 0, y: 0, z: 0, w: 0, engagement: 0.4 }
@@ -145,24 +333,20 @@ export class SensorSchemaRegistry {
         this.register('biometric', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    stress: this.ensureNumber(payload.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, issues }),
-                    heartRate: this.ensureInteger(payload.heartRate, {
-                        field: 'heartRate',
-                        min: 30,
-                        max: 220,
-                        defaultValue: 68,
-                        issues
-                    }),
-                    temperature: this.ensureNumber(payload.temperature, {
-                        field: 'temperature',
-                        min: 32,
-                        max: 40,
-                        defaultValue: 36.4,
-                        precision: 1,
-                        issues
-                    })
+                    stress: this.ensureNumber(safe.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, precision: 3, issues }),
+                    heartRate: this.ensureInteger(safe.heartRate, { field: 'heartRate', min: 30, max: 220, defaultValue: 68, issues }),
+                    temperature: this.ensureNumber(safe.temperature, { field: 'temperature', min: 32, max: 40, defaultValue: 36.4, precision: 1, issues })
                 };
+
+                if (safe.oxygen !== undefined) {
+                    normalized.oxygen = this.ensureNumber(safe.oxygen, { field: 'oxygen', min: 0, max: 1, defaultValue: 0.95, precision: 3, issues });
+                }
+                if (safe.hrv !== undefined) {
+                    normalized.hrv = this.ensureInteger(safe.hrv, { field: 'hrv', min: 10, max: 200, defaultValue: 52, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { stress: 0.2, heartRate: 68, temperature: 36.4 }
@@ -171,11 +355,20 @@ export class SensorSchemaRegistry {
         this.register('ambient', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    luminance: this.ensureNumber(payload.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, issues }),
-                    noiseLevel: this.ensureNumber(payload.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, issues }),
-                    motion: this.ensureNumber(payload.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, issues })
+                    luminance: this.ensureNumber(safe.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    noiseLevel: this.ensureNumber(safe.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, precision: 3, issues }),
+                    motion: this.ensureNumber(safe.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, precision: 3, issues })
                 };
+
+                if (safe.temperature !== undefined) {
+                    normalized.temperature = this.ensureNumber(safe.temperature, { field: 'temperature', min: -20, max: 60, defaultValue: 22, precision: 1, issues });
+                }
+                if (safe.humidity !== undefined) {
+                    normalized.humidity = this.ensureNumber(safe.humidity, { field: 'humidity', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 }
@@ -184,100 +377,414 @@ export class SensorSchemaRegistry {
         this.register('gesture', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    intent: this.ensureString(payload.intent, { field: 'intent', allowEmpty: true, issues }),
-                    vector: this.ensureVector(payload.vector, {
-                        field: 'vector',
-                        min: -1,
-                        max: 1,
-                        defaultValue: 0,
-                        issues
-                    })
+                    intent: this.ensureString(safe.intent, { field: 'intent', allowEmpty: true, defaultValue: null, issues }),
+                    vector: this.ensureVector(safe.vector, { field: 'vector', min: -1, max: 1, defaultValue: 0, issues })
                 };
+
+                if (safe.intentStrength !== undefined) {
+                    normalized.intentStrength = this.ensureNumber(safe.intentStrength, { field: 'intentStrength', min: 0, max: 1, defaultValue: 0, precision: 2, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { intent: null, vector: { x: 0, y: 0, z: 0 } }
         });
+
+        this.registerWearableSchemas();
     }
 
-    loadCustomSchemas(schemas) {
-        if (Array.isArray(schemas)) {
-            for (const entry of schemas) {
-                if (entry && typeof entry === 'object' && entry.type) {
-                    this.register(entry.type, entry.schema);
+    registerWearableSchemas() {
+        this.register('wearable.ar-visor', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.ar-visor',
+            fieldOfViewDefaults: { horizontal: 110, vertical: 90, diagonal: 120 },
+            channels: [
+                {
+                    channel: 'eye-tracking',
+                    schema: 'eye-tracking',
+                    sources: ['channels.eye-tracking', 'gaze', 'focus'],
+                    required: true,
+                    defaultConfidence: 0.82,
+                    confidencePaths: ['source.confidence', 'root.focusConfidence', 'root.quality.focus'],
+                    extend: (payload, source, { registry, issues }) => {
+                        if (source && source.vergence !== undefined) {
+                            payload.vergence = registry.ensureNumber(source.vergence, { field: 'channels.eye-tracking.vergence', min: 0, max: 5, defaultValue: 0, precision: 2, issues });
+                        }
+                        if (source && source.stability !== undefined) {
+                            payload.stability = registry.ensureNumber(source.stability, { field: 'channels.eye-tracking.stability', min: 0, max: 1, defaultValue: 0.5, precision: 2, issues });
+                        }
+                        if (source && source.blinkRate !== undefined) {
+                            payload.blinkRate = registry.ensureNumber(source.blinkRate, { field: 'channels.eye-tracking.blinkRate', min: 0, max: 2.5, defaultValue: 0.2, precision: 2, issues });
+                        }
+                    }
+                },
+                {
+                    channel: 'ambient',
+                    schema: 'ambient',
+                    sources: ['channels.ambient', 'environment'],
+                    defaultConfidence: 0.65,
+                    confidencePaths: ['source.confidence', 'root.quality.environment'],
+                    extend: (payload, source, { registry, issues }) => {
+                        if (source && source.temperature !== undefined) {
+                            payload.temperature = registry.ensureNumber(source.temperature, { field: 'channels.ambient.temperature', min: -20, max: 60, defaultValue: 22, precision: 1, issues });
+                        }
+                    }
+                },
+                {
+                    channel: 'gesture',
+                    schema: 'gesture',
+                    sources: ['channels.gesture', 'gesture'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.gesture', 'root.quality.focus']
                 }
-            }
-            return;
-        }
+            ],
+            metadata: (root, { registry, issues }, schemaConfig) => {
+                const metadata = {};
+                const fieldOfViewSource = firstPresent([
+                    getPath(root, 'metadata.fieldOfView'),
+                    root.fieldOfView
+                ]);
+                if (isPlainObject(fieldOfViewSource) || schemaConfig.fieldOfViewDefaults) {
+                    const defaults = schemaConfig.fieldOfViewDefaults || {};
+                    const fieldOfView = {
+                        horizontal: registry.ensureNumber(fieldOfViewSource?.horizontal ?? defaults.horizontal ?? 110, { field: 'metadata.fieldOfView.horizontal', min: 40, max: 160, defaultValue: 110, issues }),
+                        vertical: registry.ensureNumber(fieldOfViewSource?.vertical ?? defaults.vertical ?? 90, { field: 'metadata.fieldOfView.vertical', min: 30, max: 140, defaultValue: 90, issues })
+                    };
+                    if (fieldOfViewSource?.diagonal !== undefined || defaults.diagonal !== undefined) {
+                        fieldOfView.diagonal = registry.ensureNumber(fieldOfViewSource?.diagonal ?? defaults.diagonal ?? 120, { field: 'metadata.fieldOfView.diagonal', min: 40, max: 180, defaultValue: 120, issues });
+                    }
+                    metadata.fieldOfView = fieldOfView;
+                }
 
-        if (typeof schemas === 'object') {
-            for (const [type, schema] of Object.entries(schemas)) {
-                this.register(type, schema);
+                const poseSource = firstPresent([
+                    getPath(root, 'metadata.pose'),
+                    root.pose
+                ]);
+                if (isPlainObject(poseSource)) {
+                    const pose = {};
+                    if (poseSource.orientation) {
+                        pose.orientation = registry.ensureQuaternion(poseSource.orientation, { field: 'metadata.pose.orientation' });
+                    }
+                    if (poseSource.position) {
+                        pose.position = registry.ensureVector(poseSource.position, { field: 'metadata.pose.position', defaultValue: 0 });
+                    }
+                    if (Object.keys(pose).length) {
+                        metadata.pose = pose;
+                    }
+                }
+
+                const batteryLevel = firstPresent([root.batteryLevel, getPath(root, 'metadata.batteryLevel')]);
+                if (batteryLevel !== undefined) {
+                    metadata.batteryLevel = registry.ensureNumber(batteryLevel, { field: 'metadata.batteryLevel', min: 0, max: 1, defaultValue: 1, issues });
+                }
+
+                const deviceTemperature = firstPresent([
+                    root.deviceTemperature,
+                    getPath(root, 'metadata.deviceTemperature'),
+                    getPath(root, 'environment.temperature')
+                ]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: -20, max: 90, defaultValue: 35, precision: 1, issues });
+                }
+
+                const uptimeSeconds = firstPresent([root.uptimeSeconds, getPath(root, 'metadata.uptimeSeconds')]);
+                if (uptimeSeconds !== undefined) {
+                    metadata.uptimeSeconds = registry.ensureNumber(uptimeSeconds, { field: 'metadata.uptimeSeconds', min: 0, max: 604800, defaultValue: 0, issues });
+                }
+
+                const optics = firstPresent([getPath(root, 'metadata.optics'), root.optics]);
+                if (isPlainObject(optics)) {
+                    metadata.optics = { ...optics };
+                }
+
+                return metadata;
             }
-        }
+        }));
+
+        this.register('wearable.neural-band', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.neural-band',
+            channels: [
+                {
+                    channel: 'neural-intent',
+                    schema: 'neural-intent',
+                    sources: ['channels.neural-intent', 'intent', 'signal'],
+                    required: true,
+                    defaultConfidence: 0.7,
+                    confidencePaths: ['source.confidence', 'root.signalQuality.overall', 'root.quality.intent']
+                },
+                {
+                    channel: 'gesture',
+                    schema: 'gesture',
+                    sources: ['channels.gesture', 'gesture'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.gesture']
+                }
+            ],
+            metadata: (root, { registry, issues }) => {
+                const metadata = {};
+
+                const signalQualitySource = firstPresent([
+                    getPath(root, 'metadata.signalQuality'),
+                    root.signalQuality
+                ]);
+                if (isPlainObject(signalQualitySource)) {
+                    const quality = {};
+                    if (signalQualitySource.overall !== undefined) {
+                        quality.overall = registry.ensureNumber(signalQualitySource.overall, { field: 'metadata.signalQuality.overall', min: 0, max: 1, defaultValue: 0.5 });
+                    }
+                    if (signalQualitySource.contacts) {
+                        quality.contacts = sanitizeNumberArray(registry, signalQualitySource.contacts, 'metadata.signalQuality.contacts', { min: 0, max: 1, defaultValue: 0.5, issues });
+                    }
+                    if (Object.keys(quality).length) {
+                        metadata.signalQuality = quality;
+                    }
+                }
+
+                const impedanceSource = firstPresent([
+                    getPath(root, 'metadata.impedance'),
+                    root.impedance
+                ]);
+                if (isPlainObject(impedanceSource)) {
+                    metadata.impedance = {
+                        average: registry.ensureNumber(impedanceSource.average, { field: 'metadata.impedance.average', min: 0, max: 500, defaultValue: 0 }),
+                        variance: registry.ensureNumber(impedanceSource.variance, { field: 'metadata.impedance.variance', min: 0, max: 500, defaultValue: 0 })
+                    };
+                }
+
+                const contactState = firstPresent([
+                    getPath(root, 'metadata.contact.state'),
+                    root.contactState
+                ]);
+                const electrodes = firstPresent([
+                    getPath(root, 'metadata.contact.electrodes'),
+                    root.electrodes
+                ]);
+                if (contactState !== undefined || electrodes !== undefined) {
+                    const contact = {};
+                    if (contactState !== undefined) {
+                        contact.state = registry.ensureString(contactState, { field: 'metadata.contact.state', allowEmpty: true, defaultValue: null, issues });
+                    }
+                    const sanitizedElectrodes = sanitizeNumberArray(registry, electrodes, 'metadata.contact.electrodes', { min: 0, max: 1, defaultValue: 0.5, issues });
+                    if (sanitizedElectrodes) {
+                        contact.electrodes = sanitizedElectrodes;
+                    }
+                    if (Object.keys(contact).length) {
+                        metadata.contact = contact;
+                    }
+                }
+
+                const bandSource = firstPresent([
+                    getPath(root, 'metadata.band'),
+                    root.band
+                ]);
+                if (isPlainObject(bandSource)) {
+                    const band = {};
+                    if (bandSource.firmware !== undefined) {
+                        band.firmware = registry.ensureOptionalString(bandSource.firmware, { field: 'metadata.band.firmware', defaultValue: null });
+                    }
+                    if (bandSource.hardwareRevision !== undefined) {
+                        band.hardwareRevision = registry.ensureOptionalString(bandSource.hardwareRevision, { field: 'metadata.band.hardwareRevision', defaultValue: null });
+                    }
+                    if (Object.keys(band).length) {
+                        metadata.band = band;
+                    }
+                }
+
+                const deviceTemperature = firstPresent([root.temperature, getPath(root, 'metadata.deviceTemperature')]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: 0, max: 60, defaultValue: 33, precision: 1 });
+                }
+
+                return metadata;
+            }
+        }));
+
+        this.register('wearable.biometric-wrist', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.biometric-wrist',
+            channels: [
+                {
+                    channel: 'biometric',
+                    schema: 'biometric',
+                    sources: ['channels.biometric', 'vitals', 'biometric'],
+                    required: true,
+                    defaultConfidence: 0.75,
+                    confidencePaths: ['source.confidence', 'root.quality.vitals', 'root.quality.overall']
+                },
+                {
+                    channel: 'ambient',
+                    schema: 'ambient',
+                    sources: ['channels.ambient', 'environment'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.environment', 'root.quality.motion']
+                }
+            ],
+            metadata: (root, { registry, issues }) => {
+                const metadata = {};
+
+                const batteryLevel = firstPresent([root.batteryLevel, getPath(root, 'metadata.batteryLevel')]);
+                if (batteryLevel !== undefined) {
+                    metadata.batteryLevel = registry.ensureNumber(batteryLevel, { field: 'metadata.batteryLevel', min: 0, max: 1, defaultValue: 1 });
+                }
+
+                const skinContact = firstPresent([root.skinContact, getPath(root, 'metadata.skinContact')]);
+                if (skinContact !== undefined) {
+                    metadata.skinContact = registry.ensureBoolean(skinContact, { field: 'metadata.skinContact', defaultValue: false, issues });
+                }
+
+                const lastSync = firstPresent([root.lastSync, getPath(root, 'metadata.lastSync')]);
+                if (lastSync !== undefined) {
+                    metadata.lastSync = registry.ensureOptionalString(lastSync, { field: 'metadata.lastSync', defaultValue: null });
+                }
+
+                const motionSource = firstPresent([
+                    getPath(root, 'metadata.motion'),
+                    root.motion
+                ]);
+                if (isPlainObject(motionSource)) {
+                    const motion = {};
+                    if (motionSource.acceleration) {
+                        motion.acceleration = registry.ensureVector(motionSource.acceleration, { field: 'metadata.motion.acceleration', defaultValue: 0 });
+                    }
+                    if (Object.keys(motion).length) {
+                        metadata.motion = motion;
+                    }
+                }
+
+                const deviceTemperature = firstPresent([root.deviceTemperature, getPath(root, 'metadata.deviceTemperature')]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: 0, max: 60, defaultValue: 33, precision: 1 });
+                }
+
+                const alerts = firstPresent([root.alerts, getPath(root, 'metadata.alerts')]);
+                if (Array.isArray(alerts)) {
+                    const sanitizedAlerts = alerts
+                        .map((entry, index) => {
+                            if (typeof entry === 'string') {
+                                const trimmed = entry.trim();
+                                if (trimmed) return trimmed;
+                            }
+                            issues.push({ field: `metadata.alerts.${index}`, code: 'type', message: 'Alert entries must be non-empty strings.' });
+                            return null;
+                        })
+                        .filter(Boolean);
+                    if (sanitizedAlerts.length) {
+                        metadata.alerts = sanitizedAlerts;
+                    }
+                }
+
+                return metadata;
+            }
+        }));
     }
 
-    ensureNumber(value, { field, min, max, defaultValue = 0, precision, issues }) {
-        let numberValue = Number(value);
-        if (value === undefined || value === null || Number.isNaN(numberValue)) {
-            issues?.push({ field, code: 'type', message: 'Expected numeric value.' });
-            numberValue = defaultValue;
+    ensureNumber(value, { field, min = -Infinity, max = Infinity, defaultValue = 0, precision, issues } = {}) {
+        let numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            numeric = defaultValue;
+            issues?.push({ field, code: 'type', message: `${field} must be a finite number.` });
         }
 
-        const clamped = clamp(numberValue, min, max);
-        if (typeof min === 'number' && clamped === min && numberValue < min) {
-            issues?.push({ field, code: 'min', message: `Value below minimum; clamped to ${min}.` });
+        if (typeof min === 'number' && numeric < min) {
+            issues?.push({ field, code: 'min', message: `${field} must be ≥ ${min}.` });
+            numeric = min;
         }
-        if (typeof max === 'number' && clamped === max && numberValue > max) {
-            issues?.push({ field, code: 'max', message: `Value above maximum; clamped to ${max}.` });
+        if (typeof max === 'number' && numeric > max) {
+            issues?.push({ field, code: 'max', message: `${field} must be ≤ ${max}.` });
+            numeric = max;
         }
 
-        let finalValue = clamped;
-        if (typeof precision === 'number') {
+        if (typeof precision === 'number' && Number.isFinite(precision) && precision >= 0) {
             const factor = 10 ** precision;
-            finalValue = Math.round(finalValue * factor) / factor;
+            numeric = Math.round(numeric * factor) / factor;
         }
 
-        return finalValue;
+        return numeric;
     }
 
-    ensureInteger(value, { field, min, max, defaultValue = 0, issues }) {
-        const numberValue = this.ensureNumber(value, { field, min, max, defaultValue, issues });
-        return Math.round(numberValue);
+    ensureOptionalNumber(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue;
+        }
+        return this.ensureNumber(value, options);
     }
 
-    ensureString(value, { field, allowEmpty = false, fallback = null, issues }) {
-        if (typeof value !== 'string') {
-            if (value == null) {
-                if (!allowEmpty) {
-                    issues?.push({ field, code: 'type', message: 'Expected string value.' });
-                }
-                return fallback;
+    ensureInteger(value, options = {}) {
+        const numeric = this.ensureNumber(value, options);
+        return Math.round(numeric);
+    }
+
+    ensureOptionalInteger(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue;
+        }
+        return this.ensureInteger(value, options);
+    }
+
+    ensureBoolean(value, { field, defaultValue = false, issues } = {}) {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+        if (value === 'true' || value === 'false') {
+            return value === 'true';
+        }
+        if (Number.isFinite(Number(value))) {
+            return Boolean(Number(value));
+        }
+        issues?.push({ field, code: 'type', message: `${field} must be a boolean.` });
+        return defaultValue;
+    }
+
+    ensureString(value, { field, allowEmpty = false, defaultValue = '', issues } = {}) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!allowEmpty && trimmed === '') {
+                issues?.push({ field, code: 'empty', message: `${field} must not be empty.` });
+                return defaultValue;
             }
+            return trimmed;
+        }
 
-            try {
-                value = String(value);
-            } catch (error) {
-                issues?.push({ field, code: 'type', message: 'Value is not coercible to string.' });
-                return fallback;
+        if (value === undefined || value === null) {
+            if (defaultValue !== undefined) {
+                return defaultValue;
             }
+            issues?.push({ field, code: 'missing', message: `${field} is required.` });
+            return '';
         }
 
-        const normalized = value.trim();
-        if (!allowEmpty && normalized.length === 0) {
-            issues?.push({ field, code: 'empty', message: 'String value cannot be empty.' });
-            return fallback;
+        if (typeof value.toString === 'function') {
+            return this.ensureString(value.toString(), { field, allowEmpty, defaultValue, issues });
         }
 
-        return normalized.length === 0 ? fallback : normalized;
+        issues?.push({ field, code: 'type', message: `${field} must be a string.` });
+        return defaultValue;
     }
 
-    ensureVector(value, { field, min, max, defaultValue = 0, issues }) {
-        const base = value && typeof value === 'object' ? value : {};
+    ensureOptionalString(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue ?? null;
+        }
+        return this.ensureString(value, { ...options, allowEmpty: true });
+    }
+
+    ensureVector(value, { field, min = -Infinity, max = Infinity, defaultValue = 0, issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
         return {
-            x: this.ensureNumber(base.x, { field: `${field}.x`, min, max, defaultValue, issues }),
-            y: this.ensureNumber(base.y, { field: `${field}.y`, min, max, defaultValue, issues }),
-            z: this.ensureNumber(base.z, { field: `${field}.z`, min, max, defaultValue, issues })
+            x: this.ensureNumber(safe.x, { field: `${field}.x`, min, max, defaultValue, issues }),
+            y: this.ensureNumber(safe.y, { field: `${field}.y`, min, max, defaultValue, issues }),
+            z: this.ensureNumber(safe.z, { field: `${field}.z`, min, max, defaultValue, issues })
+        };
+    }
+
+    ensureQuaternion(value, { field, issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
+        return {
+            x: this.ensureNumber(safe.x, { field: `${field}.x`, min: -1, max: 1, defaultValue: 0, issues }),
+            y: this.ensureNumber(safe.y, { field: `${field}.y`, min: -1, max: 1, defaultValue: 0, issues }),
+            z: this.ensureNumber(safe.z, { field: `${field}.z`, min: -1, max: 1, defaultValue: 0, issues }),
+            w: this.ensureNumber(safe.w, { field: `${field}.w`, min: -1, max: 1, defaultValue: 1, issues })
         };
     }
 }
+

--- a/src/ui/adaptive/sensors/WearableDeviceManager.js
+++ b/src/ui/adaptive/sensors/WearableDeviceManager.js
@@ -1,0 +1,159 @@
+import { SensoryInputBridge } from '../SensoryInputBridge.js';
+
+const deviceKey = (type, deviceId) => `${type}:${deviceId ?? 'wearable-device'}`;
+
+export class WearableDeviceManager {
+    constructor(options = {}) {
+        const {
+            bridge,
+            autoStart = false,
+            historyLimit,
+            wearableHistoryLimit,
+            bridgeOptions = {}
+        } = options;
+
+        if (bridge instanceof SensoryInputBridge) {
+            this.bridge = bridge;
+        } else {
+            this.bridge = new SensoryInputBridge({
+                ...bridgeOptions,
+                channelHistoryLimit: historyLimit ?? bridgeOptions.channelHistoryLimit,
+                wearableHistoryLimit: wearableHistoryLimit ?? bridgeOptions.wearableHistoryLimit
+            });
+        }
+
+        this.autoStart = autoStart;
+        this.deviceSubscriptions = new Map();
+        this.typeSubscriptions = new Map();
+
+        if (this.autoStart) {
+            this.start();
+        }
+    }
+
+    getBridge() {
+        return this.bridge;
+    }
+
+    registerAdapter(type, adapter) {
+        this.bridge.registerAdapter(type, adapter);
+        this.ensureTypeSubscription(type);
+        if (this.autoStart && !this.bridge.loopHandle) {
+            this.start();
+        }
+        return adapter;
+    }
+
+    unregisterAdapter(type) {
+        if (this.typeSubscriptions.has(type)) {
+            const unsubscribe = this.typeSubscriptions.get(type);
+            if (typeof unsubscribe === 'function') {
+                unsubscribe();
+            }
+            this.typeSubscriptions.delete(type);
+        }
+        for (const key of Array.from(this.deviceSubscriptions.keys())) {
+            if (key.startsWith(`${type}:`)) {
+                this.deviceSubscriptions.delete(key);
+            }
+        }
+        this.bridge.adapters.delete(type);
+        this.bridge.channels.delete(type);
+        this.bridge.adapterStates.delete(type);
+    }
+
+    start() {
+        this.bridge.start();
+    }
+
+    stop() {
+        this.bridge.stop();
+    }
+
+    ensureTypeSubscription(type) {
+        if (this.typeSubscriptions.has(type)) {
+            return;
+        }
+        const unsubscribe = this.bridge.subscribe(`${type}:update`, snapshot => {
+            if (!snapshot) return;
+            const key = deviceKey(type, snapshot.deviceId);
+            const listeners = this.deviceSubscriptions.get(key);
+            if (!listeners || listeners.size === 0) {
+                return;
+            }
+            for (const listener of listeners) {
+                try {
+                    listener({ ...snapshot, type });
+                } catch (error) {
+                    console.error('[WearableDeviceManager] device listener failed', error);
+                }
+            }
+        });
+        this.typeSubscriptions.set(type, unsubscribe);
+    }
+
+    subscribeToDevice(type, deviceId, callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('WearableDeviceManager.subscribeToDevice requires a callback function');
+        }
+        const key = deviceKey(type, deviceId);
+        if (!this.deviceSubscriptions.has(key)) {
+            this.deviceSubscriptions.set(key, new Set());
+        }
+        const listeners = this.deviceSubscriptions.get(key);
+        listeners.add(callback);
+        this.ensureTypeSubscription(type);
+
+        const snapshot = this.bridge.getWearableSnapshot(type, deviceId);
+        if (snapshot) {
+            try {
+                callback({ ...snapshot, type });
+            } catch (error) {
+                console.error('[WearableDeviceManager] initial snapshot callback failed', error);
+            }
+        }
+
+        return () => this.unsubscribeFromDevice(type, deviceId, callback);
+    }
+
+    unsubscribeFromDevice(type, deviceId, callback) {
+        const key = deviceKey(type, deviceId);
+        const listeners = this.deviceSubscriptions.get(key);
+        if (!listeners) return;
+        listeners.delete(callback);
+        if (listeners.size === 0) {
+            this.deviceSubscriptions.delete(key);
+        }
+        this.cleanupTypeSubscription(type);
+    }
+
+    cleanupTypeSubscription(type) {
+        const hasListeners = Array.from(this.deviceSubscriptions.keys()).some(key => key.startsWith(`${type}:`));
+        if (!hasListeners) {
+            const unsubscribe = this.typeSubscriptions.get(type);
+            if (typeof unsubscribe === 'function') {
+                unsubscribe();
+            }
+            this.typeSubscriptions.delete(type);
+        }
+    }
+
+    getDeviceSnapshot(type, deviceId) {
+        const snapshot = this.bridge.getWearableSnapshot(type, deviceId);
+        return snapshot ? { ...snapshot, type } : null;
+    }
+
+    listDevices(type) {
+        return this.bridge.listWearableDevices(type);
+    }
+
+    getDeviceHistory(type) {
+        return this.bridge.getWearableHistory(type);
+    }
+
+    ingest(type, payload, confidence) {
+        this.bridge.ingest(type, payload, confidence);
+    }
+}
+
+export default WearableDeviceManager;

--- a/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
@@ -1,0 +1,203 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const assignIfDefined = (target, key, value, clone = false) => {
+    if (value === undefined || value === null) {
+        return;
+    }
+    if (clone && isPlainObject(value)) {
+        target[key] = { ...value };
+        return;
+    }
+    target[key] = value;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+    return fallback;
+};
+
+export class ARVisorWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.ar-visor',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-ar-visor',
+            defaultConfidence: options.defaultConfidence ?? 0.82,
+            ...options
+        });
+
+        this.defaultFieldOfView = {
+            horizontal: 96,
+            vertical: 89,
+            diagonal: 110,
+            ...(options.defaultFieldOfView || {})
+        };
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const gazeSource = pickFirst(safe, ['channels.eye-tracking', 'gaze', 'focus']);
+        if (gazeSource) {
+            const payload = cloneChannelPayload(gazeSource);
+            const confidence = firstNumber(
+                gazeSource.confidence,
+                safe.focusConfidence,
+                getPath(safe, 'quality.focus')
+            );
+            composite.channels['eye-tracking'] = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const ambientSource = pickFirst(safe, ['channels.ambient', 'environment']);
+        if (ambientSource) {
+            const payload = cloneChannelPayload(ambientSource);
+            const confidence = firstNumber(
+                ambientSource.confidence,
+                getPath(safe, 'quality.environment')
+            );
+            composite.channels.ambient = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.8)
+            };
+        }
+
+        const gestureSource = pickFirst(safe, ['channels.gesture', 'gesture']);
+        if (gestureSource) {
+            const payload = cloneChannelPayload(gestureSource);
+            const confidence = firstNumber(
+                gestureSource.confidence,
+                getPath(safe, 'quality.gesture'),
+                getPath(safe, 'quality.focus')
+            );
+            composite.channels.gesture = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        const fieldOfView = {
+            ...this.defaultFieldOfView,
+            ...(pickFirst(safe, ['metadata.fieldOfView', 'fieldOfView']) || {})
+        };
+        if (Object.keys(fieldOfView).length) {
+            composite.metadata.fieldOfView = fieldOfView;
+        }
+
+        const pose = pickFirst(safe, ['metadata.pose', 'pose']);
+        if (isPlainObject(pose)) {
+            const normalizedPose = {};
+            if (isPlainObject(pose.orientation)) {
+                normalizedPose.orientation = { ...pose.orientation };
+            }
+            if (isPlainObject(pose.position)) {
+                normalizedPose.position = { ...pose.position };
+            }
+            if (Object.keys(normalizedPose).length) {
+                composite.metadata.pose = normalizedPose;
+            }
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'batteryLevel',
+            firstNumber(safe.batteryLevel, getPath(safe, 'metadata.batteryLevel'))
+        );
+        assignIfDefined(
+            composite.metadata,
+            'deviceTemperature',
+            firstNumber(
+                safe.deviceTemperature,
+                getPath(safe, 'metadata.deviceTemperature'),
+                getPath(safe, 'environment.temperature')
+            )
+        );
+        assignIfDefined(
+            composite.metadata,
+            'uptimeSeconds',
+            firstNumber(safe.uptimeSeconds, getPath(safe, 'metadata.uptimeSeconds'))
+        );
+        assignIfDefined(composite.metadata, 'optics', pickFirst(safe, ['metadata.optics', 'optics']), true);
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'quality.overall'),
+                composite.channels['eye-tracking']?.confidence
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
@@ -1,0 +1,368 @@
+const clamp = (value, min, max) => {
+    if (!Number.isFinite(value)) return value;
+    if (typeof min === 'number' && value < min) return min;
+    if (typeof max === 'number' && value > max) return max;
+    return value;
+};
+
+const clampConfidence = (value, fallback = 0.75) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return clamp(fallback, 0, 1);
+    }
+    return clamp(numeric, 0, 1);
+};
+
+const clone = value => {
+    if (value == null || typeof value !== 'object') {
+        return value ?? null;
+    }
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(value);
+        } catch (error) {
+            // Fall back to JSON copy below
+        }
+    }
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+        return { ...value };
+    }
+};
+
+const compactObject = value => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return value;
+    }
+    const entries = Object.entries(value)
+        .map(([key, entryValue]) => {
+            if (entryValue == null) {
+                return null;
+            }
+            if (typeof entryValue === 'object' && !Array.isArray(entryValue)) {
+                const compacted = compactObject(entryValue);
+                if (compacted == null) {
+                    return null;
+                }
+                if (typeof compacted === 'object' && Object.keys(compacted).length === 0) {
+                    return null;
+                }
+                return [key, compacted];
+            }
+            if (Array.isArray(entryValue) && entryValue.length === 0) {
+                return null;
+            }
+            return [key, entryValue];
+        })
+        .filter(Boolean);
+
+    if (entries.length === 0) {
+        return null;
+    }
+
+    return Object.fromEntries(entries);
+};
+
+const compactChannels = (channels, fallbackConfidence) => {
+    if (!channels || typeof channels !== 'object') {
+        return {};
+    }
+    const normalized = {};
+    for (const [type, channel] of Object.entries(channels)) {
+        if (!channel) continue;
+        const payload = channel.payload && typeof channel.payload === 'object'
+            ? { ...channel.payload }
+            : (channel.payload ?? {});
+        normalized[type] = {
+            payload,
+            confidence: clampConfidence(channel.confidence, fallbackConfidence)
+        };
+    }
+    return normalized;
+};
+
+const summarizeMetadata = metadata => {
+    if (!metadata || typeof metadata !== 'object') {
+        return undefined;
+    }
+    const summary = {};
+    if (metadata.batteryLevel !== undefined) summary.batteryLevel = metadata.batteryLevel;
+    if (metadata.deviceTemperature !== undefined) summary.deviceTemperature = metadata.deviceTemperature;
+    if (metadata.skinContact !== undefined) summary.skinContact = metadata.skinContact;
+    if (metadata.signalQuality) summary.signalQuality = metadata.signalQuality;
+    if (metadata.uptimeSeconds !== undefined) summary.uptimeSeconds = metadata.uptimeSeconds;
+    if (metadata.fieldOfView) summary.fieldOfView = metadata.fieldOfView;
+    return Object.keys(summary).length > 0 ? summary : undefined;
+};
+
+export class BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        const {
+            deviceId = 'wearable-device',
+            firmwareVersion = null,
+            telemetry = null,
+            telemetryScope = 'sensors.adapter',
+            telemetryClassification = 'system',
+            licenseManager = null,
+            requiredLicenseFeature = null,
+            schemaType = 'wearable.generic',
+            defaultConfidence = 0.75,
+            sampleProvider,
+            transport = null,
+            trace,
+            traceLoop = true,
+            recordTelemetryMetadata = true
+        } = options;
+
+        this.deviceId = deviceId;
+        this.firmwareVersion = firmwareVersion;
+        this.telemetry = telemetry;
+        this.telemetryScope = telemetryScope;
+        this.telemetryClassification = telemetryClassification;
+        this.licenseManager = licenseManager;
+        this.requiredLicenseFeature = requiredLicenseFeature;
+        this.schemaType = schemaType;
+        this.defaultConfidence = defaultConfidence;
+        this.transport = transport || null;
+        this.recordTelemetryMetadata = recordTelemetryMetadata;
+
+        this.trace = Array.isArray(trace) ? [...trace] : null;
+        this.traceLoop = traceLoop !== false;
+        this.traceIndex = 0;
+
+        this.sampleProvider = typeof sampleProvider === 'function'
+            ? sampleProvider
+            : this.createDefaultSampleProvider();
+
+        this.connected = false;
+        this.lastLicenseBlock = null;
+    }
+
+    createDefaultSampleProvider() {
+        if (this.transport) {
+            return async () => {
+                if (typeof this.transport.nextSample === 'function') {
+                    return this.transport.nextSample();
+                }
+                if (typeof this.transport.read === 'function') {
+                    return this.transport.read();
+                }
+                return null;
+            };
+        }
+
+        if (!this.trace) {
+            return async () => null;
+        }
+
+        return async () => {
+            if (!this.trace.length) {
+                return null;
+            }
+            if (this.traceIndex >= this.trace.length) {
+                if (!this.traceLoop) {
+                    return null;
+                }
+                this.traceIndex = 0;
+            }
+            const entry = this.trace[this.traceIndex++];
+            if (typeof entry === 'function') {
+                return entry();
+            }
+            if (!entry || typeof entry !== 'object') {
+                return entry ?? null;
+            }
+            return clone(entry);
+        };
+    }
+
+    async connect() {
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return;
+        }
+
+        if (this.transport?.connect) {
+            await this.transport.connect();
+        }
+
+        this.resetTrace();
+        this.connected = true;
+        this.track('connected', { status: 'connected' });
+    }
+
+    async disconnect() {
+        if (this.transport?.disconnect) {
+            await this.transport.disconnect();
+        }
+        this.connected = false;
+        this.track('disconnected', { status: 'disconnected' });
+    }
+
+    async read() {
+        if (!this.connected) {
+            await this.connect();
+            if (!this.connected) {
+                return null;
+            }
+        }
+
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return null;
+        }
+
+        const raw = await this.sampleProvider();
+        if (!raw) {
+            return null;
+        }
+
+        const normalized = this.normalizeSample(raw);
+        if (!normalized || typeof normalized !== 'object') {
+            return null;
+        }
+
+        const confidence = clampConfidence(normalized.confidence, this.defaultConfidence);
+        const payload = this.decoratePayload(normalized.payload || {});
+
+        this.track('sample', {
+            confidence,
+            channels: Object.keys(payload.channels || {}),
+            metadata: this.recordTelemetryMetadata ? summarizeMetadata(payload.metadata) : undefined
+        });
+
+        return { confidence, payload };
+    }
+
+    normalizeSample(raw) {
+        return {
+            confidence: this.defaultConfidence,
+            payload: raw
+        };
+    }
+
+    decoratePayload(payload) {
+        const base = payload && typeof payload === 'object' ? { ...payload } : {};
+        if (!base.deviceId) {
+            base.deviceId = this.deviceId;
+        }
+        if (base.firmwareVersion == null && this.firmwareVersion != null) {
+            base.firmwareVersion = this.firmwareVersion;
+        }
+        if (base.channels) {
+            base.channels = compactChannels(base.channels, this.defaultConfidence);
+        }
+        if (base.metadata) {
+            const compacted = compactObject(base.metadata);
+            base.metadata = compacted || {};
+        }
+        return base;
+    }
+
+    async ensureLicense() {
+        if (!this.licenseManager) {
+            return true;
+        }
+
+        let status = typeof this.licenseManager.getStatus === 'function'
+            ? this.licenseManager.getStatus()
+            : null;
+
+        if (!status || status.state !== 'valid') {
+            if (typeof this.licenseManager.validate === 'function') {
+                try {
+                    status = await this.licenseManager.validate({
+                        scope: this.schemaType,
+                        deviceId: this.deviceId
+                    });
+                } catch (error) {
+                    this.noteLicenseBlock('validation', { error: error?.message || 'validation_failed' });
+                    return false;
+                }
+            }
+        }
+
+        if (!status || status.state !== 'valid') {
+            this.noteLicenseBlock('status', { status });
+            return false;
+        }
+
+        if (this.requiredLicenseFeature) {
+            try {
+                if (typeof this.licenseManager.requireFeature === 'function') {
+                    this.licenseManager.requireFeature(this.requiredLicenseFeature);
+                } else if (typeof this.licenseManager.hasFeature === 'function') {
+                    if (!this.licenseManager.hasFeature(this.requiredLicenseFeature)) {
+                        const error = new Error(`License missing feature: ${this.requiredLicenseFeature}`);
+                        error.code = 'LICENSE_FEATURE_MISSING';
+                        throw error;
+                    }
+                }
+            } catch (error) {
+                this.noteLicenseBlock('feature', {
+                    status,
+                    feature: this.requiredLicenseFeature,
+                    error: error?.message,
+                    code: error?.code
+                });
+                return false;
+            }
+        }
+
+        this.lastLicenseBlock = null;
+        return true;
+    }
+
+    noteLicenseBlock(reason, details) {
+        const payload = {
+            reason,
+            ...(details && typeof details === 'object' ? details : { details })
+        };
+        const snapshot = JSON.stringify(payload);
+        if (snapshot === this.lastLicenseBlock) {
+            return;
+        }
+        this.lastLicenseBlock = snapshot;
+        this.recordAudit('license_blocked', payload);
+    }
+
+    recordAudit(eventSuffix, payload) {
+        if (!this.telemetry?.recordAudit) {
+            return;
+        }
+        this.telemetry.recordAudit(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            }
+        );
+    }
+
+    track(eventSuffix, payload) {
+        if (!this.telemetry?.track) {
+            return;
+        }
+        this.telemetry.track(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            },
+            { classification: this.telemetryClassification }
+        );
+    }
+
+    resetTrace() {
+        this.traceIndex = 0;
+        if (this.transport?.reset) {
+            this.transport.reset();
+        }
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
@@ -1,0 +1,175 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+    return fallback;
+};
+
+const assignIfDefined = (target, key, value, clone = false) => {
+    if (value === undefined || value === null) {
+        return;
+    }
+    if (clone && isPlainObject(value)) {
+        target[key] = { ...value };
+        return;
+    }
+    target[key] = value;
+};
+
+export class BiometricWristWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.biometric-wrist',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-biometric',
+            defaultConfidence: options.defaultConfidence ?? 0.78,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const vitalsSource = pickFirst(safe, ['channels.biometric', 'vitals', 'biometric']);
+        if (vitalsSource) {
+            const payload = cloneChannelPayload(vitalsSource);
+            const confidence = firstNumber(
+                vitalsSource.confidence,
+                getPath(safe, 'quality.vitals'),
+                getPath(safe, 'quality.overall')
+            );
+            composite.channels.biometric = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const ambientSource = pickFirst(safe, ['channels.ambient', 'environment']);
+        if (ambientSource) {
+            const payload = cloneChannelPayload(ambientSource);
+            const confidence = firstNumber(
+                ambientSource.confidence,
+                getPath(safe, 'quality.environment'),
+                getPath(safe, 'quality.motion')
+            );
+            composite.channels.ambient = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'batteryLevel',
+            firstNumber(safe.batteryLevel, getPath(safe, 'metadata.batteryLevel'))
+        );
+        if (safe.skinContact !== undefined || getPath(safe, 'metadata.skinContact') !== undefined) {
+            const value = pickFirst(safe, ['skinContact', 'metadata.skinContact']);
+            composite.metadata.skinContact = Boolean(value);
+        }
+        assignIfDefined(composite.metadata, 'lastSync', pickFirst(safe, ['lastSync', 'metadata.lastSync']));
+
+        const motion = pickFirst(safe, ['metadata.motion', 'motion']);
+        if (isPlainObject(motion)) {
+            composite.metadata.motion = {};
+            if (isPlainObject(motion.acceleration)) {
+                composite.metadata.motion.acceleration = { ...motion.acceleration };
+            }
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'deviceTemperature',
+            firstNumber(safe.deviceTemperature, getPath(safe, 'metadata.deviceTemperature'))
+        );
+
+        const alerts = pickFirst(safe, ['metadata.alerts', 'alerts']);
+        if (Array.isArray(alerts)) {
+            const sanitized = alerts
+                .filter(value => typeof value === 'string' && value.trim().length > 0)
+                .map(value => value.trim());
+            if (sanitized.length) {
+                composite.metadata.alerts = sanitized;
+            }
+        }
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'quality.overall'),
+                composite.channels.biometric?.confidence
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
@@ -1,0 +1,166 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+    return fallback;
+};
+
+const cloneArray = value => Array.isArray(value) ? [...value] : undefined;
+
+export class NeuralBandWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.neural-band',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-neural-band',
+            defaultConfidence: options.defaultConfidence ?? 0.7,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const intentSource = pickFirst(safe, ['channels.neural-intent', 'intent', 'signal']);
+        if (intentSource) {
+            const payload = cloneChannelPayload(intentSource);
+            const confidence = firstNumber(
+                intentSource.confidence,
+                getPath(safe, 'signalQuality.overall'),
+                getPath(safe, 'quality.intent')
+            );
+            composite.channels['neural-intent'] = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const gestureSource = pickFirst(safe, ['channels.gesture', 'gesture']);
+        if (gestureSource) {
+            const payload = cloneChannelPayload(gestureSource);
+            const confidence = firstNumber(
+                gestureSource.confidence,
+                getPath(safe, 'quality.gesture')
+            );
+            composite.channels.gesture = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        const signalQuality = pickFirst(safe, ['metadata.signalQuality', 'signalQuality']);
+        if (isPlainObject(signalQuality)) {
+            composite.metadata.signalQuality = { ...signalQuality };
+            if (Array.isArray(signalQuality.contacts)) {
+                composite.metadata.signalQuality.contacts = cloneArray(signalQuality.contacts);
+            }
+        }
+
+        const impedance = pickFirst(safe, ['metadata.impedance', 'impedance']);
+        if (isPlainObject(impedance)) {
+            composite.metadata.impedance = { ...impedance };
+        }
+
+        const contactState = pickFirst(safe, ['metadata.contact.state', 'contactState']);
+        const electrodes = pickFirst(safe, ['metadata.contact.electrodes', 'electrodes']);
+        if (contactState !== undefined || electrodes !== undefined) {
+            composite.metadata.contact = {};
+            if (contactState !== undefined) {
+                composite.metadata.contact.state = contactState;
+            }
+            if (Array.isArray(electrodes)) {
+                composite.metadata.contact.electrodes = cloneArray(electrodes);
+            }
+        }
+
+        const band = pickFirst(safe, ['metadata.band', 'band']);
+        if (isPlainObject(band)) {
+            composite.metadata.band = { ...band };
+        }
+
+        const temperature = firstNumber(safe.temperature, getPath(safe, 'metadata.deviceTemperature'));
+        if (temperature !== undefined) {
+            composite.metadata.deviceTemperature = temperature;
+        }
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'signalQuality.overall'),
+                getPath(safe, 'quality.overall'),
+                composite.channels['neural-intent']?.confidence
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/tests/vitest/wearables-adapters.test.js
+++ b/tests/vitest/wearables-adapters.test.js
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { SensorSchemaRegistry } from '../../src/ui/adaptive/sensors/SensorSchemaRegistry.js';
+import { SensoryInputBridge } from '../../src/ui/adaptive/SensoryInputBridge.js';
+import { WearableDeviceManager } from '../../src/ui/adaptive/sensors/WearableDeviceManager.js';
+import { BiometricWristWearableAdapter } from '../../src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js';
+import { LicenseManager } from '../../src/product/licensing/LicenseManager.js';
+
+describe('Wearable sensor schemas', () => {
+    let registry;
+
+    beforeEach(() => {
+        registry = new SensorSchemaRegistry();
+    });
+
+    it('normalizes AR visor payloads and reports range violations', () => {
+        const result = registry.validate('wearable.ar-visor', {
+            deviceId: 'visor-alpha',
+            gaze: { x: 1.4, y: -0.3, depth: 0.9, vergence: 6.2, stability: -0.4 },
+            environment: { luminance: 1.3, noiseLevel: -0.1, motion: 0.4, temperature: 82 },
+            gesture: { intent: 'swipe-right', vector: { x: 1.4, y: -1.2, z: 0.8 } },
+            fieldOfView: { horizontal: 190, vertical: 15, diagonal: 220 },
+            batteryLevel: 1.2,
+            deviceTemperature: 92,
+            uptimeSeconds: -5
+        });
+
+        const eye = result.payload.channels['eye-tracking'];
+        expect(eye.confidence).toBeCloseTo(0.82, 5);
+        expect(eye.payload.x).toBeLessThanOrEqual(1);
+        expect(eye.payload.y).toBeGreaterThanOrEqual(0);
+        expect(eye.payload.vergence).toBeLessThanOrEqual(5);
+
+        const ambient = result.payload.channels.ambient;
+        expect(ambient.payload.luminance).toBeLessThanOrEqual(1);
+        expect(ambient.payload.noiseLevel).toBeGreaterThanOrEqual(0);
+        expect(ambient.payload.temperature).toBeLessThanOrEqual(60);
+
+        const gesture = result.payload.channels.gesture;
+        expect(gesture.payload.vector.x).toBeLessThanOrEqual(1);
+        expect(gesture.payload.vector.y).toBeGreaterThanOrEqual(-1);
+
+        const metadata = result.payload.metadata;
+        expect(metadata.batteryLevel).toBeLessThanOrEqual(1);
+        expect(metadata.deviceTemperature).toBeLessThanOrEqual(90);
+        expect(metadata.uptimeSeconds).toBeGreaterThanOrEqual(0);
+        expect(metadata.fieldOfView.horizontal).toBeLessThanOrEqual(160);
+        expect(metadata.fieldOfView.vertical).toBeGreaterThanOrEqual(30);
+
+        const issueFields = result.issues.map(issue => issue.field);
+        expect(issueFields).toContain('channels.eye-tracking.vergence');
+        expect(issueFields).toContain('channels.ambient.luminance');
+        expect(issueFields).toContain('metadata.batteryLevel');
+    });
+});
+
+describe('SensoryInputBridge wearable multiplexing', () => {
+    it('routes wearable payloads into semantic channels and emits metadata events', () => {
+        const bridge = new SensoryInputBridge({ autoConnectAdapters: false, confidenceThreshold: 0 });
+        let metadataEvent = null;
+        bridge.subscribe('wearable.ar-visor:metadata', event => {
+            metadataEvent = event;
+        });
+
+        const payload = {
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            channels: {
+                'eye-tracking': { confidence: 0.9, payload: { x: 0.35, y: 0.62, depth: 0.42 } },
+                ambient: { confidence: 0.5, payload: { luminance: 0.58, noiseLevel: 0.24, motion: 0.16 } },
+                gesture: { confidence: 0.61, payload: { intent: 'tap', vector: { x: 0.1, y: 0.2, z: -0.05 } } }
+            },
+            metadata: { batteryLevel: 0.82 }
+        };
+
+        bridge.processSample('wearable.ar-visor', { confidence: 0.94, payload });
+
+        const snapshot = bridge.getSnapshot();
+        const expectedFocusX = 0.5 + (0.35 - 0.5) * 0.9;
+        const expectedFocusY = 0.5 + (0.62 - 0.5) * 0.9;
+        const expectedLuminance = 0.5 + (0.58 - 0.5) * 0.5;
+
+        expect(snapshot.focusVector.x).toBeCloseTo(expectedFocusX, 5);
+        expect(snapshot.focusVector.y).toBeCloseTo(expectedFocusY, 5);
+        expect(snapshot.environment.luminance).toBeCloseTo(expectedLuminance, 5);
+        expect(snapshot.gestureIntent).toBe('tap');
+
+        expect(metadataEvent).toMatchObject({
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            metadata: expect.objectContaining({ batteryLevel: 0.82 }),
+            confidence: 0.94,
+            timestamp: expect.any(Number)
+        });
+    });
+});
+
+describe('Wearable adapters', () => {
+    it('enforces licensing before streaming biometric wrist samples', async () => {
+        const telemetry = {
+            track: vi.fn(),
+            recordAudit: vi.fn()
+        };
+        const licenseManager = new LicenseManager();
+
+        const adapter = new BiometricWristWearableAdapter({
+            telemetry,
+            licenseManager,
+            deviceId: 'wrist-01',
+            trace: [
+                {
+                    vitals: { stress: 0.44, heartRate: 72, temperature: 37.4, oxygen: 0.97, hrv: 54 },
+                    environment: { luminance: 0.32, noiseLevel: 0.18, motion: 0.2, temperature: 24, humidity: 0.41 },
+                    quality: { overall: 0.91, vitals: 0.9, environment: 0.6 },
+                    batteryLevel: 0.76,
+                    skinContact: true
+                }
+            ]
+        });
+
+        const blocked = await adapter.read();
+        expect(blocked).toBeNull();
+        expect(telemetry.recordAudit).toHaveBeenCalled();
+        const auditPayload = telemetry.recordAudit.mock.calls[0][1];
+        expect(auditPayload.reason).toBe('status');
+
+        telemetry.recordAudit.mockClear();
+
+        licenseManager.setLicense({ key: 'valid-key', features: ['wearables-biometric'] });
+        await licenseManager.validate();
+
+        const sample = await adapter.read();
+        expect(sample?.payload.channels.biometric).toBeDefined();
+        expect(sample?.payload.channels.biometric.payload.heartRate).toBe(72);
+        expect(telemetry.track).toHaveBeenCalled();
+        const trackCall = telemetry.track.mock.calls.find(([event]) => event.includes('wearable.biometric-wrist.sample'));
+        expect(trackCall).toBeDefined();
+        expect(trackCall[1].channels).toContain('biometric');
+        expect(trackCall[2]).toEqual({ classification: 'system' });
+        expect(telemetry.recordAudit).not.toHaveBeenCalled();
+    });
+});
+
+describe('SensoryInputBridge history and wearable snapshots', () => {
+    it('retains bounded channel history and publishes wearable snapshots', () => {
+        const bridge = new SensoryInputBridge({
+            autoConnectAdapters: false,
+            confidenceThreshold: 0,
+            channelHistoryLimit: 2
+        });
+
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.1, y: 0.2, depth: 0.3 } });
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.4, y: 0.5, depth: 0.6 } });
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.8, y: 0.9, depth: 0.2 } });
+
+        const history = bridge.getChannelHistory('eye-tracking');
+        expect(history).toHaveLength(2);
+        expect(history[0].payload.x).toBeCloseTo(0.4, 5);
+        expect(history[1].payload.x).toBeCloseTo(0.8, 5);
+
+        const wearablePayload = {
+            deviceId: 'visor-history',
+            channels: {
+                'eye-tracking': { confidence: 0.6, payload: { x: 0.25, y: 0.5, depth: 0.4 } }
+            },
+            metadata: { batteryLevel: 0.9 }
+        };
+
+        const updates = [];
+        const globalUpdates = [];
+        bridge.subscribe('wearable.ar-visor:update', snapshot => updates.push(snapshot));
+        bridge.subscribe('wearable:update', snapshot => globalUpdates.push(snapshot));
+
+        bridge.processSample('wearable.ar-visor', { confidence: 0.82, payload: wearablePayload });
+
+        const snapshot = bridge.getWearableSnapshot('wearable.ar-visor', 'visor-history');
+        expect(snapshot?.channels['eye-tracking'].payload.x).toBeCloseTo(0.25, 5);
+        expect(snapshot?.metadata?.batteryLevel).toBeCloseTo(0.9, 5);
+        expect(bridge.listWearableDevices('wearable.ar-visor')).toContain('visor-history');
+
+        const wearableHistory = bridge.getWearableHistory('wearable.ar-visor');
+        expect(wearableHistory).toHaveLength(1);
+        expect(wearableHistory[0].composite.channels['eye-tracking'].payload.depth).toBeCloseTo(0.4, 5);
+
+        expect(updates).toHaveLength(1);
+        expect(globalUpdates).toHaveLength(1);
+        expect(globalUpdates[0].type).toBe('wearable.ar-visor');
+    });
+});
+
+describe('WearableDeviceManager orchestration', () => {
+    it('relays composite updates to subscribers and exposes snapshots', () => {
+        const bridge = new SensoryInputBridge({
+            autoConnectAdapters: false,
+            confidenceThreshold: 0,
+            channelHistoryLimit: 3
+        });
+        const manager = new WearableDeviceManager({ bridge });
+
+        const adapter = {
+            read: vi.fn()
+        };
+        manager.registerAdapter('wearable.neural-band', adapter);
+
+        const updates = [];
+        const unsubscribe = manager.subscribeToDevice('wearable.neural-band', 'band-x', snapshot => {
+            updates.push(snapshot);
+        });
+
+        manager.ingest('wearable.neural-band', {
+            deviceId: 'band-x',
+            channels: {
+                'neural-intent': {
+                    confidence: 0.85,
+                    payload: { x: 0.12, y: -0.1, z: 0.05, w: 0.9, engagement: 0.75 }
+                }
+            },
+            metadata: { signalQuality: { overall: 0.92 } }
+        }, 0.88);
+
+        expect(updates).toHaveLength(1);
+        expect(updates[0].type).toBe('wearable.neural-band');
+        expect(updates[0].metadata.signalQuality.overall).toBeCloseTo(0.92, 5);
+
+        const snapshot = manager.getDeviceSnapshot('wearable.neural-band', 'band-x');
+        expect(snapshot).not.toBeNull();
+        expect(snapshot.channels['neural-intent'].payload.w).toBeCloseTo(0.9, 5);
+
+        unsubscribe();
+
+        manager.ingest('wearable.neural-band', {
+            deviceId: 'band-x',
+            channels: {
+                'neural-intent': {
+                    confidence: 0.5,
+                    payload: { x: 0.3, y: 0.1, z: 0.15, w: 0.6, engagement: 0.5 }
+                }
+            }
+        }, 0.6);
+
+        expect(updates).toHaveLength(1);
+        expect(manager.listDevices('wearable.neural-band')).toContain('band-x');
+
+        const history = manager.getDeviceHistory('wearable.neural-band');
+        expect(history.length).toBeGreaterThanOrEqual(2);
+        expect(history[history.length - 1].composite.channels['neural-intent'].payload.w).toBeCloseTo(0.6, 5);
+    });
+});
+


### PR DESCRIPTION
## Summary
- extend the sensory bridge with deep cloning, bounded channel history, and wearable snapshot publishing utilities
- add a WearableDeviceManager helper to fan-out composite updates, manage subscriptions, and proxy ingestion into the bridge
- update the Vitest coverage and SDK types to exercise the new history APIs and manager orchestration helpers

## Testing
- npx vitest run tests/vitest/wearables-adapters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e947fe80b883299276fde55e59b349