### PR TITLE
Add quaternion cluster toolkit for spatial blending

### DIFF
--- a/DOCS/QUATERNIONS_IN_XR.md
+++ b/DOCS/QUATERNIONS_IN_XR.md
@@ -1,0 +1,42 @@
+# Quaternion Alignment for XR Wearables
+
+## Why Quaternions Matter in XR
+Quaternions are the de-facto representation for XR orientation because they avoid the gimbal lock and interpolation artefacts that plague Euler angles. OpenXR and WebXR expose headset, controller, and spatial anchor poses as `position` + `orientation` objects, where the orientation is always a unit quaternion. This encoding powers:
+
+- **Headset and Controller Tracking** – Every `XRSpace` pose, action pose, and hand joint is expressed as a quaternion so runtimes can smoothly compose device motion, origin offsets, and stage references.
+- **Spatial Mapping** – Anchors, hit-test results, and detected planes carry quaternions to lock world-aligned normals and tangents, ensuring scene understanding survives re-localisation and drifting sensors.
+- **Camera & View Rendering** – View matrices are derived from quaternion orientations so the rendered frustum matches the user’s head pose without accumulating floating-point drift.
+
+## Current Runtime Touchpoints
+Our wearables stack already threads quaternion data through the full ingestion path:
+
+- **Schema Normalisation** – `SensorSchemaRegistry` enforces quaternion shape and normalisation for wearable poses, spatial planes, hit-test results, and anchors so downstream systems always receive the canonical `x/y/z/w` tuple.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L520-L533】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L880-L909】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L932-L969】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1014-L1049】
+- **Adapter Ingestion** – `ARVisorWearableAdapter` now unwraps spatial traces, preserves quaternion payloads, and forwards them with calibrated confidences so the registry can emit validated `spatial.*` channels.【F:src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js†L17-L113】【F:src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js†L147-L226】
+- **Bridge Propagation** – The `SensoryInputBridge` fans out composite wearable channels (including `spatial.*`) to semantic listeners, allowing shaders and simulation layers to subscribe to quaternion-bearing poses as soon as they are ingested.【F:src/ui/adaptive/SensoryInputBridge.js†L294-L347】
+
+## Synergy with the Quaternion Shader Pipeline
+The rendering track’s quaternion-based shader system can consume the exact payloads we are emitting:
+
+1. **Direct Uniform Updates** – Wearable spatial channels now surface validated quaternions for planes, anchors, and hit tests. The shader pipeline can bind these as per-frame uniforms to align lighting probes, decals, and particle systems without converting from Euler angles.
+2. **Shared Normalisation Rules** – The registry’s `ensureQuaternion` guarantees unit-length inputs. The shader system can rely on this invariant and skip redundant renormalisation work on the GPU, reducing ALU overhead when thousands of quaternions are processed per frame.
+3. **Consistent Handedness & Spaces** – By anchoring to the same pose definitions that OpenXR/WebXR uses, we avoid left/right handed mismatches between CPU logic and vertex shaders. Spatial channels annotate the reference space, enabling shaders to compose quaternions with the viewer pose exactly like the runtime.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L737-L807】
+4. **Temporal Blending** – Adapter confidences expose how trustworthy each quaternion sample is. The shader system can lerp orientations using these confidences (or discard low-confidence frames) to smooth reprojection and anchor stabilisation.
+
+## Shader System Synchronization
+- **Runtime bridge** – `ShaderQuaternionSynchronizer` listens to `spatial.anchors`, `spatial.hit-tests`, and `spatial.pose` updates from the `SensoryInputBridge`, normalises the quaternions, and maps them onto the shared `rot4d*` parameters for the faceted, quantum, and holographic systems while deriving motion energy for secondary effects.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L1-L207】
+- **Quantum modulation** – The synchronizer feeds the quantum engine by lerping `rot4dXW/YW/ZW` and enriching `chaos`/`intensity` so volumetric lattices respond to headset motion through the existing `updateParameter` pipeline.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L208-L233】【F:systems/quantum/QuantumSystem.js†L248-L305】
+- **Holographic hue steering** – Yaw-driven hue offsets and motion-weighted saturation deltas land on the holographic system’s parameter map, letting the shader palette pivot with spatial orientation without rewriting its UI bindings.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L208-L233】【F:systems/holographic/HolographicSystem.js†L299-L348】
+- **Faceted dynamics** – Faceted visuals inherit the same quaternion-driven `rot4d*` envelopes, and motion energy subtly boosts `speed`, complementing the legacy slider interactions already wired through `updateParameter`.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L208-L233】【F:systems/faceted/FacetedSystem.js†L248-L305】
+- **SDK access** – Adaptive SDK consumers can now spawn synchronizers through `createShaderQuaternionSynchronizer`, giving downstream apps a turnkey way to route OpenXR/WebXR quaternions into our shader stack without touching internal bridge wiring.【F:src/core/AdaptiveSDK.js†L8-L140】【F:types/adaptive-sdk.d.ts†L872-L912】
+- **Coverage** – Dedicated Vitest coverage exercises anchor-triggered updates, motion-energy modulation, and confidence attenuation so shader teams can rely on deterministic quaternion behaviour before integrating the runtime feed.【F:tests/vitest/shader-quaternion-sync.test.js†L1-L102】
+
+## Implementation Plan
+1. **Shader Interface Contracts** – Expose helper utilities in the adaptive SDK that convert wearable spatial channels into GPU-ready uniform buffers (e.g., quaternion + translation + confidence).
+2. **Cross-Team Validation** – Build diagnostic overlays that render plane normals and anchor axes directly from the shared quaternion data, proving that wearables, bridge, and shaders are interpreting the orientations identically.
+3. **Runtime Optimisations** – Cache quaternion-to-matrix conversions inside the shader pipeline but invalidate when `SensoryInputBridge` emits updated spatial channels, keeping CPU↔GPU work balanced.
+4. **Future Extensions** – Extend the same path for hand joint quaternions and controller grips once those adapters land, ensuring the shader system can drive IK solvers and retargeted avatars without bespoke conversions.
+
+## When to Execute
+- **Now** – Aligning ingestion and shader expectations is critical while spatial channels are still being built. The adapter updates in this turn mean we already emit the required data; the shader track can start wiring uniform bindings immediately.
+- **Next 1–2 Turns** – Deliver SDK helpers and diagnostic overlays so developers can consume the quaternion streams confidently.
+- **Ongoing** – As we add more OpenXR interaction profiles (controllers, hands), extend the same quaternion normalisation pipeline to maintain end-to-end consistency.

--- a/DOCS/QUATERNION_SHADER_LOCALIZATION_RESEARCH.md
+++ b/DOCS/QUATERNION_SHADER_LOCALIZATION_RESEARCH.md
@@ -1,0 +1,56 @@
+# Quaternion Visualizer Core & XR Localization Research Track
+
+## Purpose
+This brief maps the quaternion foundations of the faceted, quantum, and holographic visualizers to the XR localization data now flowing through the wearable runtime. It captures the current integration points (SensorSchemaRegistry → SensoryInputBridge → ShaderQuaternionSynchronizer → shader systems), surfaces the new diagnostics overlay, and outlines research opportunities that extend beyond basic pose synchronisation.
+
+## Quaternion Core Across Visualizers
+
+| Visualizer | Quaternion Touchpoints | Notes |
+| --- | --- | --- |
+| **Quantum** | `rot4dXW`, `rot4dYW`, `rot4dZW`, `chaos`, `intensity` | The quantum lattice uses 4D rotation matrices to warp volumetric lattices. `rot4d*` axes steer hyperplane sampling while `chaos` and `intensity` inject motion energy into particle densities.【F:systems/quantum/QuantumSystem.js†L248-L318】 |
+| **Holographic** | `rot4dXW`, `rot4dYW`, `rot4dZW`, `hue`, `saturation` | The holographic stack derives camera and hue offsets from quaternion yaw/pitch, letting palette shifts mirror headset orientation while keeping historical slider affordances intact.【F:systems/holographic/HolographicSystem.js†L299-L347】 |
+| **Faceted** | `rot4dXW`, `rot4dYW`, `rot4dZW`, `speed` | Faceted geometry leans on the same quaternion-derived 4D rotations. Motion energy modulates playback `speed`, pairing localized motion with tessellation pacing.【F:systems/faceted/FacetedSystem.js†L248-L312】 |
+
+All three systems accept quaternion-driven parameter writes through the shared `updateParameter` interface, which preserves slider/UI state while enabling runtime programmatic control.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L191-L233】
+
+## XR Localization Data Flow
+
+1. **Wearable ingestion** – Spatial channels (pose, anchors, hit-tests, planes, depth) are normalized by `SensorSchemaRegistry` composites and fed into the `SensoryInputBridge` via device adapters.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1-L1298】【F:src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js†L1-L393】
+2. **Bridge routing** – The bridge manages subscribers, confidence thresholds, bounded history, and snapshot tracking, emitting spatial events over semantic channels (`spatial.pose`, `spatial.anchors`, etc.).【F:src/ui/adaptive/SensoryInputBridge.js†L1-L360】
+3. **Quaternion synchronisation** – `ShaderQuaternionSynchronizer` listens to the spatial channels, normalises quaternions, derives motion energy, and writes to shader parameters with confidence-aware smoothing.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L1-L233】
+4. **Diagnostics overlay** – The new `ShaderQuaternionDiagnosticsOverlay` renders yaw/pitch/roll, motion energy, confidence, and per-system parameter deltas for real-time validation and research instrumentation.【F:src/ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js†L1-L214】
+
+## Spatial Quaternion Toolkit
+
+- **Cluster blending** – `QuaternionClusterToolkit` exposes `blendAnchorCluster` and `blendHitTestCluster` so multiple anchors or hit-test results can be merged into a representative quaternion with weighted confidences, spatial averaging, and angular variance metrics before they reach the synchronizer.【F:src/ui/adaptive/renderers/QuaternionClusterToolkit.js†L1-L205】
+- **Sample averaging** – `averageQuaternionSamples` aligns quaternions into a shared hemisphere and computes a normalized weighted mean, guaranteeing stable outputs for shader pipelines even when spatial providers supply noisy orientations.【F:src/ui/adaptive/renderers/QuaternionClusterToolkit.js†L19-L76】
+- **SDK access** – The Adaptive SDK now surfaces the toolkit through `sdk.quaternionToolkit`, enabling downstream apps to compose custom spatial aggregations or diagnostics without reimplementing quaternion math.【F:src/core/AdaptiveSDK.js†L6-L13】【F:src/core/AdaptiveSDK.js†L205-L212】【F:types/adaptive-sdk.d.ts†L1042-L1059】
+
+## Research Vectors Beyond Synchronicity
+
+### 1. Quaternion Field Sculpting
+- **Objective**: Use spatial anchor clusters to interpolate quaternion fields that bend shader geometry without direct device motion.
+- **Approach**: Sample multiple anchors, blend their orientations, and feed the synthesized field into the synchronizer observers to drive `rot4d*` envelopes beyond single-pose tracking.
+- **Considerations**: Requires temporal smoothing to avoid conflicting anchor orientations; leverage `ShaderQuaternionSynchronizer.addObserver` to derive blended targets without modifying adapter code.【F:src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js†L108-L147】
+
+### 2. Motion Energy Feedback Loops
+- **Objective**: Transform motion energy into generative feedback across shader layers (e.g., coupling quantum chaos with holographic hue phasing).
+- **Approach**: Observe synchronizer updates, compute cross-system ratios, and push derived parameters (e.g., map motion energy into holographic bloom radius) via the diagnostics overlay to validate perceptual thresholds.
+- **Tooling**: Use the diagnostics overlay to visualize correlations and identify saturation points before hardening new parameter pipelines.【F:src/ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js†L120-L194】
+
+### 3. Depth-Weighted Quaternion Warping
+- **Objective**: Blend WebXR depth buffers with quaternion orientation to create parallax-aware shader deformations.
+- **Approach**: Extend adapters to emit per-pixel normals, convert them into quaternions, and combine with global pose quaternions to warp shader coordinate spaces (e.g., quantum lattice). Requires augmenting synchronizer observers to accept per-fragment aggregates.
+- **Dependencies**: Depth/plane composites are already available via the registry, so focus is on quaternion synthesis and shader uniform mapping.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L1101-L1200】
+
+### 4. Quaternion-Based Interaction Mapping
+- **Objective**: Map WebXR hit-test normals into shader interaction volumes to spawn reactive visual effects aligned with real-world surfaces.
+- **Approach**: Use hit-test quaternion outputs to orient shader emitters, coupling rotation with spatial anchors for persistence. The diagnostics overlay can verify orientation fidelity before promoting interactions to production.
+
+## Next Steps
+1. **Observer Toolkit** – Build reusable utilities atop `ShaderQuaternionSynchronizer.addObserver` for quaternion blending, filtering, and feature extraction (e.g., angular velocity spectra).
+2. **Overlay Enhancements** – Add timeline scrubbing and export for the diagnostics overlay so researchers can capture quaternion/parameter traces for offline experimentation.
+3. **Shader Experiment Sandbox** – Integrate overlay outputs with shader developer tooling (e.g., live GLSL editors) to trial quaternion-driven modulations rapidly.
+4. **Academic Partnerships** – Use the document as a primer for external research collaborators exploring quaternion field synthesis, XR localization, and novel visual metaphors.
+
+Maintaining this document alongside the execution log ensures the XR localization research agenda stays aligned with runtime capabilities while encouraging exploratory work beyond basic synchronisation.

--- a/DOCS/wearables-platform-comparison.md
+++ b/DOCS/wearables-platform-comparison.md
@@ -1,0 +1,45 @@
+# XR Wearables Platform Alignment Brief
+
+## Executive Summary
+- Khronos Group's **OpenXR** standard is the dominant cross-vendor runtime API for XR headsets, smart glasses, and controllers; it is used by Meta Quest, Microsoft HoloLens, HTC Vive, Varjo, and Pico shipping runtimes.
+- OpenXR exposes a stable abstraction centered on session/space management, action-based input, and standardized extension discovery for sensors such as eye tracking, hand tracking, facial expression, and body tracking.
+- Our current wearable stack uses bespoke composite schemas, confidence weighting, and licensing gates implemented in the `SensorSchemaRegistry`, `SensoryInputBridge`, and device-specific adapters. This offers flexibility but diverges from OpenXR's action/space semantics and standardized extension ecosystem.
+- Aligning our telemetry and SDK layers to mirror OpenXR concepts (action sets, interaction profiles, XrSpace-based poses, extension identifiers) will reduce friction for partners shipping OpenXR runtimes, simplify certification, and improve interoperability with downstream engines.
+
+## Industry Baseline: OpenXR
+OpenXR is an open royalty-free standard managed by the Khronos Group. Its key architectural pillars include:
+
+1. **Runtime / Application Contract** – Applications connect to a vendor-provided OpenXR runtime which exposes `xrCreateSession`, `xrBeginSession`, and `xrEndSession` for lifecycle control. Runtimes unify headset pose, composition layers, and time synchronization without vendor-specific SDKs.
+2. **Action-Based Input** – Instead of polling raw device channels, OpenXR defines `XrActionSet` and `XrAction` objects bound to interaction profiles (e.g., `XR_INPUT_SOURCE_HEAD`, `XR_EXT_eye_gaze_interaction`). Actions expose types such as boolean, float, pose, and vibration. Applications query `xrSyncActions` to fetch state per frame.
+3. **Spaces & Poses** – Device tracking is expressed via `XrSpace` objects. Headset, controller, hand, and face anchors are located with `xrLocateSpace`, returning poses with confidence data tied to a common time base.
+4. **Extension Registry** – OpenXR publishes optional extensions for advanced sensors: `XR_EXT_eye_gaze_interaction` (eye tracking), `XR_FB_face_tracking` / `XR_HTC_body_tracking` (facial/body), `XR_ML_marker_understanding` (Vision Pro style). Vendors ship runtime manifests advertising supported extensions so applications can dynamically enable them.
+5. **Event Pump & Frame Timing** – `xrPollEvent` exposes lifecycle and state notifications, while `xrWaitFrame`/`xrBeginFrame` coordinate rendering cadence, ensuring telemetry, rendering, and passthrough align to the runtime's predicted display time.
+
+## Current Wearables Stack Snapshot
+Our implementation currently provides:
+
+- **Custom composite schemas per wearable**: `SensorSchemaRegistry` registers device-specific bundles (AR visor, neural band, biometric wrist) that normalize nested payloads, compute metadata, and clamp confidences per channel.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L398-L492】【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L504-L612】
+- **Bridge-managed history & snapshots**: `SensoryInputBridge` recursively applies wearable composites, tracks bounded history, and exposes `getWearableSnapshot` and `listWearableDevices` utilities for downstream consumers.【F:src/ui/adaptive/SensoryInputBridge.js†L321-L568】
+- **Adapter-driven ingestion**: Concrete adapters extend `BaseWearableDeviceAdapter` to enforce license checks, throttle telemetry, and feed normalized payloads into the bridge via the `WearableDeviceManager` facade.【F:src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js†L99-L238】【F:src/ui/adaptive/sensors/WearableDeviceManager.js†L5-L158】
+
+## Gap Analysis vs. OpenXR
+| Area | OpenXR Approach | Current Implementation | Observations |
+| --- | --- | --- | --- |
+| Device Discovery | `xrEnumerateViewConfigurations`, `xrEnumeratePaths`, and runtime-advertised extensions identify sensors at runtime. | Device types are hard-coded in the registry with static schema IDs (`wearable.ar-visor`, `wearable.neural-band`, etc.). | Need a dynamic discovery mechanism or mapping layer to OpenXR interaction profiles and extension strings. |
+| Input Model | Actions represent semantic intent (select, squeeze, gaze) bound to interaction profiles. | Channels deliver raw payloads (vectors, quaternions, biometrics) with per-channel confidences. | Consider layering an action abstraction on top of channels to map to OpenXR-compatible semantics. |
+| Spatial Data | Poses delivered via `XrSpace` with time-aligned `XrPosef`. | Pose metadata optional per wearable; not tied to shared reference frames or predicted display time. | Introduce space identifiers, timestamp alignment, and orientation conventions matching `xrLocateSpace` outputs. |
+| Extension Negotiation | Applications query `xrEnumerateInstanceExtensionProperties` to opt into features. | Licensing gates exist, but extension availability is implicit; no registry of capabilities. | Provide an extension capability manifest per adapter that mirrors OpenXR extension naming. |
+| Event Timing | Frame loop synchronized via `xrWaitFrame` and `xrBeginFrame`. | Bridge timestamps rely on incoming payload timestamps without runtime coordination. | Add clock synchronization hooks or integrate runtime frame prediction data if available. |
+
+## Recommendations
+1. **Capability Manifests & Interaction Profiles** – Augment each adapter with a manifest that declares supported OpenXR interaction profiles and extension IDs. Use this to autogenerate discovery payloads and align schema identifiers with OpenXR naming.
+2. **Action Layer Abstraction** – Build an action mapping service that converts normalized channel data (e.g., gaze vectors, intent confidences) into OpenXR-style action states. This will let downstream engines interface via familiar semantics.
+3. **Space-Aware Metadata** – Extend wearable metadata to include named spaces (`local`, `stage`, `view`) and deliver poses with the same axes, units, and handedness as OpenXR's `XrPosef`. Capture predicted display time or frame ID alongside sensor timestamps.
+4. **Extension Negotiation API** – Provide APIs similar to `xrEnumerateInstanceExtensionProperties` so clients can detect optional capabilities (eye tracking, biometrics) before subscribing, aligning with license gating.
+5. **Compliance Testing** – Create automated compatibility tests that validate our normalized payloads against OpenXR conformance guidelines (pose conventions, action ranges), improving partner confidence.
+
+## Next Steps
+- Prototype a lightweight adapter that projects our AR visor schema into OpenXR-compatible action bindings (head pose -> `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO`, gaze -> `XR_EXT_eye_gaze_interaction`).
+- Draft partner documentation showing how to integrate our telemetry service with an OpenXR runtime, including manifest examples and suggested extension names.
+- Evaluate leveraging existing OpenXR SDKs (e.g., Monado, OpenXR Loader) within our tooling to validate interoperability early in development.
+

--- a/PLANNING/WEARABLES_OPENXR_ALIGNMENT_PLAN.md
+++ b/PLANNING/WEARABLES_OPENXR_ALIGNMENT_PLAN.md
@@ -1,0 +1,106 @@
+# Wearables OpenXR Alignment Development Plan
+
+## 1. Purpose & Scope
+This plan describes how to evolve the wearables stack (sensor schemas, adapters, telemetry bridge, SDK surface) so it conforms to OpenXR runtime expectations while remaining compatible with existing adaptive runtime consumers. The scope covers the runtime/device integration lane; UI/web telemetry consumers remain in a parallel track but must be kept in sync through shared contracts. We assume willingness to refactor or replace components when alignment yields clearer interoperability or reduced maintenance.
+
+## 2. Guiding Principles
+1. **Interop First** – Prefer OpenXR-native abstractions (actions, spaces, interaction profiles) over bespoke constructs when a one-to-one mapping exists.
+2. **Progressive Adoption** – Layer new capabilities behind feature flags/manifests so existing partners can migrate gradually.
+3. **Testable Compliance** – Every change should be validated through automated tests comparing our payloads/actions against OpenXR conformance rules.
+4. **Bidirectional Compatibility** – Support both ingesting OpenXR runtimes and projecting data back out for non-OpenXR consumers.
+5. **Documented Migration Paths** – Provide clear developer documentation, changelogs, and SDK typings describing behavioral changes.
+
+## 3. Target Architecture Overview
+| Layer | Current State | Target Refactor | Notes |
+| --- | --- | --- | --- |
+| Device Discovery | Static schema registration inside `SensorSchemaRegistry`. | Capability manifests per adapter with OpenXR interaction profile IDs and extension names; dynamic registry enumeration. | Aligns with recommendations from the platform comparison brief. |
+| Data Model | Channel-based payloads with confidences. | Dual-path model: normalized channels plus derived OpenXR `XrAction` state cache. | Allows existing consumers to keep channel data while OpenXR apps bind to actions. |
+| Spatial Context | Optional metadata without shared reference frames. | Standardized `XrSpace` identifiers (local, stage, view) stored alongside poses and timestamps. | Requires refactoring `SensoryInputBridge` metadata handling. |
+| Negotiation & Licensing | Implicit licensing gates per adapter. | Explicit capability negotiation API mirroring `xrEnumerateInstanceExtensionProperties` + license attestation handshake. | Keeps licensing but exposes it through OpenXR-inspired flow. |
+| Telemetry & Events | Bridge-managed event emission without runtime frame synchronization. | Clock service integrated with runtime prediction (`xrWaitFrame` analogue) ensuring telemetry is aligned with frame timing. | Enables deterministic replay/testing. |
+| SDK Surface | Custom TS types for adapters/bridge. | Namespaced OpenXR compatibility layer (`adaptive.openxr`) exporting action enums, capability queries, and compatibility helpers. | Provide progressive adoption wrappers. |
+
+## 4. Workstreams & Tasks
+
+### 4.1 Capability & Discovery Manifests
+- Define manifest schema describing interaction profiles, OpenXR extension IDs, licensing requirements, and fallback behaviors.
+- Refactor adapters (`BaseWearableDeviceAdapter` derivatives) to publish manifests and register with an enumerator API.
+- Update `WearableDeviceManager` to expose `listCapabilities()` akin to `xrEnumerateInstanceExtensionProperties`.
+- Provide migration tooling to convert existing static registry entries into manifests.
+
+### 4.2 Action Layer Abstraction
+- Design action mapping table translating channel payloads into OpenXR action types (boolean, float, vector2f, pose, vibration).
+- Implement an `ActionStateStore` inside the bridge that updates per frame using normalized channel data.
+- Supply default bindings for AR visor, neural band, biometric wrist adapters referencing standard interaction profiles (e.g., `XR_EXT_eye_gaze_interaction`).
+- Extend tests to validate that action states match expected ranges and semantics for each device.
+
+### 4.3 Space & Timing Alignment
+- Introduce a `SpaceRegistry` that manages named spaces (`local`, `stage`, `view`, device-specific anchors) with consistent orientation/handedness.
+- Update payload metadata to embed `XrSpace` identifiers and include predicted display times or frame IDs from a shared clock service.
+- Refactor `SensoryInputBridge` to propagate aligned timestamps and provide utilities similar to `xrLocateSpace`.
+- Add conformance checks verifying pose matrices, handedness, and timestamp monotonicity.
+
+### 4.4 Negotiation, Licensing, and Consent Flow
+- Build a negotiation API sequence mirroring OpenXR initialization: capability query → license check → session creation.
+- Integrate telemetry/licensing modules so attestation occurs when capabilities are enabled.
+- Document consent prompts aligning with OpenXR privacy guidelines (eye, hand, biometric data).
+- Provide sample flows for enabling/disabling extensions dynamically at runtime.
+
+### 4.5 SDK & Tooling Updates
+- Introduce an `adaptive-openxr` TypeScript namespace exposing helpers for action creation, capability querying, and migration adapters.
+- Update `types/adaptive-sdk.d.ts` and developer docs with OpenXR-compatible interfaces.
+- Create reference implementation demonstrating bridging our stack with an OpenXR runtime (e.g., Monado) including a sample WebXR overlay.
+- Offer CLI tooling to validate manifests and action mappings before publishing.
+
+### 4.6 Compliance & QA Automation
+- Expand Vitest suites with OpenXR conformance fixtures (pose validation, action semantics, extension negotiation).
+- Add integration tests replaying OpenXR event streams to ensure compatibility.
+- Establish nightly compatibility runs against a headless OpenXR runtime to guard against regressions.
+- Coordinate with QA to capture manual certification steps for major vendors (Meta, Microsoft, HTC, Varjo, Pico).
+
+### 4.7 Migration & Deprecation Strategy
+- Publish deprecation schedule for legacy schema registration APIs, including feature flags controlling new behavior.
+- Provide compatibility shims and instrumentation to detect deprecated usage in partner integrations.
+- Stage rollout: **Phase A** (dual path), **Phase B** (default to OpenXR alignment), **Phase C** (remove legacy-only hooks).
+- Communicate timeline in release notes and partner briefings.
+
+## 5. Deliverables & Milestones
+| Milestone | Target | Key Deliverables |
+| --- | --- | --- |
+| M1 – Manifest Foundations | Sprint 0-1 | Manifest schema, adapter updates, discovery API, migration script, baseline tests. |
+| M2 – Action & Space Layer | Sprint 2-3 | ActionStateStore, default bindings, SpaceRegistry, bridge refactor, pose/time conformance tests. |
+| M3 – Negotiation & SDK | Sprint 4-5 | Capability negotiation API, licensing alignment, `adaptive-openxr` namespace, sample integration app. |
+| M4 – Compliance Automation | Sprint 6 | Nightly conformance pipeline, coverage reports, QA certification checklist. |
+| M5 – Migration Cutover | Sprint 7+ | Deprecation toggles, telemetry dashboards updated, partner comms package, readiness review. |
+
+## 6. Decision Points & Refactor Triggers
+- **Manifest Adoption:** If manifest integration reveals fundamental schema constraints, greenlight full replacement of `SensorSchemaRegistry` internals with manifest-driven registry.
+- **Action Mapping Complexity:** If action derivation becomes unmanageable, consider exposing a dedicated OpenXR runtime adapter instead of channel-to-action translation.
+- **Space Alignment:** If existing metadata cannot be reconciled, replace metadata pipeline with new `SpaceRegistry` and migrate consumers via compatibility layer.
+- **SDK Surface:** Decide whether to keep hybrid APIs or fork an `adaptive-openxr` package when dual maintenance becomes costly.
+
+## 7. Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Divergence from UI/web telemetry contracts | Breaks dashboards/analytics. | Share manifest schema and action mappings with UI/web team, add cross-track contract tests. |
+| Vendor-specific extension gaps | Missing functionality for proprietary features. | Allow manifest overrides per deployment, maintain vendor extension catalog with fallback strategies. |
+| Performance overhead from dual data paths | Increased latency in bridge processing. | Profile bridge, introduce configurable throttling, and optimize hot paths using typed arrays/batched updates. |
+| Certification delays | Slows partner onboarding. | Engage vendors early with pilot builds, maintain compliance checklist, automate evidence capture. |
+
+## 8. Dependencies
+- Telemetry/licensing services for capability gating and consent logging.
+- Access to OpenXR runtime (e.g., Monado, vendor SDKs) for automated tests.
+- Hardware samples or recorded traces for AR visor, neural band, biometric wrist devices.
+- Collaboration with UI/web telemetry track for dashboard adjustments.
+
+## 9. Reporting & Communication
+- **Weekly**: Alignment sync with UI/web and platform compliance stakeholders.
+- **Bi-weekly**: OpenXR compatibility demo to surface progress and collect partner feedback.
+- **Release Notes**: Dedicated section for OpenXR alignment status and migration guidance.
+- **Dashboarding**: Track manifest adoption, action coverage, and conformance pass rates.
+
+## 10. Immediate Next Steps
+1. Finalize manifest schema draft and circulate for stakeholder review.
+2. Prototype manifest-based registration for one adapter (AR visor) to validate discovery flow.
+3. Set up OpenXR runtime harness (Monado or vendor-provided) within CI to support upcoming automation.
+4. Publish engineering RFC summarizing migration phases and solicit feedback from partner teams.

--- a/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
+++ b/PLANNING/WEARABLES_PHASE_ZERO_DEVELOPMENT_PLAN.md
@@ -1,0 +1,134 @@
+# Wearables Development – Phase Zero Execution Plan
+
+This plan establishes the concrete engineering path for taking the adaptive VIB34D wearables stack from Phase 0 (prototype) into sustained development. It scopes only the **wearables runtime and hardware integration lane**—the UI/web experience team will operate a parallel track and consume the telemetry/licensing foundations already delivered in this repository.
+
+## 1. Current Baseline
+
+- Adaptive runtime, telemetry, licensing, commercialization analytics, and projection/blueprint tooling already exist inside the SDK surface (`src/core`, `src/product`, `src/ui/adaptive`).
+- `wearable-designer.html` remains a monolithic demo shell demonstrating the features but is not yet modular or hardware-backed.
+- Telemetry, consent, licensing attestation, commercialization snapshotting, and projection scenario infrastructure are implemented and validated through Vitest + Playwright smoke coverage.
+- No production-grade wearable device adapters, schema-enforced sensor payload bridges, or deployment automation for wearable firmware/app containers exist.
+
+## 2. Phase Zero Objectives & Exit Criteria
+
+| Objective | Description | Exit Criteria |
+|-----------|-------------|---------------|
+| Establish Wearable Device Integration Foundations | Deliver reference adapters, schema validation, and telemetry routing for real sensor inputs. | Sensor schema registry covers real device payloads, adapters stream data into `SensoryInputBridge`, hardware smoke tests execute on CI rig. |
+| Modularize Wearable Runtime Package | Decouple the adaptive engine usage from the demo shell and expose reusable modules for firmware/app integrators. | `AdaptiveSDK` publishes wearable presets, modular samples replace demo wiring, API surface documented in `types/adaptive-sdk.d.ts`. |
+| Align with Telemetry/Licensing Track | Ensure wearables lane consumes and exercises telemetry, consent, licensing, commercialization flows owned by the web/UI team. | Shared acceptance tests confirm telemetry gating/licensing attestation triggered from hardware adapters; audit/compliance exports include wearable-origin metadata. |
+| Delivery Governance | Lock sprint cadence, tooling, and automation so Phase 1+ can scale. | Phase Zero completion review, tracker entries updated, automated smoke lane for hardware registered in CI. |
+
+Phase Zero concludes once real wearable signals hydrate the adaptive engine end-to-end (including telemetry/licensing flows), modular runtime packages ship with documentation, and repeatable automation validates integrations.
+
+## 3. Workstreams & Tasks
+
+### 3.1 Hardware & Sensor Integration
+
+1. **Device Inventory & Payload Mapping**
+   - Catalogue initial wearable targets (AR visor, neural band, biometric wrist device).
+   - Extract data formats, sampling rates, consent requirements.
+   - Update `SensorSchemaRegistry` with concrete schema definitions and tolerance ranges.
+2. **Adapter Development**
+   - Implement `src/ui/adaptive/sensors/adapters/<device>.js` for each device with normalization logic feeding `SensoryInputBridge`.
+   - Provide mock adapter implementations for local development and automated tests.
+3. **Hardware Smoke Bench**
+   - Script Playwright/Vitest-compatible harness to replay recorded sensor streams.
+   - Automate on-device smoke test recipe (e.g., Node bridge + WebSocket feed) to validate integration before firmware drops.
+4. **Telemetry Hook-Up**
+   - Ensure adapters flag telemetry classifications via `ProductTelemetryHarness`.
+   - Confirm licensing profiles (e.g., `wearables-pro`, `wearables-enterprise`) gate sensor activation.
+
+### 3.2 Adaptive Runtime Hardening
+
+1. **Runtime Profiles**
+   - Package wearable presets inside `AdaptiveSDK` (synthesizer strategies, annotations, projection packs).
+   - Document DI entry points for firmware/app teams.
+2. **Blueprint & Projection Validation**
+   - Add automated checks ensuring `LayoutBlueprintRenderer` and `ProjectionFieldComposer` operate within hardware constraints (FOV, refresh windows, energy budgets).
+   - Extend validator outputs with device-specific warnings.
+3. **Commercialization Touchpoints**
+   - Preconfigure commercialization snapshot/store adapters for wearable SKUs.
+   - Verify commercialization KPIs remain accurate when signals originate from hardware adapters.
+
+### 3.3 Packaging & Distribution
+
+1. **Module Extraction**
+   - Break down `wearable-designer.html` dependencies into reusable modules (awaiting B-05 but begin with runtime packaging).
+   - Publish reference implementations under `packages/wearables-kit` (or similar) with bundler config, typings, and quickstart README.
+2. **Firmware/Companion App SDK**
+   - Provide minimal Node/TypeScript wrapper for wearable firmware teams to embed adaptive runtime via WebView or native bridge.
+   - Document telemetry/licensing handshake requirements for companion apps.
+3. **Release Automation**
+   - Set up semantic versioning, changelog generation, and artifact publishing (internal registry) for wearables kit.
+
+### 3.4 Governance & Collaboration
+
+1. **Phase Zero Sprints**
+   - Sprint 0: Inventory + schema updates, finalize adapter scaffolding.
+   - Sprint 1: Implement first hardware adapter + mock harness; integrate telemetry/licensing flows.
+   - Sprint 2: Runtime presets, commercialization validation, documentation draft.
+   - Sprint 3: Packaging, release automation, cross-track demo review.
+2. **Cross-Track Agreements**
+   - Weekly sync with UI/web track to share telemetry/licensing API changes.
+   - Shared definition of done referencing compliance exports and commercialization dashboards.
+3. **Documentation Deliverables**
+   - Update `DOCS/ADAPTIVE_SDK_DEVELOPER_HANDOFF_GUIDE.md` with wearable hardware lane.
+   - Produce hardware integration cookbook (per device) and troubleshooting FAQ.
+
+## 4. Dependencies & Interfaces
+
+- **Telemetry/Licensing:** Consume existing providers (`ProductTelemetryHarness`, `LicenseManager`, `LicenseAttestationProfileRegistry`). Hardware adapters must emit consent state and licensing context; UI/web track owns dashboards/export visualization.
+- **Testing Stack:** Reuse Vitest for unit coverage, Playwright for consent/licensing flows, extend to include sensor stream replays. Consider integrating hardware lab harness via GitHub Actions self-hosted runner.
+- **Types & SDK Surface:** Continue expanding `types/adaptive-sdk.d.ts` for new adapter interfaces; ensure module packaging emits types for firmware teams.
+
+## 5. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Hardware availability delays | Blocks adapter validation and telemetry handshake. | Maintain recorded sensor traces; use emulators until devices arrive; schedule early vendor engagement. |
+| Drift between wearables kit and UI/web telemetry contract | Broken dashboards, inconsistent compliance exports. | Shared schema contract repo; automated contract tests run across both tracks. |
+| Performance constraints on low-power devices | Latency in adaptive layout/projection rendering. | Profile runtime on reference hardware; expose configuration knobs for throttling strategies; implement watchdog telemetry to flag overruns. |
+| Licensing/attestation mismatches | Sensor activation blocked or untracked monetization usage. | Pre-register wearables profiles in catalog; add integration tests for attestation flows triggered via adapters. |
+
+## 6. Deliverables Checklist
+
+- [ ] Updated sensor schema definitions + adapter scaffolding checked in.
+- [ ] Wearable device adapters streaming real data through `SensoryInputBridge`.
+- [ ] Automated harness replaying sensor traces in CI.
+- [ ] Adaptive runtime wearable presets packaged and documented.
+- [ ] Commercialization telemetry validated with hardware-origin signals.
+- [ ] Wearables kit packaging + release automation operational.
+- [ ] Cross-track demo review demonstrating end-to-end telemetry, licensing, commercialization, and adaptive visualization with live wearable input.
+
+## 7. Milestones, Staffing, and Reporting Cadence
+
+### 7.1 Sprint-by-Sprint Commitments
+
+| Sprint | Focus | Primary Deliverables |
+|--------|-------|----------------------|
+| Sprint 0 | Device discovery & schema foundation | Finalized device inventory, signed-off payload schemas, adapter scaffolding merged, mock sensor capture repository established. |
+| Sprint 1 | First hardware path live | AR visor adapter + mock harness replay in CI, telemetry/licensing contract tests green, firmware handoff notes published. |
+| Sprint 2 | Runtime + commercialization alignment | Wearable presets available via `AdaptiveSDK`, commercialization validation scripts automated, documentation walkthrough recorded. |
+| Sprint 3 | Packaging & release readiness | Wearables kit package published to internal registry, release automation validated, cross-track end-to-end demo executed. |
+
+### 7.2 Staffing & RACI Snapshot
+
+| Role | Lead | Accountable Areas |
+|------|------|-------------------|
+| Wearables Integration Lead | Embedded systems engineer | Device inventory, adapter implementation, hardware smoke bench upkeep. |
+| Adaptive Runtime Architect | Core runtime engineer | Preset packaging, performance profiling, commercialization checks. |
+| Telemetry/Licensing Liaison | Shared with UI/web track | Schema alignment, consent/licensing validation, compliance exports. |
+| DevOps & Release Owner | Platform engineer | CI hardware lane, semantic versioning, artifact publishing. |
+| Program Manager | Delivery coordinator | Sprint ceremonies, risk tracking, stakeholder comms, exit review facilitation. |
+
+### 7.3 Reporting Rhythm
+
+- **Daily**: Async stand-up updates in shared channel with blockers escalated within 2 hours.
+- **Twice Weekly**: Hardware adapter test report (device status, telemetry/licensing assertions, trace replay results).
+- **Weekly**: Cross-track sync with UI/web lane to reconcile API changes, licensing catalog updates, and commercialization dashboards.
+- **Sprint Reviews**: Joint demo including live wearable feed, telemetry/licensing dashboards, and commercialization snapshots.
+- **Sprint Retros**: Capture process improvements and feed into governance backlog ahead of Phase One scale-up.
+
+---
+
+**Next Action:** Kick off Sprint 0 by formalizing device inventory interviews, capturing payload specifications, and preparing schema updates within the existing adaptive runtime repositories.

--- a/PLANNING/WEARABLES_SPATIAL_DEVELOPMENT_EXECUTION_LOG.md
+++ b/PLANNING/WEARABLES_SPATIAL_DEVELOPMENT_EXECUTION_LOG.md
@@ -1,0 +1,40 @@
+# Wearables Spatial Development Execution Log
+
+## Purpose
+This document consolidates our active development strategy for the wearables runtime as we extend it toward OpenXR/WebXR spatial interoperability. It captures the architectural context that guides implementation choices and establishes a per-turn execution log so progress stays transparent and aligned with the agreed roadmap.
+
+## Architecture Snapshot
+### Runtime Orchestration
+- **SensoryInputBridge** centralizes adapter lifecycle management, schema validation, bounded history, and snapshot emission for wearable channels, enabling consistent routing and telemetry across the adaptive interface engine.
+- **WearableDeviceManager** wraps the bridge to register adapters, subscribe to device-level updates, and proxy ingestion without duplicating orchestration concerns.
+
+### Schema Normalization
+- **SensorSchemaRegistry** provides reusable validators and composite builders that normalize wearable payloads, enforce required channels, and surface field-level issues for downstream consumers.
+
+### Adapter Layer
+- **BaseWearableDeviceAdapter** handles licensing gates, telemetry metadata, trace playback/transport ingestion, and channel compaction while allowing device-specific subclasses to focus on normalization.
+
+## Strategic Focus Areas
+1. **Standards Alignment** – Map OpenXR/WebXR interaction profiles, hit-test semantics, spatial anchors, and environmental sensing onto existing schemas to ensure compatibility without re-platforming.
+2. **Spatial Data Pipeline** – Extend registry/bridge/adapters to ingest spatial meshes, planes, depth, and lighting signals with confidence clamping and temporal coherence guarantees.
+3. **SDK & Tooling Evolution** – Surface new spatial capabilities through adaptive SDK typings, developer tooling, and diagnostics while maintaining backward compatibility for current wearable integrations.
+4. **Telemetry & Licensing** – Preserve auditability by threading telemetry scopes/classifications through new adapters and ensuring feature gating aligns with licensing policies.
+
+## Execution Rhythm
+- Each turn produces a concrete deliverable (code, tests, or validated documentation) that advances the strategic focus areas above.
+- The execution log (below) records objectives, artifacts, and next actions after every turn so stakeholders can audit progress and course-correct quickly.
+
+## Turn Execution Log
+| Turn Timestamp (UTC) | Focus | Deliverables | Next Actions |
+| --- | --- | --- | --- |
+| 2025-02-14T00:00 | Establish execution log & reaffirm architecture | This document summarizing runtime architecture, strategy, and cadence expectations. | Prioritize spatial schema extensions for hit testing & anchors integration, preparing adapter shims and validation harnesses. |
+| 2025-02-14T02:00 | Define spatial schema deltas & implement registry scaffolding | WebXR spatial schema delta brief plus SensorSchemaRegistry/type/test updates covering planes, depth, hit-test rays/results, and anchor wrappers. | Wire spatial channels through AR visor composites and begin adapter ingestion spikes for recorded plane/depth traces. |
+| 2025-02-14T04:00 | Wire AR visor spatial ingestion & align quaternion strategy | ARVisor adapter spatial channel ingestion, Vitest coverage exercising schema-ready payloads, and quaternion alignment brief linking runtime payloads with the shader track. | Expose SDK helpers for quaternion uniform packing and start diagnostic overlays for spatial channel validation. |
+| 2025-02-14T06:00 | Quaternion-driven shader synchronization | Implemented `ShaderQuaternionSynchronizer` to stream spatial quaternions into faceted/quantum/holographic parameters, exposed SDK factory hooks, refreshed quaternion documentation, and added Vitest coverage validating motion-energy mapping and confidence gating. | Integrate synchronizer into runtime scenes and drive shader diagnostics that visualise rot4d alignment against incoming wearable poses. |
+| 2025-02-14T08:00 | Quaternion diagnostics integration & research scaffolding | Added a real-time `ShaderQuaternionDiagnosticsOverlay`, expanded the synchronizer with observer hooks, exposed SDK helpers, published a quaternion/XR research brief, and covered the new flows with Vitest suites. | Wire the overlay into showcase scenes, capture synchronized traces for shader experimentation, and prototype quaternion blending utilities for anchor clusters. |
+| 2025-02-14T10:00 | Quaternion cluster toolkit & spatial aggregation pipeline | Implemented a reusable quaternion cluster toolkit with weighted anchor/hit-test blending, integrated it into the synchronizer/SDK, expanded Vitest coverage, and documented the toolkit within the spatial research brief. | Feed aggregated quaternions into scene demos, validate cluster variance heuristics against real trace captures, and explore blending hooks for collaborative multi-device poses. |
+
+## Maintenance Notes
+- Update the **Architecture Snapshot** if core runtime abstractions materially change.
+- Append a new row to the **Turn Execution Log** after each development turn, capturing tangible outputs and the immediate follow-up target.
+- Reference supporting design memos (OpenXR alignment, WebXR spatial plan) when sequencing complex spatial capabilities to maintain cross-team alignment.

--- a/PLANNING/WEBXR_HIT_TEST_AND_SPATIAL_PLAN.md
+++ b/PLANNING/WEBXR_HIT_TEST_AND_SPATIAL_PLAN.md
@@ -1,0 +1,83 @@
+# WebXR Spatial Interaction Integration Plan
+
+## 1. Purpose
+This document analyzes the WebXR spatial interaction stack—Hit Testing, Anchors, Plane Detection/Scene Understanding, and Depth Sensing—to determine what our wearables runtime must implement so the adaptive platform can participate in browser-grade XR experiences. The goal is to connect the Khronos-aligned wearables architecture to WebXR semantics, ensuring downstream UI/web teams receive telemetry that aligns with standard APIs without duplicating effort.
+
+## 2. WebXR Spatial Modules Overview
+### 2.1 Hit Testing API
+- Provides `XRHitTestSource` objects bound to reference spaces (viewer, local, bounded-floor) and optional ray offsets.
+- Runtime returns `XRHitTestResult` entries per frame with pose transforms, surface normals (when available), and transient input metadata for tracked controllers/hands.
+- Hit tests are expected to respect real-world geometry from depth/meshing subsystems and can be lightweight (viewer-aligned rays) or heavy (scene meshes).
+
+### 2.2 Anchors Module
+- Allows apps to create persistent `XRAnchor` objects from hit test results.
+- Anchors require continuous pose tracking, pose accuracy metadata, and lifecycle events (removed/updated) to keep spatial content stable.
+- Anchors are typically backed by platform world-understanding services (ARKit, ARCore, Windows Mixed Reality) that manage relocalization.
+
+### 2.3 Plane & Scene Understanding
+- WebXR Plane Detection module yields `XRPlane` objects representing planar surfaces with polygon meshes, alignment hints (horizontal/vertical), and tracking states.
+- Scene Understanding proposals extend this to semantic meshes (walls, floors, ceilings) requiring spatial classification and timestamped updates.
+
+### 2.4 Depth Sensing
+- WebXR Depth Sensing provides `XRDepthInformation` buffers (CPU-friendly or GPU textures) keyed to views, enabling per-pixel depth reconstruction.
+- Accurate hit testing and occlusion rely on synchronized camera pose, intrinsics, and confidence maps.
+
+### 2.5 Lighting Estimation (Optional but Related)
+- Supplies spherical harmonics or reflection probes for realistic rendering; depends on similar world-understanding data.
+
+## 3. Mapping Requirements to Our Architecture
+| WebXR Capability | Data Requirements | Current State | Required Enhancements |
+| --- | --- | --- | --- |
+| Hit Testing | Ray definition, spatial scene data, per-frame results tied to spaces and predicted display time. | Bridge tracks wearable snapshots and poses but lacks scene geometry ingestion. | Introduce a spatial scene service that aggregates plane/depth feeds, exposes `performHitTest()` APIs, and emits results via the bridge with OpenXR-compatible `XrSpace` metadata. |
+| Anchors | Persistent anchors with update/removal events and tracking accuracy metrics. | No persistent spatial object registry. | Build an `AnchorStore` linked to the SpaceRegistry; adapters must surface platform anchor IDs, status, and accuracy/confidence to downstream consumers. |
+| Plane Detection | Plane polygons, orientation, extents, timestamps. | Schemas only cover wearable telemetry (poses, biometrics). | Extend SensorSchemaRegistry with spatial scene composites (`scene.plane`, `scene.mesh`) and ensure adapters forward plane updates. |
+| Depth Sensing | View-relative depth buffers, intrinsics, reliability. | No depth channel support. | Add GPU/CPU depth buffer channels, integrate with frame timing service, and align metadata with WebXR `XRDepthInformation`. |
+| Lighting Estimation | Spherical harmonics, reflection cube maps. | Not represented. | Optional: define lighting channels for runtime parity; treat as stretch goal after hit test/anchors. |
+
+## 4. Implementation Plan
+### Phase A – Spatial Data Foundations (Sprint 0-1)
+1. **Scene Data Schema**: Extend `SensorSchemaRegistry` with spatial scene composites for planes, meshes, and depth buffers; include alignment with OpenXR spaces for compatibility.【F:src/ui/adaptive/sensors/SensorSchemaRegistry.js†L398-L612】
+2. **Spatial Ingestion Adapters**: Update wearable adapters (especially AR visor) to source plane/depth feeds from device SDKs and publish to the bridge, guarded by capability manifests.
+3. **SpaceRegistry Enhancements**: Finalize `SpaceRegistry` design from the OpenXR alignment plan to anchor scene data against consistent reference spaces.
+
+### Phase B – Hit Testing Service (Sprint 2-3)
+1. **Hit Test Manager**: Implement a `HitTestService` within the bridge layer that maintains registered rays, consumes scene data, and emits hit test results each frame aligned with predicted display time.
+2. **Transient Input Support**: Link the `WearableDeviceManager` hand/controller data to hit test subscriptions so transient sources mirror WebXR semantics.
+3. **Testing Harness**: Create Vitest suites simulating plane + ray intersections and validating pose accuracy/clamping rules.
+
+### Phase C – Anchor Lifecycle (Sprint 3-4)
+1. **AnchorStore**: Persist anchors derived from hit test results, propagate updates/removals, and expose subscription APIs similar to `XRAnchorSet`.
+2. **Relocalization Hooks**: Surface adapter callbacks for when platform anchors adjust due to world understanding updates; ensure bridge re-bases poses smoothly.
+3. **SDK Exposure**: Extend `types/adaptive-sdk.d.ts` with anchor/hit test interfaces, referencing OpenXR spaces for dual compatibility.【F:types/adaptive-sdk.d.ts†L1-L202】
+
+### Phase D – Depth & Lighting Integration (Sprint 4-5)
+1. **Depth Buffer Pipeline**: Support streaming GPU textures or CPU buffers, gating by capability manifest due to bandwidth implications.
+2. **Occlusion Utilities**: Provide helper APIs for compositors to query depth at a pose; align with WebXR depth semantics.
+3. **Lighting Channels (Optional)**: If required by UX roadmap, add lighting estimation channels mapped to spherical harmonics.
+
+## 5. Readiness & Sequencing Recommendation
+- **Start Immediately After Manifest Foundations**: Spatial data work (Phase A) should begin once capability manifests are in review (end of current Sprint 0) so scene schemas integrate with the same manifest/negotiation architecture.
+- **Parallelization Guidance**: Hit test service (Phase B) can overlap with action layer work as long as shared SpaceRegistry contracts are stable.
+- **Anchors & Depth**: Defer anchor lifecycle until hit test outputs are validated; depth sensing should follow anchors since it relies on established frame timing and scene data ingestion.
+- **UI/Web Coordination**: Web telemetry track must prepare to consume new spatial events; schedule joint design reviews before Phase B kicks off.
+
+## 6. Architectural Assurance Checklist
+1. **Spaces Unified**: Confirm all spatial outputs (hit tests, anchors, planes) reference the same `XrSpace` identifiers defined in the OpenXR alignment plan.
+2. **Capability Negotiation**: Extend manifest schema to advertise `spatial.hit-test`, `spatial.anchors`, `spatial.depth`, and `spatial.lighting` flags so clients can opt in before subscription.
+3. **Telemetry Compliance**: Ensure telemetry payloads include confidence/accuracy metrics required by WebXR modules (e.g., anchor tracking states, depth buffer confidence).
+4. **Performance Budgets**: Profile scene ingestion and hit testing to stay within frame budget (ideally <2 ms per frame on target hardware) and expose tuning knobs (ray count, plane update rate).
+5. **Security & Privacy**: Coordinate with licensing/consent flows to gate spatial understanding features, mirroring platform privacy requirements.
+
+## 7. Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Scene data overburdens bridge history | Latency spikes, dropped frames. | Introduce dedicated spatial cache with eviction separate from wearable channel history; stream large meshes via references instead of inline payloads. |
+| Divergent coordinate conventions | Misaligned hit results across OpenXR/WebXR consumers. | Standardize on right-handed, meter-based poses with quaternion orientation; add automated conformance tests comparing to reference traces. |
+| Privacy compliance gaps for spatial mapping | Blocks deployment in regulated markets. | Integrate consent prompts and logging with licensing gates before enabling spatial capabilities. |
+| Testing complexity | Hard to simulate world-understanding data. | Build deterministic fixtures using synthetic planes/depth maps and integrate with CI to validate hit test math. |
+
+## 8. Next Steps
+1. Finalize capability manifest extensions for spatial features and circulate to UI/web + platform stakeholders.
+2. Kick off Phase A spike to prototype plane schema ingestion using recorded AR visor traces.
+3. Draft SDK interface proposal for hit test/anchor APIs and share with developer advocacy for feedback.
+4. Schedule architecture review to confirm SpaceRegistry and HitTestService designs before implementation begins.

--- a/PLANNING/WEBXR_SPATIAL_SCHEMA_DELTAS.md
+++ b/PLANNING/WEBXR_SPATIAL_SCHEMA_DELTAS.md
@@ -1,0 +1,43 @@
+# WebXR Spatial Schema Deltas
+
+## Purpose
+This note captures the concrete schema updates our wearables runtime needs so the spatial data we ingest from devices can map directly to WebXR hit testing, plane detection, depth sensing, and anchor semantics. It complements the broader WebXR spatial integration plan by translating feature goals into specific payload structures that must be supported inside `SensorSchemaRegistry` and the wearable composites.
+
+## Guiding Principles
+- **WebXR Compatible Fields** – Each schema mirrors the data expected by WebXR (`XRHitTestResult`, `XRPlane`, `XRDepthInformation`, `XRAnchor`) so UI/web consumers can project the payloads into browser APIs with minimal transformation.
+- **OpenXR-Friendly Spaces** – Space references always specify an OpenXR/WebXR-aligned reference space type and optional runtime-defined identifier, guaranteeing consistent spatial relationships.
+- **Confidence & Tracking Metadata** – All schemas expose confidence/accuracy/tracking-state data so downstream systems can gate rendering.
+- **Collection-Level Wrappers** – Wearable composites emit spatial data as collections (planes, hit test results, anchors) keyed by timestamps to reduce bridge churn and support delta updates (`removedIds`).
+
+## Schema Overview
+| Schema Type | Purpose | Key Fields |
+| --- | --- | --- |
+| `spatial.space-reference` | Helper structure reused by other schemas to describe the reference space for a pose or dataset. | `{ type: 'viewer' \| 'local' \| 'local-floor' \| 'bounded-floor' \| 'unbounded' \| 'stage' \| 'device' \| 'custom'; id?: string; }` |
+| `spatial.pose` | Pose helper capturing position + orientation with WebXR-aligned conventions (right-handed, meters). | `{ position: { x, y, z }; orientation: { x, y, z, w }; }` |
+| `spatial.scene-plane` | Represents a single detected plane aligned with WebXR `XRPlane`. | `id`, `space`, `pose`, `alignment` (`horizontal`/`vertical`/`slanted`/`unknown`), `extent` (`width`, `height`), `polygon[]`, `lastChangedTime`, `trackingState`, `classification` |
+| `spatial.scene-planes` | Collection wrapper for plane updates carried by wearables. | `timestamp`, `space`, `planes[]`, `removedIds[]` |
+| `spatial.depth-buffer` | CPU/GPU depth data aligned with WebXR `XRDepthInformation`. | `space`, `viewId`, `timestamp`, `format`, `width`, `height`, `rawValueToMeters`, `near`, `far`, `intrinsics`, `buffer` descriptor, `confidence` |
+| `spatial.hit-test-ray` | Registered hit-test source definition. | `id`, `space`, `offsetRay` (`origin`, `direction`), `entityTypes[]`, `targetRaySpace`, `handedness`, `transient`, `profile`, `initialResults` |
+| `spatial.hit-test-result` | Result payload matching `XRHitTestResult`. | `rayId`, `space`, `pose`, `transformMatrix`, `distance`, `timestamp`, `type`, `normal`, `anchors[]`, `inputSource` descriptor, `confidence` |
+| `spatial.hit-test-results` | Collection wrapper for per-frame hit-test evaluations. | `timestamp`, `space`, `results[]` |
+| `spatial.anchor` | Persistent anchor state. | `id`, `space`, `pose`, `lastChangedTime`, `trackingState`, `accuracy`, `associatedRayId`, `classification`, `confidence` |
+| `spatial.anchors` | Anchor set changes shared by wearables. | `timestamp`, `space`, `anchors[]`, `removedIds[]` |
+
+## Wearable Composite Impact (AR Visor First)
+- Add optional `spatial.planes`, `spatial.depth`, `spatial.hit-tests`, and `spatial.anchors` channels to the AR visor composite.
+- Each channel should look for raw data under `channels.spatial.*`, `spatial.*`, or `scene.*` nodes so adapters can source device SDK payloads naturally.
+- Default confidences:
+  - Planes: `0.78` (scene understanding reliability).
+  - Depth: `0.72` (sensor noise, depends on device).
+  - Hit tests: `0.8` (aggregated from scene + ray quality).
+  - Anchors: `0.76` (platform-managed accuracy).
+- Bridge metadata should surface `timestamp` and `space` to keep history/time-series consistent with wearable snapshots.
+
+## Development Sequencing
+1. **Sprint Now (Turn N)** – Implement the new schemas in `SensorSchemaRegistry`, add AR visor composite channels, and cover them with Vitest fixtures. This establishes the data contract before adapter/bridge services are wired up.
+2. **Next Sprint (Turn N+1)** – Extend `SensoryInputBridge` / `WearableDeviceManager` with spatial routing helpers (e.g., `bridge.subscribe('wearable.ar-visor:spatial.planes', ...)`) and start ingesting recorded plane/depth traces.
+3. **Turn N+2** – Build the hit test orchestration service that consumes registered rays and spatial data to emit `spatial.hit-test-results` collections each frame.
+4. **Turn N+3** – Layer in anchor lifecycle management and integrate capability manifest gating.
+
+## Ready-to-Start Decision
+All required dependencies (registry helpers, composite wiring plan, confidence defaults) are now defined. Implementation should begin **immediately** so upcoming turns can focus on adapter ingestion and bridge services.

--- a/src/core/AdaptiveSDK.js
+++ b/src/core/AdaptiveSDK.js
@@ -2,6 +2,13 @@ import { AdaptiveInterfaceEngine } from './AdaptiveInterfaceEngine.js';
 import { createConsentPanel as baseCreateConsentPanel } from '../ui/components/ConsentPanel.js';
 import { LicenseManager } from '../product/licensing/LicenseManager.js';
 import { RemoteLicenseAttestor } from '../product/licensing/RemoteLicenseAttestor.js';
+import { ShaderQuaternionSynchronizer } from '../ui/adaptive/renderers/ShaderQuaternionSynchronizer.js';
+import { ShaderQuaternionDiagnosticsOverlay } from '../ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js';
+import {
+    averageQuaternionSamples,
+    blendAnchorCluster,
+    blendHitTestCluster
+} from '../ui/adaptive/renderers/QuaternionClusterToolkit.js';
 
 export function createAdaptiveSDK(config = {}) {
     const telemetryOptions = { ...(config.telemetry || {}) };
@@ -196,6 +203,39 @@ export function createAdaptiveSDK(config = {}) {
         projectionSimulator: engine.projectionSimulator,
         licenseManager,
         licenseAttestor,
+        ShaderQuaternionSynchronizer,
+        ShaderQuaternionDiagnosticsOverlay,
+        quaternionToolkit: {
+            averageQuaternionSamples,
+            blendAnchorCluster,
+            blendHitTestCluster
+        },
+        createShaderQuaternionSynchronizer(options = {}) {
+            const { systems, systemResolver, ...rest } = options || {};
+            const resolver = typeof systemResolver === 'function'
+                ? systemResolver
+                : (name => {
+                    if (systems && systems[name]) {
+                        return systems[name];
+                    }
+                    if (typeof engine?.getVisualSystem === 'function') {
+                        const resolved = engine.getVisualSystem(name);
+                        if (resolved) {
+                            return resolved;
+                        }
+                    }
+                    if (typeof window !== 'undefined' && window?.systemManager?.systems instanceof Map) {
+                        return window.systemManager.systems.get(name) || null;
+                    }
+                    return null;
+                });
+
+            return new ShaderQuaternionSynchronizer({
+                bridge: engine.sensoryBridge,
+                systemResolver: resolver,
+                ...rest
+            });
+        },
         registerLayoutStrategy: engine.registerLayoutStrategy.bind(engine),
         registerLayoutAnnotation: engine.registerLayoutAnnotation.bind(engine),
         registerTelemetryProvider: engine.registerTelemetryProvider.bind(engine),
@@ -230,6 +270,25 @@ export function createAdaptiveSDK(config = {}) {
         getLicenseCommercializationSnapshots: engine.getLicenseCommercializationSnapshots.bind(engine),
         getLicenseCommercializationKpiReport: engine.getLicenseCommercializationKpiReport.bind(engine),
         exportLicenseCommercializationSnapshots: engine.exportLicenseCommercializationSnapshots.bind(engine),
+        createShaderQuaternionDiagnosticsOverlay(options = {}) {
+            const synchronizer = options.synchronizer instanceof ShaderQuaternionSynchronizer
+                ? options.synchronizer
+                : this.createShaderQuaternionSynchronizer(options.synchronizerOptions || {});
+
+            const overlayOptions = {
+                synchronizer,
+                container: options.container,
+                document: options.document,
+                theme: options.theme,
+                format: options.format
+            };
+
+            const overlay = new ShaderQuaternionDiagnosticsOverlay(overlayOptions);
+            if (options.autoMount !== false) {
+                overlay.mount();
+            }
+            return overlay;
+        },
         startLicenseCommercializationSnapshotSchedule: engine.startLicenseCommercializationSnapshotSchedule.bind(engine),
         stopLicenseCommercializationSnapshotSchedule: engine.stopLicenseCommercializationSnapshotSchedule.bind(engine),
         setLicense(license) {

--- a/src/ui/adaptive/renderers/QuaternionClusterToolkit.js
+++ b/src/ui/adaptive/renderers/QuaternionClusterToolkit.js
@@ -1,0 +1,228 @@
+const EPSILON = 1e-9;
+
+const identityQuaternion = () => ({ x: 0, y: 0, z: 0, w: 1 });
+
+function normalizeQuaternion(quaternion) {
+    if (!quaternion || typeof quaternion !== 'object') {
+        return null;
+    }
+    const x = Number(quaternion.x) || 0;
+    const y = Number(quaternion.y) || 0;
+    const z = Number(quaternion.z) || 0;
+    const w = Number.isFinite(quaternion.w) ? Number(quaternion.w) : Math.sqrt(Math.max(0, 1 - (x * x + y * y + z * z)));
+    const length = Math.hypot(x, y, z, w);
+    if (length < EPSILON) {
+        return null;
+    }
+    return { x: x / length, y: y / length, z: z / length, w: w / length };
+}
+
+function dotQuaternion(a, b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+function alignHemisphere(reference, quaternion) {
+    return dotQuaternion(reference, quaternion) < 0
+        ? { x: -quaternion.x, y: -quaternion.y, z: -quaternion.z, w: -quaternion.w }
+        : quaternion;
+}
+
+export function averageQuaternionSamples(samples = [], options = {}) {
+    const { fallbackIdentity = true } = options;
+    let reference = null;
+    let accumX = 0;
+    let accumY = 0;
+    let accumZ = 0;
+    let accumW = 0;
+    let totalWeight = 0;
+    let count = 0;
+
+    for (const sample of samples) {
+        if (!sample) continue;
+        const orientation = sample.orientation || sample.quaternion;
+        const weight = Math.max(0, Number(sample.weight ?? sample.confidence ?? 1));
+        if (!orientation || weight <= 0) {
+            continue;
+        }
+        const normalized = normalizeQuaternion(orientation);
+        if (!normalized) {
+            continue;
+        }
+        const aligned = reference ? alignHemisphere(reference, normalized) : normalized;
+        if (!reference) {
+            reference = aligned;
+        }
+        accumX += aligned.x * weight;
+        accumY += aligned.y * weight;
+        accumZ += aligned.z * weight;
+        accumW += aligned.w * weight;
+        totalWeight += weight;
+        count += 1;
+    }
+
+    if (totalWeight <= EPSILON || count === 0) {
+        return fallbackIdentity ? identityQuaternion() : null;
+    }
+
+    const length = Math.hypot(accumX, accumY, accumZ, accumW);
+    if (length <= EPSILON) {
+        return fallbackIdentity ? identityQuaternion() : null;
+    }
+
+    return {
+        x: accumX / length,
+        y: accumY / length,
+        z: accumZ / length,
+        w: accumW / length
+    };
+}
+
+export function blendAnchorCluster(anchors = [], options = {}) {
+    if (!Array.isArray(anchors) || anchors.length === 0) {
+        return null;
+    }
+
+    const samples = [];
+    let sumConfidence = 0;
+    let totalWeight = 0;
+    let count = 0;
+    let positionX = 0;
+    let positionY = 0;
+    let positionZ = 0;
+
+    for (const anchor of anchors) {
+        const pose = anchor?.pose;
+        const orientation = pose?.orientation;
+        if (!orientation) {
+            continue;
+        }
+        const confidence = Math.max(0, Math.min(1, Number(anchor?.confidence ?? pose?.confidence ?? 0.5)));
+        const weight = confidence > 0 ? confidence : 0.0001;
+
+        samples.push({ orientation, weight, confidence });
+        if (pose?.position) {
+            positionX += Number(pose.position.x) * weight || 0;
+            positionY += Number(pose.position.y) * weight || 0;
+            positionZ += Number(pose.position.z) * weight || 0;
+        }
+        sumConfidence += confidence * weight;
+        totalWeight += weight;
+        count += 1;
+    }
+
+    if (samples.length === 0 || totalWeight <= EPSILON) {
+        return null;
+    }
+
+    const orientation = averageQuaternionSamples(samples);
+    if (!orientation) {
+        return null;
+    }
+
+    const avgConfidence = Math.max(0, Math.min(1, sumConfidence / totalWeight));
+    const blendedPosition = {
+        x: positionX / totalWeight,
+        y: positionY / totalWeight,
+        z: positionZ / totalWeight
+    };
+
+    let variance = 0;
+    for (const sample of samples) {
+        const normalized = normalizeQuaternion(sample.orientation);
+        if (!normalized) continue;
+        const dot = Math.abs(dotQuaternion(orientation, normalized));
+        variance += (1 - dot) * sample.weight;
+    }
+    variance = variance / totalWeight;
+
+    return {
+        orientation,
+        confidence: avgConfidence,
+        weight: totalWeight,
+        sampleCount: count,
+        position: blendedPosition,
+        variance,
+        space: options.space || null
+    };
+}
+
+export function blendHitTestCluster(results = [], options = {}) {
+    if (!Array.isArray(results) || results.length === 0) {
+        return null;
+    }
+
+    const { distanceFalloff = 0.01 } = options;
+    const samples = [];
+    let totalWeight = 0;
+    let sumConfidence = 0;
+    let sumDistance = 0;
+    let positionX = 0;
+    let positionY = 0;
+    let positionZ = 0;
+    let count = 0;
+
+    for (const result of results) {
+        const pose = result?.pose;
+        const orientation = pose?.orientation;
+        if (!orientation) {
+            continue;
+        }
+        const confidence = Math.max(0, Math.min(1, Number(result?.confidence ?? 0.5)));
+        const distance = Math.max(0, Number(result?.distance ?? 0));
+        const weight = Math.max(EPSILON, confidence - distance * distanceFalloff);
+
+        samples.push({ orientation, weight, confidence });
+        if (pose?.position) {
+            positionX += Number(pose.position.x) * weight || 0;
+            positionY += Number(pose.position.y) * weight || 0;
+            positionZ += Number(pose.position.z) * weight || 0;
+        }
+        sumConfidence += confidence * weight;
+        sumDistance += distance * weight;
+        totalWeight += weight;
+        count += 1;
+    }
+
+    if (samples.length === 0 || totalWeight <= EPSILON) {
+        return null;
+    }
+
+    const orientation = averageQuaternionSamples(samples);
+    if (!orientation) {
+        return null;
+    }
+
+    const blendedPosition = {
+        x: positionX / totalWeight,
+        y: positionY / totalWeight,
+        z: positionZ / totalWeight
+    };
+
+    let variance = 0;
+    for (const sample of samples) {
+        const normalized = normalizeQuaternion(sample.orientation);
+        if (!normalized) continue;
+        const dot = Math.abs(dotQuaternion(orientation, normalized));
+        variance += (1 - dot) * sample.weight;
+    }
+    variance = variance / totalWeight;
+
+    return {
+        orientation,
+        confidence: Math.max(0, Math.min(1, sumConfidence / totalWeight)),
+        averageDistance: sumDistance / totalWeight,
+        weight: totalWeight,
+        sampleCount: count,
+        position: blendedPosition,
+        variance,
+        space: options.space || null
+    };
+}
+
+export const QuaternionClusterToolkit = {
+    averageQuaternionSamples,
+    blendAnchorCluster,
+    blendHitTestCluster
+};
+
+export default QuaternionClusterToolkit;

--- a/src/ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js
+++ b/src/ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js
@@ -1,0 +1,286 @@
+/**
+ * ShaderQuaternionDiagnosticsOverlay
+ * ------------------------------------------------------------
+ * Lightweight diagnostic overlay that visualises quaternion-driven updates
+ * flowing through the ShaderQuaternionSynchronizer. Renders Euler angles,
+ * motion energy, confidence, and the most recent parameter writes for each
+ * shader system so designers can correlate spatial localisation with the
+ * faceted/quantum/holographic pipelines in real time.
+ */
+
+const DEG_PER_RAD = 180 / Math.PI;
+
+let stylesInjected = false;
+
+const ensureStyles = doc => {
+    if (stylesInjected || !doc?.head) {
+        return;
+    }
+    const style = doc.createElement('style');
+    style.dataset.shaderQuaternionOverlay = 'true';
+    style.textContent = `
+        .shader-quaternion-overlay {
+            position: absolute;
+            bottom: 16px;
+            right: 16px;
+            min-width: 260px;
+            max-width: 360px;
+            padding: 12px 16px;
+            border-radius: 12px;
+            font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+            font-size: 12px;
+            line-height: 1.5;
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+            backdrop-filter: blur(14px);
+            z-index: 9999;
+        }
+        .shader-quaternion-overlay--dark {
+            background: rgba(6, 10, 26, 0.86);
+            color: #f3f5ff;
+            border: 1px solid rgba(102, 126, 255, 0.25);
+        }
+        .shader-quaternion-overlay--light {
+            background: rgba(242, 246, 255, 0.92);
+            color: #101322;
+            border: 1px solid rgba(16, 19, 34, 0.12);
+        }
+        .shader-q-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .shader-q-meta {
+            font-size: 11px;
+            opacity: 0.75;
+        }
+        .shader-q-orientation {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(0, 1fr));
+            gap: 6px 8px;
+            margin-bottom: 10px;
+        }
+        .shader-q-metric {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+        .shader-q-metric .label {
+            text-transform: uppercase;
+            font-size: 10px;
+            opacity: 0.6;
+        }
+        .shader-q-metric .value {
+            font-weight: 600;
+            font-size: 12px;
+        }
+        .shader-q-system-row {
+            display: grid;
+            grid-template-columns: 72px minmax(0, 1fr);
+            gap: 8px;
+            align-items: start;
+            padding: 6px 0;
+            border-top: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        .shader-quaternion-overlay--light .shader-q-system-row {
+            border-top-color: rgba(16, 19, 34, 0.08);
+        }
+        .shader-q-system-row:first-of-type {
+            border-top: none;
+        }
+        .shader-q-system-name {
+            text-transform: uppercase;
+            font-weight: 600;
+            font-size: 11px;
+            opacity: 0.7;
+        }
+        .shader-q-system-params {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+        .shader-q-param {
+            padding: 2px 6px;
+            border-radius: 8px;
+            background: rgba(102, 126, 255, 0.18);
+            color: inherit;
+        }
+        .shader-quaternion-overlay--light .shader-q-param {
+            background: rgba(16, 19, 34, 0.08);
+        }
+    `;
+    doc.head.appendChild(style);
+    stylesInjected = true;
+};
+
+const formatNumber = (value, { decimals = 2, clamp } = {}) => {
+    let next = Number(value);
+    if (!Number.isFinite(next)) {
+        return '0.00';
+    }
+    if (typeof clamp === 'object' && clamp) {
+        const { min = -Infinity, max = Infinity } = clamp;
+        next = Math.min(max, Math.max(min, next));
+    }
+    return next.toFixed(decimals);
+};
+
+const resolveContainer = (doc, target) => {
+    if (!target) {
+        return doc?.body || null;
+    }
+    if (typeof target === 'string') {
+        return doc?.querySelector?.(target) || null;
+    }
+    if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+        return target;
+    }
+    return null;
+};
+
+export class ShaderQuaternionDiagnosticsOverlay {
+    constructor(options = {}) {
+        const {
+            synchronizer,
+            container,
+            document: providedDocument,
+            theme = 'dark',
+            format = {}
+        } = options;
+
+        if (!synchronizer || typeof synchronizer.addObserver !== 'function') {
+            throw new Error('ShaderQuaternionDiagnosticsOverlay requires a ShaderQuaternionSynchronizer instance');
+        }
+
+        this.synchronizer = synchronizer;
+        this.document = providedDocument || (typeof document !== 'undefined' ? document : null);
+        this.container = resolveContainer(this.document, container);
+        this.theme = theme;
+        this.format = {
+            angleDecimals: typeof format.angleDecimals === 'number' ? format.angleDecimals : 1,
+            energyDecimals: typeof format.energyDecimals === 'number' ? format.energyDecimals : 2,
+            confidenceDecimals: typeof format.confidenceDecimals === 'number' ? format.confidenceDecimals : 2
+        };
+
+        this.root = null;
+        this.rows = new Map();
+        this.unsubscribe = null;
+        this.lastPayload = null;
+    }
+
+    mount() {
+        if (!this.document || !this.container) {
+            return this;
+        }
+        ensureStyles(this.document);
+        this.unmount();
+
+        const root = this.document.createElement('section');
+        root.className = `shader-quaternion-overlay shader-quaternion-overlay--${this.theme}`;
+        root.dataset.testid = 'shader-quaternion-overlay';
+        root.innerHTML = `
+            <header class="shader-q-header">
+                <span class="shader-q-title">Quaternion Spatial Diagnostics</span>
+                <span class="shader-q-meta" data-testid="shader-q-source">–</span>
+            </header>
+            <div class="shader-q-orientation">
+                <div class="shader-q-metric"><span class="label">Yaw</span><span class="value" data-testid="shader-q-yaw">0.0°</span></div>
+                <div class="shader-q-metric"><span class="label">Pitch</span><span class="value" data-testid="shader-q-pitch">0.0°</span></div>
+                <div class="shader-q-metric"><span class="label">Roll</span><span class="value" data-testid="shader-q-roll">0.0°</span></div>
+                <div class="shader-q-metric"><span class="label">Motion</span><span class="value" data-testid="shader-q-motion">0.00</span></div>
+                <div class="shader-q-metric"><span class="label">Confidence</span><span class="value" data-testid="shader-q-confidence">0.00</span></div>
+            </div>
+            <div class="shader-q-systems" data-testid="shader-q-systems"></div>
+        `;
+
+        this.container.appendChild(root);
+        this.root = root;
+
+        this.unsubscribe = this.synchronizer.addObserver(payload => {
+            this.lastPayload = payload;
+            this.render(payload);
+        });
+
+        if (this.lastPayload) {
+            this.render(this.lastPayload);
+        }
+
+        return this;
+    }
+
+    unmount() {
+        if (typeof this.unsubscribe === 'function') {
+            try {
+                this.unsubscribe();
+            } catch (error) {
+                // ignore
+            }
+        }
+        this.unsubscribe = null;
+        this.rows.clear();
+        if (this.root?.parentNode) {
+            this.root.parentNode.removeChild(this.root);
+        }
+        this.root = null;
+    }
+
+    render(payload) {
+        if (!this.root || !payload) {
+            return;
+        }
+
+        const { euler = {}, motionEnergy = 0, confidence = 0, source, systems = [] } = payload;
+
+        const yaw = this.root.querySelector('[data-testid="shader-q-yaw"]');
+        const pitch = this.root.querySelector('[data-testid="shader-q-pitch"]');
+        const roll = this.root.querySelector('[data-testid="shader-q-roll"]');
+        const motion = this.root.querySelector('[data-testid="shader-q-motion"]');
+        const confidenceNode = this.root.querySelector('[data-testid="shader-q-confidence"]');
+        const sourceNode = this.root.querySelector('[data-testid="shader-q-source"]');
+
+        if (yaw) yaw.textContent = `${formatNumber((euler.yaw || 0) * DEG_PER_RAD, { decimals: this.format.angleDecimals })}°`;
+        if (pitch) pitch.textContent = `${formatNumber((euler.pitch || 0) * DEG_PER_RAD, { decimals: this.format.angleDecimals })}°`;
+        if (roll) roll.textContent = `${formatNumber((euler.roll || 0) * DEG_PER_RAD, { decimals: this.format.angleDecimals })}°`;
+        if (motion) motion.textContent = formatNumber(motionEnergy, { decimals: this.format.energyDecimals, clamp: { min: 0, max: 1 } });
+        if (confidenceNode) confidenceNode.textContent = formatNumber(confidence, { decimals: this.format.confidenceDecimals, clamp: { min: 0, max: 1 } });
+        if (sourceNode) sourceNode.textContent = source ? String(source) : '–';
+
+        const container = this.root.querySelector('[data-testid="shader-q-systems"]');
+        if (!container) {
+            return;
+        }
+
+        for (const system of systems) {
+            const { system: name, parameters = {} } = system || {};
+            if (!name) continue;
+
+            let row = this.rows.get(name);
+            if (!row) {
+                row = this.document.createElement('div');
+                row.className = 'shader-q-system-row';
+                row.dataset.system = name;
+                row.innerHTML = `
+                    <div class="shader-q-system-name">${name}</div>
+                    <div class="shader-q-system-params" data-testid="shader-q-params-${name}"></div>
+                `;
+                container.appendChild(row);
+                this.rows.set(name, row);
+            }
+
+            const paramsContainer = row.querySelector(`[data-testid="shader-q-params-${name}"]`);
+            if (!paramsContainer) continue;
+
+            paramsContainer.innerHTML = '';
+            for (const [param, value] of Object.entries(parameters)) {
+                const pill = this.document.createElement('span');
+                pill.className = 'shader-q-param';
+                pill.textContent = `${param}: ${formatNumber(value, { decimals: this.format.energyDecimals })}`;
+                paramsContainer.appendChild(pill);
+            }
+        }
+    }
+}
+
+export default ShaderQuaternionDiagnosticsOverlay;

--- a/src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js
+++ b/src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js
@@ -1,0 +1,514 @@
+import {
+    blendAnchorCluster,
+    blendHitTestCluster
+} from './QuaternionClusterToolkit.js';
+
+/**
+ * ShaderQuaternionSynchronizer
+ * ------------------------------------------------------------
+ * Bridges normalized spatial quaternions from the SensoryInputBridge into the
+ * three primary VIB34D shader systems (faceted, quantum, holographic). The
+ * synchronizer listens to spatial anchor, hit-test, and pose channels, derives
+ * smoothed motion energy, and applies orientation-driven parameter updates so
+ * visual systems react coherently to wearable localization data.
+ */
+
+const ROTATION_LIMIT = 6.28; // ±2π rad slider range
+const DEG_PER_RAD = 180 / Math.PI;
+
+const PARAM_LIMITS = {
+    rot4dXW: { min: -ROTATION_LIMIT, max: ROTATION_LIMIT },
+    rot4dYW: { min: -ROTATION_LIMIT, max: ROTATION_LIMIT },
+    rot4dZW: { min: -ROTATION_LIMIT, max: ROTATION_LIMIT },
+    chaos: { min: 0, max: 1 },
+    intensity: { min: 0, max: 1 },
+    speed: { min: 0.1, max: 4 },
+    saturation: { min: 0, max: 1 },
+    hue: { min: 0, max: 360 }
+};
+
+const CHANNELS = ['spatial.anchors', 'spatial.hit-tests', 'spatial.pose'];
+
+const identityQuaternion = () => ({ x: 0, y: 0, z: 0, w: 1 });
+
+export class ShaderQuaternionSynchronizer {
+    constructor(options = {}) {
+        const {
+            bridge,
+            systems,
+            systemResolver,
+            rotationScale = 2,
+            minConfidence = 0.45,
+            baseAlpha = 0.25,
+            energySmoothing = 0.35,
+            velocityReference = 8,
+            logger = console,
+            anchorReducer = blendAnchorCluster,
+            hitTestReducer = blendHitTestCluster
+        } = options;
+
+        if (!bridge || typeof bridge.subscribe !== 'function') {
+            throw new Error('ShaderQuaternionSynchronizer requires a SensoryInputBridge instance');
+        }
+
+        this.bridge = bridge;
+        this.rotationScale = rotationScale;
+        this.minConfidence = minConfidence;
+        this.baseAlpha = baseAlpha;
+        this.energySmoothing = Math.max(0, Math.min(1, energySmoothing));
+        this.velocityReference = Math.max(0.001, velocityReference);
+        this.logger = logger;
+        this.anchorReducer = typeof anchorReducer === 'function' ? anchorReducer : blendAnchorCluster;
+        this.hitTestReducer = typeof hitTestReducer === 'function' ? hitTestReducer : blendHitTestCluster;
+
+        this.resolveSystem = typeof systemResolver === 'function'
+            ? systemResolver
+            : (name => (systems && systems[name]) || null);
+
+        this.enabled = true;
+        this.subscriptions = [];
+        this.baseParameters = new Map();
+        this.lastQuaternion = null;
+        this.lastTimestamp = null;
+        this.motionEnergy = 0;
+        this.observers = new Set();
+
+        if (typeof options.onUpdate === 'function') {
+            this.observers.add(options.onUpdate);
+        }
+    }
+
+    start() {
+        this.stop();
+        CHANNELS.forEach(channel => {
+            const unsubscribe = this.bridge.subscribe(channel, event => {
+                try {
+                    this.handleEvent(channel, event || {});
+                } catch (error) {
+                    this.logger?.warn?.('[ShaderQuaternionSynchronizer] channel handler failed', { channel, error });
+                }
+            });
+            this.subscriptions.push(unsubscribe);
+        });
+        return this;
+    }
+
+    stop() {
+        while (this.subscriptions.length > 0) {
+            try {
+                this.subscriptions.pop()?.();
+            } catch (error) {
+                this.logger?.warn?.('[ShaderQuaternionSynchronizer] unsubscribe failed', error);
+            }
+        }
+    }
+
+    addObserver(observer) {
+        if (typeof observer === 'function') {
+            this.observers.add(observer);
+            return () => this.removeObserver(observer);
+        }
+        return () => {};
+    }
+
+    removeObserver(observer) {
+        if (typeof observer === 'function') {
+            this.observers.delete(observer);
+        }
+    }
+
+    clearObservers() {
+        this.observers.clear();
+    }
+
+    notifyObservers(payload) {
+        if (!this.observers || this.observers.size === 0) {
+            return;
+        }
+        for (const observer of this.observers) {
+            try {
+                observer(payload);
+            } catch (error) {
+                this.logger?.warn?.('[ShaderQuaternionSynchronizer] observer failed', error);
+            }
+        }
+    }
+
+    setEnabled(enabled) {
+        this.enabled = !!enabled;
+    }
+
+    handleEvent(channel, event) {
+        if (!this.enabled) {
+            return;
+        }
+        const confidence = this.normalizeConfidence(event.confidence);
+        const timestamp = typeof event.timestamp === 'number' ? event.timestamp : performance?.now?.() || Date.now();
+
+        if (channel === 'spatial.anchors') {
+            const anchorCluster = this.extractAnchorPose(event.payload);
+            if (anchorCluster?.orientation) {
+                const effectiveConfidence = this.normalizeConfidence(anchorCluster.confidence ?? confidence);
+                this.applyOrientation(anchorCluster.orientation, {
+                    confidence: effectiveConfidence,
+                    timestamp,
+                    source: channel,
+                    metadata: { anchorCluster }
+                });
+            }
+            return;
+        }
+
+        if (channel === 'spatial.hit-tests') {
+            const hitTestCluster = this.extractHitTestPose(event.payload);
+            if (hitTestCluster?.orientation) {
+                const effectiveConfidence = this.normalizeConfidence(hitTestCluster.confidence ?? confidence);
+                this.applyOrientation(hitTestCluster.orientation, {
+                    confidence: effectiveConfidence,
+                    timestamp,
+                    source: channel,
+                    metadata: { hitTestCluster }
+                });
+            }
+            return;
+        }
+
+        if (channel === 'spatial.pose') {
+            const orientation = event.payload?.orientation;
+            if (orientation) {
+                this.applyOrientation(orientation, { confidence, timestamp, source: channel });
+            }
+        }
+    }
+
+    extractAnchorPose(payload) {
+        const anchors = payload?.anchors;
+        if (!Array.isArray(anchors) || anchors.length === 0) {
+            return null;
+        }
+
+        const cluster = this.anchorReducer ? this.anchorReducer(anchors, { space: payload?.space || payload?.referenceSpace || null }) : null;
+        if (cluster?.orientation) {
+            return cluster;
+        }
+
+        let best = anchors[0];
+        let bestConfidence = typeof best?.confidence === 'number' ? best.confidence : -1;
+        for (const anchor of anchors) {
+            const confidence = typeof anchor?.confidence === 'number' ? anchor.confidence : -1;
+            if (confidence > bestConfidence) {
+                best = anchor;
+                bestConfidence = confidence;
+            }
+        }
+        if (!best?.pose) {
+            return null;
+        }
+        return {
+            orientation: best.pose.orientation,
+            confidence: best.confidence,
+            position: best.pose.position,
+            space: payload?.space || payload?.referenceSpace || null,
+            sampleCount: 1,
+            weight: typeof best.confidence === 'number' ? best.confidence : 1
+        };
+    }
+
+    extractHitTestPose(payload) {
+        const results = payload?.results;
+        if (!Array.isArray(results) || results.length === 0) {
+            return null;
+        }
+
+        const cluster = this.hitTestReducer ? this.hitTestReducer(results, { space: payload?.space || payload?.referenceSpace || null }) : null;
+        if (cluster?.orientation) {
+            return cluster;
+        }
+
+        let best = null;
+        let bestScore = -Infinity;
+        for (const result of results) {
+            const confidence = typeof result?.confidence === 'number' ? result.confidence : 0.5;
+            const distance = typeof result?.distance === 'number' ? result.distance : 0;
+            const score = confidence - distance * 0.01; // prefer confident, close hits
+            if (score > bestScore) {
+                bestScore = score;
+                best = result;
+            }
+        }
+        if (!best?.pose) {
+            return null;
+        }
+        return {
+            orientation: best.pose.orientation,
+            confidence: best.confidence,
+            distance: best.distance,
+            position: best.pose.position,
+            sampleCount: 1,
+            weight: typeof best.confidence === 'number' ? best.confidence : 1,
+            space: payload?.space || payload?.referenceSpace || null
+        };
+    }
+
+    applyOrientation(quaternion, context = {}) {
+        const normalized = this.normalizeQuaternion(quaternion);
+        const timestamp = typeof context.timestamp === 'number' ? context.timestamp : this.lastTimestamp || 0;
+        const confidence = this.normalizeConfidence(context.confidence);
+
+        if (!normalized) {
+            return;
+        }
+
+        const euler = this.quaternionToEuler(normalized);
+        const rotationTarget = {
+            rot4dXW: this.clampNumber(euler.pitch * this.rotationScale, PARAM_LIMITS.rot4dXW),
+            rot4dYW: this.clampNumber(euler.yaw * this.rotationScale, PARAM_LIMITS.rot4dYW),
+            rot4dZW: this.clampNumber(euler.roll * this.rotationScale, PARAM_LIMITS.rot4dZW)
+        };
+
+        const motionEnergy = this.computeMotionEnergy(normalized, timestamp);
+
+        const applied = [];
+        const quantum = this.applyToSystem('quantum', rotationTarget, motionEnergy, confidence, euler);
+        if (quantum) applied.push(quantum);
+        const holographic = this.applyToSystem('holographic', rotationTarget, motionEnergy, confidence, euler);
+        if (holographic) applied.push(holographic);
+        const faceted = this.applyToSystem('faceted', rotationTarget, motionEnergy, confidence, euler);
+        if (faceted) applied.push(faceted);
+
+        this.notifyObservers({
+            quaternion: normalized,
+            euler,
+            motionEnergy,
+            confidence,
+            timestamp,
+            source: context.source || null,
+            systems: applied,
+            metadata: context.metadata || null
+        });
+    }
+
+    applyToSystem(systemName, rotationTarget, motionEnergy, confidence, euler) {
+        const system = this.resolveSystem(systemName);
+        if (!system || typeof system.updateParameter !== 'function') {
+            return null;
+        }
+
+        const results = [];
+        const record = result => {
+            if (result) {
+                results.push(result);
+            }
+        };
+
+        record(this.applyParameter(systemName, system, 'rot4dXW', rotationTarget.rot4dXW, confidence));
+        record(this.applyParameter(systemName, system, 'rot4dYW', rotationTarget.rot4dYW, confidence));
+        record(this.applyParameter(systemName, system, 'rot4dZW', rotationTarget.rot4dZW, confidence));
+
+        if (systemName === 'quantum') {
+            const baseChaos = this.getBaseParameter(systemName, system, 'chaos', 0.2);
+            const baseIntensity = this.getBaseParameter(systemName, system, 'intensity', 0.7);
+            const chaosTarget = this.clampNumber(baseChaos + motionEnergy * 0.5, PARAM_LIMITS.chaos);
+            const intensityTarget = this.clampNumber(baseIntensity + motionEnergy * 0.4, PARAM_LIMITS.intensity);
+            record(this.applyParameter(systemName, system, 'chaos', chaosTarget, confidence));
+            record(this.applyParameter(systemName, system, 'intensity', intensityTarget, confidence));
+        } else if (systemName === 'holographic') {
+            const baseHue = this.getBaseParameter(systemName, system, 'hue', 320);
+            const baseSaturation = this.getBaseParameter(systemName, system, 'saturation', 0.9);
+            const hueTarget = this.clampNumber(baseHue + euler.yaw * DEG_PER_RAD * 8, PARAM_LIMITS.hue);
+            const saturationTarget = this.clampNumber(baseSaturation + motionEnergy * 0.15, PARAM_LIMITS.saturation);
+            record(this.applyParameter(systemName, system, 'hue', hueTarget, confidence));
+            record(this.applyParameter(systemName, system, 'saturation', saturationTarget, confidence));
+        } else if (systemName === 'faceted') {
+            const baseSpeed = this.getBaseParameter(systemName, system, 'speed', 1);
+            const speedTarget = this.clampNumber(baseSpeed + motionEnergy * 0.6, PARAM_LIMITS.speed);
+            record(this.applyParameter(systemName, system, 'speed', speedTarget, confidence));
+        }
+
+        if (results.length === 0) {
+            return null;
+        }
+
+        const parameters = {};
+        for (const entry of results) {
+            parameters[entry.param] = entry.value;
+        }
+
+        return {
+            system: systemName,
+            parameters,
+            confidence,
+            motionEnergy,
+            euler
+        };
+    }
+
+    applyParameter(systemName, system, param, targetValue, confidence) {
+        const limits = PARAM_LIMITS[param];
+        const sanitizedTarget = limits ? this.clampNumber(targetValue, limits) : targetValue;
+        const current = this.getCurrentParameter(system, param);
+        const alpha = this.computeAlpha(confidence);
+        const nextValue = this.lerp(current, sanitizedTarget, alpha);
+
+        if (!Number.isFinite(nextValue)) {
+            return null;
+        }
+
+        try {
+            system.updateParameter(param, nextValue);
+        } catch (error) {
+            this.logger?.warn?.('[ShaderQuaternionSynchronizer] failed to update parameter', { systemName, param, error });
+        }
+
+        return {
+            param,
+            value: nextValue,
+            alpha,
+            target: sanitizedTarget,
+            previous: current
+        };
+    }
+
+    getCurrentParameter(system, param) {
+        if (!system) return 0;
+        if (typeof system.getParameter === 'function') {
+            const value = system.getParameter(param);
+            return Number.isFinite(value) ? value : 0;
+        }
+        if (system.parameters instanceof Map && system.parameters.has(param)) {
+            const value = Number(system.parameters.get(param));
+            return Number.isFinite(value) ? value : 0;
+        }
+        if (system.parameters && typeof system.parameters[param] !== 'undefined') {
+            const value = Number(system.parameters[param]);
+            return Number.isFinite(value) ? value : 0;
+        }
+        return 0;
+    }
+
+    getBaseParameter(systemName, system, param, fallback) {
+        if (!this.baseParameters.has(systemName)) {
+            this.baseParameters.set(systemName, new Map());
+        }
+        const map = this.baseParameters.get(systemName);
+        if (!map.has(param)) {
+            const value = this.getCurrentParameter(system, param);
+            map.set(param, Number.isFinite(value) ? value : fallback);
+        }
+        return map.get(param);
+    }
+
+    normalizeQuaternion(quaternion) {
+        if (!quaternion || typeof quaternion !== 'object') {
+            return identityQuaternion();
+        }
+        const x = Number(quaternion.x) || 0;
+        const y = Number(quaternion.y) || 0;
+        const z = Number(quaternion.z) || 0;
+        const w = Number(quaternion.w);
+        const wValue = Number.isFinite(w) ? w : Math.sqrt(Math.max(0, 1 - (x * x + y * y + z * z)));
+        const length = Math.hypot(x, y, z, wValue);
+        if (length === 0) {
+            return identityQuaternion();
+        }
+        return {
+            x: x / length,
+            y: y / length,
+            z: z / length,
+            w: wValue / length
+        };
+    }
+
+    quaternionToEuler(q) {
+        // Roll (x-axis rotation)
+        const sinr = 2 * (q.w * q.x + q.y * q.z);
+        const cosr = 1 - 2 * (q.x * q.x + q.y * q.y);
+        const roll = Math.atan2(sinr, cosr);
+
+        // Pitch (y-axis rotation)
+        const sinp = 2 * (q.w * q.y - q.z * q.x);
+        const pitch = Math.abs(sinp) >= 1 ? Math.sign(sinp) * (Math.PI / 2) : Math.asin(sinp);
+
+        // Yaw (z-axis rotation)
+        const siny = 2 * (q.w * q.z + q.x * q.y);
+        const cosy = 1 - 2 * (q.y * q.y + q.z * q.z);
+        const yaw = Math.atan2(siny, cosy);
+
+        return { roll, pitch, yaw };
+    }
+
+    normalizeConfidence(value) {
+        if (!Number.isFinite(value)) {
+            return this.baseAlpha;
+        }
+        return Math.max(0, Math.min(1, value));
+    }
+
+    computeAlpha(confidence) {
+        if (!Number.isFinite(confidence)) {
+            return this.baseAlpha;
+        }
+        if (confidence <= 0) {
+            return this.baseAlpha * 0.5;
+        }
+        if (confidence < this.minConfidence) {
+            return this.baseAlpha * (confidence / this.minConfidence);
+        }
+        return Math.max(this.baseAlpha, Math.min(1, confidence));
+    }
+
+    computeMotionEnergy(quaternion, timestamp) {
+        if (!this.lastQuaternion) {
+            this.lastQuaternion = quaternion;
+            this.lastTimestamp = timestamp;
+            this.motionEnergy = 0;
+            return 0;
+        }
+
+        const deltaQuat = this.multiply(quaternion, this.conjugate(this.lastQuaternion));
+        const angle = 2 * Math.atan2(
+            Math.hypot(deltaQuat.x, deltaQuat.y, deltaQuat.z),
+            deltaQuat.w
+        );
+
+        const lastTime = typeof this.lastTimestamp === 'number' ? this.lastTimestamp : timestamp;
+        const deltaTimeSeconds = Math.max(0.001, (timestamp - lastTime) / 1000);
+        const angularVelocity = Math.abs(angle) / deltaTimeSeconds;
+        const instantaneousEnergy = Math.min(1, angularVelocity / this.velocityReference);
+
+        this.motionEnergy = this.lerp(this.motionEnergy, instantaneousEnergy, this.energySmoothing);
+        this.lastQuaternion = quaternion;
+        this.lastTimestamp = timestamp;
+        return this.motionEnergy;
+    }
+
+    multiply(a, b) {
+        return {
+            w: a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+            x: a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+            y: a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+            z: a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w
+        };
+    }
+
+    conjugate(q) {
+        return { x: -q.x, y: -q.y, z: -q.z, w: q.w };
+    }
+
+    lerp(start, end, alpha) {
+        return start + (end - start) * alpha;
+    }
+
+    clampNumber(value, limits) {
+        if (!limits) return value;
+        const min = typeof limits.min === 'number' ? limits.min : -Infinity;
+        const max = typeof limits.max === 'number' ? limits.max : Infinity;
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return min;
+        }
+        return Math.max(min, Math.min(max, number));
+    }
+}
+
+export default ShaderQuaternionSynchronizer;

--- a/src/ui/adaptive/sensors/SensorSchemaRegistry.js
+++ b/src/ui/adaptive/sensors/SensorSchemaRegistry.js
@@ -1,4 +1,13 @@
 /**
+ * SensorSchemaRegistry
+ * ------------------------------------------------------------
+ * Normalizes heterogeneous sensor payloads before they are applied to
+ * higher-level adaptive behaviours. The registry ships with baseline schemas
+ * for the core focus/intent/biometric channels and can be extended at runtime
+ * with wearables-specific composite payloads.
+ */
+
+/**
  * @typedef {Object} SensorSchemaIssue
  * @property {string} field
  * @property {string} code
@@ -15,15 +24,196 @@
  * @typedef {{ normalize(payload: Record<string, any>, registry: SensorSchemaRegistry): SensorSchemaResult | Record<string, any>; fallback?: Record<string, any>; }} SensorSchemaDefinition
  */
 
-const clamp = (value, min, max) => {
-    if (typeof min === 'number' && value < min) {
-        return min;
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = Array.isArray(path) ? path : String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
     }
-    if (typeof max === 'number' && value > max) {
-        return max;
-    }
-    return value;
+    return current;
 };
+
+const firstPresent = values => {
+    for (const value of values) {
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const compactObject = value => {
+    if (!isPlainObject(value)) return undefined;
+    const entries = Object.entries(value)
+        .filter(([, entry]) => entry !== undefined && entry !== null);
+    if (entries.length === 0) {
+        return undefined;
+    }
+    return Object.fromEntries(entries);
+};
+
+const SPATIAL_SPACE_TYPES = [
+    'viewer',
+    'local',
+    'local-floor',
+    'bounded-floor',
+    'unbounded',
+    'stage',
+    'device',
+    'custom'
+];
+
+const PLANE_ALIGNMENTS = ['horizontal', 'vertical', 'slanted', 'unknown'];
+const PLANE_CLASSIFICATIONS = ['floor', 'ceiling', 'wall', 'table', 'seat', 'screen', 'platform', 'unknown'];
+const TRACKING_STATES = ['tracked', 'emulated', 'paused', 'unknown'];
+const HIT_TEST_ENTITY_TYPES = ['plane', 'mesh', 'point', 'feature-point', 'unknown'];
+const HIT_TEST_RESULT_TYPES = ['plane', 'mesh', 'point', 'feature-point', 'unknown'];
+const HANDEDNESS_VALUES = ['none', 'left', 'right'];
+
+const DEFAULT_MATRIX4 = [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+];
+
+const sanitizeNumberArray = (registry, source, field, options = {}) => {
+    if (!Array.isArray(source) || source.length === 0) {
+        return undefined;
+    }
+    const sanitized = source.map((entry, index) => registry.ensureNumber(entry, {
+        ...options,
+        field: `${field}.${index}`
+    }));
+    return sanitized.length ? sanitized : undefined;
+};
+
+const createWearableCompositeSchema = config => ({
+    normalize(payload = {}, registry) {
+        const issues = [];
+        const safe = isPlainObject(payload) ? payload : {};
+
+        const deviceId = registry.ensureString(
+            firstPresent([
+                safe.deviceId,
+                config.defaultDeviceId
+            ]),
+            {
+                field: 'deviceId',
+                allowEmpty: false,
+                defaultValue: config.defaultDeviceId || 'wearable-device',
+                issues
+            }
+        );
+
+        const firmwareVersion = registry.ensureOptionalString(
+            firstPresent([
+                safe.firmwareVersion,
+                getPath(safe, 'metadata.firmwareVersion')
+            ]),
+            {
+                field: 'firmwareVersion',
+                defaultValue: null,
+                issues
+            }
+        );
+
+        const channels = {};
+        for (const channelConfig of config.channels || []) {
+            const rawSource = channelConfig.fromRaw
+                ? channelConfig.fromRaw(safe)
+                : firstPresent((channelConfig.sources || []).map(source => getPath(safe, source)));
+
+            if (!rawSource) {
+                if (channelConfig.required) {
+                    issues.push({
+                        field: `channels.${channelConfig.channel}`,
+                        code: 'missing',
+                        message: `${channelConfig.channel} channel is required.`
+                    });
+                }
+                continue;
+            }
+
+            const sourcePayload = isPlainObject(rawSource.payload)
+                ? rawSource.payload
+                : (isPlainObject(rawSource) ? rawSource : {});
+
+            const { payload: channelPayload, issues: channelIssues } = registry.validate(
+                channelConfig.schema,
+                sourcePayload
+            );
+
+            if (Array.isArray(channelIssues) && channelIssues.length) {
+                for (const issue of channelIssues) {
+                    issues.push({
+                        field: issue.field && issue.field !== '*'
+                            ? `channels.${channelConfig.channel}.${issue.field}`
+                            : `channels.${channelConfig.channel}`,
+                        code: issue.code,
+                        message: issue.message
+                    });
+                }
+            }
+
+            if (typeof channelConfig.extend === 'function') {
+                channelConfig.extend(channelPayload, rawSource, { registry, issues });
+            }
+
+            const confidenceCandidates = [];
+            if (Array.isArray(channelConfig.confidencePaths)) {
+                for (const path of channelConfig.confidencePaths) {
+                    confidenceCandidates.push(getPath({ source: rawSource, root: safe }, path));
+                }
+            } else if (typeof channelConfig.confidence === 'function') {
+                confidenceCandidates.push(channelConfig.confidence(rawSource, safe));
+            } else if (channelConfig.confidence !== undefined) {
+                confidenceCandidates.push(channelConfig.confidence);
+            } else {
+                confidenceCandidates.push(rawSource.confidence);
+            }
+
+            const confidence = registry.ensureNumber(
+                firstPresent(confidenceCandidates),
+                {
+                    field: `channels.${channelConfig.channel}.confidence`,
+                    min: 0,
+                    max: 1,
+                    defaultValue: channelConfig.defaultConfidence ?? 1,
+                    issues
+                }
+            );
+
+            channels[channelConfig.channel] = {
+                payload: channelPayload,
+                confidence
+            };
+        }
+
+        let metadata;
+        if (typeof config.metadata === 'function') {
+            metadata = compactObject(config.metadata(safe, { registry, issues }, config));
+        }
+
+        const normalized = {
+            deviceId,
+            firmwareVersion,
+            channels
+        };
+
+        if (metadata && Object.keys(metadata).length) {
+            normalized.metadata = metadata;
+        }
+
+        return { payload: normalized, issues };
+    }
+});
 
 export class SensorSchemaRegistry {
     constructor(options = {}) {
@@ -56,6 +246,26 @@ export class SensorSchemaRegistry {
         this.schemas.set(type, normalizedSchema);
     }
 
+    loadCustomSchemas(schemas) {
+        if (Array.isArray(schemas)) {
+            for (const entry of schemas) {
+                if (!entry) continue;
+                if (Array.isArray(entry) && entry.length === 2) {
+                    this.register(entry[0], entry[1]);
+                } else if (typeof entry === 'object' && entry.type && entry.schema) {
+                    this.register(entry.type, entry.schema);
+                }
+            }
+            return;
+        }
+
+        if (isPlainObject(schemas)) {
+            for (const [type, schema] of Object.entries(schemas)) {
+                this.register(type, schema);
+            }
+        }
+    }
+
     /**
      * @param {string} type
      * @param {Record<string, any>} payload
@@ -70,7 +280,10 @@ export class SensorSchemaRegistry {
         try {
             const result = schema.normalize(payload ?? {}, this);
             if (!result || typeof result !== 'object') {
-                return { payload: {}, issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }] };
+                return {
+                    payload: {},
+                    issues: [{ field: '*', code: 'schema-invalid-return', message: 'Schema normalize must return an object.' }]
+                };
             }
 
             if ('payload' in result) {
@@ -84,7 +297,7 @@ export class SensorSchemaRegistry {
         } catch (error) {
             return {
                 payload: schema.fallback ?? {},
-                issues: [{ field: '*', code: 'schema-error', message: error.message }]
+                issues: [{ field: '*', code: 'schema-error', message: error?.message || 'Schema normalization failed.' }]
             };
         }
     }
@@ -93,29 +306,26 @@ export class SensorSchemaRegistry {
         this.register('eye-tracking', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    x: this.ensureNumber(payload.x, {
-                        field: 'x',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.5,
-                        issues
-                    }),
-                    y: this.ensureNumber(payload.y, {
-                        field: 'y',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.5,
-                        issues
-                    }),
-                    depth: this.ensureNumber(payload.depth, {
-                        field: 'depth',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.3,
-                        issues
-                    })
+                    x: this.ensureNumber(safe.x, { field: 'x', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    y: this.ensureNumber(safe.y, { field: 'y', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    depth: this.ensureNumber(safe.depth, { field: 'depth', min: 0, max: 1, defaultValue: 0.3, precision: 3, issues })
                 };
+
+                if (safe.vergence !== undefined) {
+                    normalized.vergence = this.ensureNumber(safe.vergence, { field: 'vergence', min: 0, max: 5, defaultValue: 0, precision: 2, issues });
+                }
+                if (safe.stability !== undefined) {
+                    normalized.stability = this.ensureNumber(safe.stability, { field: 'stability', min: 0, max: 1, defaultValue: 0.5, precision: 2, issues });
+                }
+                if (safe.blinkRate !== undefined) {
+                    normalized.blinkRate = this.ensureNumber(safe.blinkRate, { field: 'blinkRate', min: 0, max: 2.5, defaultValue: 0.2, precision: 2, issues });
+                }
+                if (safe.fixation !== undefined) {
+                    normalized.fixation = this.ensureNumber(safe.fixation, { field: 'fixation', min: 0, max: 1, defaultValue: 0, precision: 3, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { x: 0.5, y: 0.5, depth: 0.3 }
@@ -124,19 +334,22 @@ export class SensorSchemaRegistry {
         this.register('neural-intent', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    x: this.ensureNumber(payload.x, { field: 'x', min: -1, max: 1, defaultValue: 0, issues }),
-                    y: this.ensureNumber(payload.y, { field: 'y', min: -1, max: 1, defaultValue: 0, issues }),
-                    z: this.ensureNumber(payload.z, { field: 'z', min: -1, max: 1, defaultValue: 0, issues }),
-                    w: this.ensureNumber(payload.w, { field: 'w', min: -1, max: 1, defaultValue: 0, issues }),
-                    engagement: this.ensureNumber(payload.engagement, {
-                        field: 'engagement',
-                        min: 0,
-                        max: 1,
-                        defaultValue: 0.4,
-                        issues
-                    })
+                    x: this.ensureNumber(safe.x, { field: 'x', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    y: this.ensureNumber(safe.y, { field: 'y', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    z: this.ensureNumber(safe.z, { field: 'z', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    w: this.ensureNumber(safe.w, { field: 'w', min: -1, max: 1, defaultValue: 0, precision: 3, issues }),
+                    engagement: this.ensureNumber(safe.engagement, { field: 'engagement', min: 0, max: 1, defaultValue: 0.4, precision: 3, issues })
                 };
+
+                if (safe.signalToNoise !== undefined) {
+                    normalized.signalToNoise = this.ensureNumber(safe.signalToNoise, { field: 'signalToNoise', min: 0, max: 60, defaultValue: 0, precision: 2, issues });
+                }
+                if (safe.bandwidth !== undefined) {
+                    normalized.bandwidth = this.ensureNumber(safe.bandwidth, { field: 'bandwidth', min: 0, max: 200, defaultValue: 0, precision: 2, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { x: 0, y: 0, z: 0, w: 0, engagement: 0.4 }
@@ -145,24 +358,20 @@ export class SensorSchemaRegistry {
         this.register('biometric', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    stress: this.ensureNumber(payload.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, issues }),
-                    heartRate: this.ensureInteger(payload.heartRate, {
-                        field: 'heartRate',
-                        min: 30,
-                        max: 220,
-                        defaultValue: 68,
-                        issues
-                    }),
-                    temperature: this.ensureNumber(payload.temperature, {
-                        field: 'temperature',
-                        min: 32,
-                        max: 40,
-                        defaultValue: 36.4,
-                        precision: 1,
-                        issues
-                    })
+                    stress: this.ensureNumber(safe.stress, { field: 'stress', min: 0, max: 1, defaultValue: 0.2, precision: 3, issues }),
+                    heartRate: this.ensureInteger(safe.heartRate, { field: 'heartRate', min: 30, max: 220, defaultValue: 68, issues }),
+                    temperature: this.ensureNumber(safe.temperature, { field: 'temperature', min: 32, max: 40, defaultValue: 36.4, precision: 1, issues })
                 };
+
+                if (safe.oxygen !== undefined) {
+                    normalized.oxygen = this.ensureNumber(safe.oxygen, { field: 'oxygen', min: 0, max: 1, defaultValue: 0.95, precision: 3, issues });
+                }
+                if (safe.hrv !== undefined) {
+                    normalized.hrv = this.ensureInteger(safe.hrv, { field: 'hrv', min: 10, max: 200, defaultValue: 52, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { stress: 0.2, heartRate: 68, temperature: 36.4 }
@@ -171,11 +380,20 @@ export class SensorSchemaRegistry {
         this.register('ambient', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    luminance: this.ensureNumber(payload.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, issues }),
-                    noiseLevel: this.ensureNumber(payload.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, issues }),
-                    motion: this.ensureNumber(payload.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, issues })
+                    luminance: this.ensureNumber(safe.luminance, { field: 'luminance', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues }),
+                    noiseLevel: this.ensureNumber(safe.noiseLevel, { field: 'noiseLevel', min: 0, max: 1, defaultValue: 0.2, precision: 3, issues }),
+                    motion: this.ensureNumber(safe.motion, { field: 'motion', min: 0, max: 1, defaultValue: 0.1, precision: 3, issues })
                 };
+
+                if (safe.temperature !== undefined) {
+                    normalized.temperature = this.ensureNumber(safe.temperature, { field: 'temperature', min: -20, max: 60, defaultValue: 22, precision: 1, issues });
+                }
+                if (safe.humidity !== undefined) {
+                    normalized.humidity = this.ensureNumber(safe.humidity, { field: 'humidity', min: 0, max: 1, defaultValue: 0.5, precision: 3, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 }
@@ -184,100 +402,986 @@ export class SensorSchemaRegistry {
         this.register('gesture', {
             normalize: payload => {
                 const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
                 const normalized = {
-                    intent: this.ensureString(payload.intent, { field: 'intent', allowEmpty: true, issues }),
-                    vector: this.ensureVector(payload.vector, {
-                        field: 'vector',
-                        min: -1,
-                        max: 1,
-                        defaultValue: 0,
-                        issues
-                    })
+                    intent: this.ensureString(safe.intent, { field: 'intent', allowEmpty: true, defaultValue: null, issues }),
+                    vector: this.ensureVector(safe.vector, { field: 'vector', min: -1, max: 1, defaultValue: 0, issues })
                 };
+
+                if (safe.intentStrength !== undefined) {
+                    normalized.intentStrength = this.ensureNumber(safe.intentStrength, { field: 'intentStrength', min: 0, max: 1, defaultValue: 0, precision: 2, issues });
+                }
+
                 return { payload: normalized, issues };
             },
             fallback: { intent: null, vector: { x: 0, y: 0, z: 0 } }
         });
+
+        this.registerWearableSchemas();
     }
 
-    loadCustomSchemas(schemas) {
-        if (Array.isArray(schemas)) {
-            for (const entry of schemas) {
-                if (entry && typeof entry === 'object' && entry.type) {
-                    this.register(entry.type, entry.schema);
+    registerWearableSchemas() {
+        this.register('wearable.ar-visor', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.ar-visor',
+            fieldOfViewDefaults: { horizontal: 110, vertical: 90, diagonal: 120 },
+            channels: [
+                {
+                    channel: 'eye-tracking',
+                    schema: 'eye-tracking',
+                    sources: ['channels.eye-tracking', 'gaze', 'focus'],
+                    required: true,
+                    defaultConfidence: 0.82,
+                    confidencePaths: ['source.confidence', 'root.focusConfidence', 'root.quality.focus'],
+                    extend: (payload, source, { registry, issues }) => {
+                        if (source && source.vergence !== undefined) {
+                            payload.vergence = registry.ensureNumber(source.vergence, { field: 'channels.eye-tracking.vergence', min: 0, max: 5, defaultValue: 0, precision: 2, issues });
+                        }
+                        if (source && source.stability !== undefined) {
+                            payload.stability = registry.ensureNumber(source.stability, { field: 'channels.eye-tracking.stability', min: 0, max: 1, defaultValue: 0.5, precision: 2, issues });
+                        }
+                        if (source && source.blinkRate !== undefined) {
+                            payload.blinkRate = registry.ensureNumber(source.blinkRate, { field: 'channels.eye-tracking.blinkRate', min: 0, max: 2.5, defaultValue: 0.2, precision: 2, issues });
+                        }
+                    }
+                },
+                {
+                    channel: 'ambient',
+                    schema: 'ambient',
+                    sources: ['channels.ambient', 'environment'],
+                    defaultConfidence: 0.65,
+                    confidencePaths: ['source.confidence', 'root.quality.environment'],
+                    extend: (payload, source, { registry, issues }) => {
+                        if (source && source.temperature !== undefined) {
+                            payload.temperature = registry.ensureNumber(source.temperature, { field: 'channels.ambient.temperature', min: -20, max: 60, defaultValue: 22, precision: 1, issues });
+                        }
+                    }
+                },
+                {
+                    channel: 'gesture',
+                    schema: 'gesture',
+                    sources: ['channels.gesture', 'gesture'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.gesture', 'root.quality.focus']
+                },
+                {
+                    channel: 'spatial.planes',
+                    schema: 'spatial.scene-planes',
+                    sources: ['channels.spatial.planes', 'spatial.planes', 'scene.planes'],
+                    defaultConfidence: 0.78,
+                    confidencePaths: ['source.confidence', 'root.quality.scene', 'root.sceneConfidence']
+                },
+                {
+                    channel: 'spatial.depth',
+                    schema: 'spatial.depth-buffer',
+                    sources: ['channels.spatial.depth', 'spatial.depth', 'scene.depth'],
+                    defaultConfidence: 0.72,
+                    confidencePaths: ['source.confidence', 'root.quality.scene', 'root.depthConfidence']
+                },
+                {
+                    channel: 'spatial.hit-tests',
+                    schema: 'spatial.hit-test-results',
+                    sources: ['channels.spatial.hitTests', 'spatial.hitTests', 'scene.hitTests'],
+                    defaultConfidence: 0.8,
+                    confidencePaths: ['source.confidence', 'root.quality.scene', 'root.hitTestConfidence']
+                },
+                {
+                    channel: 'spatial.anchors',
+                    schema: 'spatial.anchors',
+                    sources: ['channels.spatial.anchors', 'spatial.anchors', 'scene.anchors'],
+                    defaultConfidence: 0.76,
+                    confidencePaths: ['source.confidence', 'root.quality.scene', 'root.anchorConfidence']
                 }
-            }
-            return;
-        }
+            ],
+            metadata: (root, { registry, issues }, schemaConfig) => {
+                const metadata = {};
+                const fieldOfViewSource = firstPresent([
+                    getPath(root, 'metadata.fieldOfView'),
+                    root.fieldOfView
+                ]);
+                if (isPlainObject(fieldOfViewSource) || schemaConfig.fieldOfViewDefaults) {
+                    const defaults = schemaConfig.fieldOfViewDefaults || {};
+                    const fieldOfView = {
+                        horizontal: registry.ensureNumber(fieldOfViewSource?.horizontal ?? defaults.horizontal ?? 110, { field: 'metadata.fieldOfView.horizontal', min: 40, max: 160, defaultValue: 110, issues }),
+                        vertical: registry.ensureNumber(fieldOfViewSource?.vertical ?? defaults.vertical ?? 90, { field: 'metadata.fieldOfView.vertical', min: 30, max: 140, defaultValue: 90, issues })
+                    };
+                    if (fieldOfViewSource?.diagonal !== undefined || defaults.diagonal !== undefined) {
+                        fieldOfView.diagonal = registry.ensureNumber(fieldOfViewSource?.diagonal ?? defaults.diagonal ?? 120, { field: 'metadata.fieldOfView.diagonal', min: 40, max: 180, defaultValue: 120, issues });
+                    }
+                    metadata.fieldOfView = fieldOfView;
+                }
 
-        if (typeof schemas === 'object') {
-            for (const [type, schema] of Object.entries(schemas)) {
-                this.register(type, schema);
+                const poseSource = firstPresent([
+                    getPath(root, 'metadata.pose'),
+                    root.pose
+                ]);
+                if (isPlainObject(poseSource)) {
+                    const pose = {};
+                    if (poseSource.orientation) {
+                        pose.orientation = registry.ensureQuaternion(poseSource.orientation, { field: 'metadata.pose.orientation' });
+                    }
+                    if (poseSource.position) {
+                        pose.position = registry.ensureVector(poseSource.position, { field: 'metadata.pose.position', defaultValue: 0 });
+                    }
+                    if (Object.keys(pose).length) {
+                        metadata.pose = pose;
+                    }
+                }
+
+                const batteryLevel = firstPresent([root.batteryLevel, getPath(root, 'metadata.batteryLevel')]);
+                if (batteryLevel !== undefined) {
+                    metadata.batteryLevel = registry.ensureNumber(batteryLevel, { field: 'metadata.batteryLevel', min: 0, max: 1, defaultValue: 1, issues });
+                }
+
+                const deviceTemperature = firstPresent([
+                    root.deviceTemperature,
+                    getPath(root, 'metadata.deviceTemperature'),
+                    getPath(root, 'environment.temperature')
+                ]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: -20, max: 90, defaultValue: 35, precision: 1, issues });
+                }
+
+                const uptimeSeconds = firstPresent([root.uptimeSeconds, getPath(root, 'metadata.uptimeSeconds')]);
+                if (uptimeSeconds !== undefined) {
+                    metadata.uptimeSeconds = registry.ensureNumber(uptimeSeconds, { field: 'metadata.uptimeSeconds', min: 0, max: 604800, defaultValue: 0, issues });
+                }
+
+                const optics = firstPresent([getPath(root, 'metadata.optics'), root.optics]);
+                if (isPlainObject(optics)) {
+                    metadata.optics = { ...optics };
+                }
+
+                return metadata;
             }
-        }
+        }));
+
+        this.register('wearable.neural-band', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.neural-band',
+            channels: [
+                {
+                    channel: 'neural-intent',
+                    schema: 'neural-intent',
+                    sources: ['channels.neural-intent', 'intent', 'signal'],
+                    required: true,
+                    defaultConfidence: 0.7,
+                    confidencePaths: ['source.confidence', 'root.signalQuality.overall', 'root.quality.intent']
+                },
+                {
+                    channel: 'gesture',
+                    schema: 'gesture',
+                    sources: ['channels.gesture', 'gesture'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.gesture']
+                }
+            ],
+            metadata: (root, { registry, issues }) => {
+                const metadata = {};
+
+                const signalQualitySource = firstPresent([
+                    getPath(root, 'metadata.signalQuality'),
+                    root.signalQuality
+                ]);
+                if (isPlainObject(signalQualitySource)) {
+                    const quality = {};
+                    if (signalQualitySource.overall !== undefined) {
+                        quality.overall = registry.ensureNumber(signalQualitySource.overall, { field: 'metadata.signalQuality.overall', min: 0, max: 1, defaultValue: 0.5 });
+                    }
+                    if (signalQualitySource.contacts) {
+                        quality.contacts = sanitizeNumberArray(registry, signalQualitySource.contacts, 'metadata.signalQuality.contacts', { min: 0, max: 1, defaultValue: 0.5, issues });
+                    }
+                    if (Object.keys(quality).length) {
+                        metadata.signalQuality = quality;
+                    }
+                }
+
+                const impedanceSource = firstPresent([
+                    getPath(root, 'metadata.impedance'),
+                    root.impedance
+                ]);
+                if (isPlainObject(impedanceSource)) {
+                    metadata.impedance = {
+                        average: registry.ensureNumber(impedanceSource.average, { field: 'metadata.impedance.average', min: 0, max: 500, defaultValue: 0 }),
+                        variance: registry.ensureNumber(impedanceSource.variance, { field: 'metadata.impedance.variance', min: 0, max: 500, defaultValue: 0 })
+                    };
+                }
+
+                const contactState = firstPresent([
+                    getPath(root, 'metadata.contact.state'),
+                    root.contactState
+                ]);
+                const electrodes = firstPresent([
+                    getPath(root, 'metadata.contact.electrodes'),
+                    root.electrodes
+                ]);
+                if (contactState !== undefined || electrodes !== undefined) {
+                    const contact = {};
+                    if (contactState !== undefined) {
+                        contact.state = registry.ensureString(contactState, { field: 'metadata.contact.state', allowEmpty: true, defaultValue: null, issues });
+                    }
+                    const sanitizedElectrodes = sanitizeNumberArray(registry, electrodes, 'metadata.contact.electrodes', { min: 0, max: 1, defaultValue: 0.5, issues });
+                    if (sanitizedElectrodes) {
+                        contact.electrodes = sanitizedElectrodes;
+                    }
+                    if (Object.keys(contact).length) {
+                        metadata.contact = contact;
+                    }
+                }
+
+                const bandSource = firstPresent([
+                    getPath(root, 'metadata.band'),
+                    root.band
+                ]);
+                if (isPlainObject(bandSource)) {
+                    const band = {};
+                    if (bandSource.firmware !== undefined) {
+                        band.firmware = registry.ensureOptionalString(bandSource.firmware, { field: 'metadata.band.firmware', defaultValue: null });
+                    }
+                    if (bandSource.hardwareRevision !== undefined) {
+                        band.hardwareRevision = registry.ensureOptionalString(bandSource.hardwareRevision, { field: 'metadata.band.hardwareRevision', defaultValue: null });
+                    }
+                    if (Object.keys(band).length) {
+                        metadata.band = band;
+                    }
+                }
+
+                const deviceTemperature = firstPresent([root.temperature, getPath(root, 'metadata.deviceTemperature')]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: 0, max: 60, defaultValue: 33, precision: 1 });
+                }
+
+                return metadata;
+            }
+        }));
+
+        this.register('wearable.biometric-wrist', createWearableCompositeSchema({
+            defaultDeviceId: 'wearable.biometric-wrist',
+            channels: [
+                {
+                    channel: 'biometric',
+                    schema: 'biometric',
+                    sources: ['channels.biometric', 'vitals', 'biometric'],
+                    required: true,
+                    defaultConfidence: 0.75,
+                    confidencePaths: ['source.confidence', 'root.quality.vitals', 'root.quality.overall']
+                },
+                {
+                    channel: 'ambient',
+                    schema: 'ambient',
+                    sources: ['channels.ambient', 'environment'],
+                    defaultConfidence: 0.6,
+                    confidencePaths: ['source.confidence', 'root.quality.environment', 'root.quality.motion']
+                }
+            ],
+            metadata: (root, { registry, issues }) => {
+                const metadata = {};
+
+                const batteryLevel = firstPresent([root.batteryLevel, getPath(root, 'metadata.batteryLevel')]);
+                if (batteryLevel !== undefined) {
+                    metadata.batteryLevel = registry.ensureNumber(batteryLevel, { field: 'metadata.batteryLevel', min: 0, max: 1, defaultValue: 1 });
+                }
+
+                const skinContact = firstPresent([root.skinContact, getPath(root, 'metadata.skinContact')]);
+                if (skinContact !== undefined) {
+                    metadata.skinContact = registry.ensureBoolean(skinContact, { field: 'metadata.skinContact', defaultValue: false, issues });
+                }
+
+                const lastSync = firstPresent([root.lastSync, getPath(root, 'metadata.lastSync')]);
+                if (lastSync !== undefined) {
+                    metadata.lastSync = registry.ensureOptionalString(lastSync, { field: 'metadata.lastSync', defaultValue: null });
+                }
+
+                const motionSource = firstPresent([
+                    getPath(root, 'metadata.motion'),
+                    root.motion
+                ]);
+                if (isPlainObject(motionSource)) {
+                    const motion = {};
+                    if (motionSource.acceleration) {
+                        motion.acceleration = registry.ensureVector(motionSource.acceleration, { field: 'metadata.motion.acceleration', defaultValue: 0 });
+                    }
+                    if (Object.keys(motion).length) {
+                        metadata.motion = motion;
+                    }
+                }
+
+                const deviceTemperature = firstPresent([root.deviceTemperature, getPath(root, 'metadata.deviceTemperature')]);
+                if (deviceTemperature !== undefined) {
+                    metadata.deviceTemperature = registry.ensureNumber(deviceTemperature, { field: 'metadata.deviceTemperature', min: 0, max: 60, defaultValue: 33, precision: 1 });
+                }
+
+                const alerts = firstPresent([root.alerts, getPath(root, 'metadata.alerts')]);
+                if (Array.isArray(alerts)) {
+                    const sanitizedAlerts = alerts
+                        .map((entry, index) => {
+                            if (typeof entry === 'string') {
+                                const trimmed = entry.trim();
+                                if (trimmed) return trimmed;
+                            }
+                            issues.push({ field: `metadata.alerts.${index}`, code: 'type', message: 'Alert entries must be non-empty strings.' });
+                            return null;
+                        })
+                        .filter(Boolean);
+                    if (sanitizedAlerts.length) {
+                        metadata.alerts = sanitizedAlerts;
+                    }
+                }
+
+                return metadata;
+            }
+        }));
+
+        this.registerSpatialSchemas();
     }
 
-    ensureNumber(value, { field, min, max, defaultValue = 0, precision, issues }) {
-        let numberValue = Number(value);
-        if (value === undefined || value === null || Number.isNaN(numberValue)) {
-            issues?.push({ field, code: 'type', message: 'Expected numeric value.' });
-            numberValue = defaultValue;
+    registerSpatialSchemas() {
+        this.register('spatial.pose', {
+            normalize: payload => ({
+                payload: this.ensurePose(payload, { field: 'pose' }),
+                issues: []
+            }),
+            fallback: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } }
+        });
+
+        this.register('spatial.space-reference', {
+            normalize: payload => ({
+                payload: this.ensureSpaceReference(payload, { field: 'space' }),
+                issues: []
+            }),
+            fallback: { type: 'local', id: null }
+        });
+
+        this.register('spatial.scene-plane', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const id = this.ensureString(firstPresent([safe.id, safe.planeId]), { field: 'id', allowEmpty: false, defaultValue: 'plane', issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'local', issues });
+                const pose = this.ensurePose(firstPresent([safe.pose, safe.transform, safe]), { field: 'pose', issues });
+                const alignment = this.ensureEnum(firstPresent([safe.alignment, safe.orientation, safe.alignmentHint]), { field: 'alignment', allowed: PLANE_ALIGNMENTS, defaultValue: 'unknown', issues, allowUndefined: true });
+                const extentSource = isPlainObject(safe.extent) ? safe.extent : safe.size;
+                const extent = extentSource
+                    ? {
+                        width: this.ensureNumber(firstPresent([extentSource.width, extentSource.x, extentSource[0]]), { field: 'extent.width', min: 0, max: 200, defaultValue: 0, precision: 4, issues }),
+                        height: this.ensureNumber(firstPresent([extentSource.height, extentSource.y, extentSource[1]]), { field: 'extent.height', min: 0, max: 200, defaultValue: 0, precision: 4, issues })
+                    }
+                    : { width: 0, height: 0 };
+                const polygon = this.ensureVectorArray(firstPresent([safe.polygon, safe.polygonPoints, safe.points]), { field: 'polygon', minLength: 3, issues });
+                const lastChangedTime = this.ensureNumber(firstPresent([safe.lastChangedTime, safe.timestamp, safe.time]), { field: 'lastChangedTime', min: 0, defaultValue: 0, issues });
+                const trackingState = this.ensureOptionalEnum(firstPresent([safe.trackingState, safe.state]), { field: 'trackingState', allowed: TRACKING_STATES, defaultValue: 'tracked', issues });
+                const classification = this.ensureOptionalEnum(firstPresent([safe.classification, safe.semanticLabel]), { field: 'classification', allowed: PLANE_CLASSIFICATIONS, defaultValue: 'unknown', issues });
+
+                const normalized = compactObject({
+                    id,
+                    space,
+                    pose,
+                    alignment,
+                    extent,
+                    polygon: polygon?.length ? polygon : undefined,
+                    lastChangedTime,
+                    trackingState,
+                    classification
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: {
+                id: 'plane',
+                space: { type: 'local', id: null },
+                pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+                alignment: 'unknown',
+                extent: { width: 0, height: 0 },
+                polygon: [],
+                lastChangedTime: 0
+            }
+        });
+
+        this.register('spatial.scene-planes', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const timestamp = this.ensureNumber(firstPresent([safe.timestamp, safe.time, safe.lastChangedTime]), { field: 'timestamp', min: 0, defaultValue: 0, issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'local', issues });
+                const planesSource = Array.isArray(safe.planes) ? safe.planes : (Array.isArray(safe.added) ? safe.added : []);
+                const planes = [];
+
+                planesSource.forEach((entry, index) => {
+                    const result = this.validate('spatial.scene-plane', entry);
+                    planes.push(result.payload);
+                    if (result.issues?.length) {
+                        for (const issue of result.issues) {
+                            issues.push({
+                                field: `planes.${index}${issue.field && issue.field !== '*' ? `.${issue.field}` : ''}`,
+                                code: issue.code,
+                                message: issue.message
+                            });
+                        }
+                    }
+                });
+
+                const removedIds = this.ensureStringArray(firstPresent([safe.removedIds, safe.removed, safe.deletedIds]), { field: 'removedIds', allowEmpty: true, issues });
+
+                const normalized = compactObject({
+                    timestamp,
+                    space,
+                    planes,
+                    removedIds: removedIds.length ? removedIds : undefined
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: { timestamp: 0, space: { type: 'local', id: null }, planes: [] }
+        });
+
+        this.register('spatial.depth-buffer', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const timestamp = this.ensureNumber(firstPresent([safe.timestamp, safe.time]), { field: 'timestamp', min: 0, defaultValue: 0, issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'viewer', issues });
+                const viewId = this.ensureOptionalString(firstPresent([safe.viewId, safe.view, safe.cameraId]), { field: 'viewId', issues });
+                const format = this.ensureString(firstPresent([safe.format, safe.pixelFormat]), { field: 'format', allowEmpty: false, defaultValue: 'unknown', issues });
+                const width = this.ensureInteger(safe.width, { field: 'width', min: 1, max: 8192, defaultValue: 1, issues });
+                const height = this.ensureInteger(safe.height, { field: 'height', min: 1, max: 8192, defaultValue: 1, issues });
+                const rawValueToMeters = this.ensureNumber(firstPresent([safe.rawValueToMeters, safe.metersPerUnit]), { field: 'rawValueToMeters', min: 1e-6, max: 100, defaultValue: 0.001, precision: 6, issues });
+                const near = this.ensureOptionalNumber(firstPresent([safe.near, safe.nearDepth]), { field: 'near', min: 0, max: 1000, defaultValue: null, issues });
+                const far = this.ensureOptionalNumber(firstPresent([safe.far, safe.farDepth]), { field: 'far', min: 0, max: 1000, defaultValue: null, issues });
+                const intrinsics = this.ensureCameraIntrinsics(firstPresent([safe.intrinsics, safe.cameraIntrinsics]), { field: 'intrinsics', issues });
+                const buffer = this.ensureDepthBufferDescriptor(firstPresent([safe.buffer, safe.resource, safe.data]), { field: 'buffer', issues });
+                const confidence = this.ensureOptionalNumber(safe.confidence, { field: 'confidence', min: 0, max: 1, defaultValue: null, issues });
+
+                const normalized = compactObject({
+                    timestamp,
+                    space,
+                    viewId,
+                    format,
+                    width,
+                    height,
+                    rawValueToMeters,
+                    near,
+                    far,
+                    intrinsics,
+                    buffer,
+                    confidence
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: {
+                timestamp: 0,
+                space: { type: 'viewer', id: null },
+                format: 'unknown',
+                width: 1,
+                height: 1,
+                rawValueToMeters: 0.001,
+                buffer: { type: 'cpu', handle: null }
+            }
+        });
+
+        this.register('spatial.hit-test-ray', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const id = this.ensureString(firstPresent([safe.id, safe.rayId, safe.sourceId]), { field: 'id', allowEmpty: false, defaultValue: 'hit-test-ray', issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'viewer', issues });
+                const offsetRay = this.ensureRay(firstPresent([safe.offsetRay, safe.ray, safe.spaceRay]), { field: 'offsetRay', issues });
+                const entityTypes = this.ensureEnumArray(firstPresent([safe.entityTypes, safe.entities, safe.filters]), { field: 'entityTypes', allowed: HIT_TEST_ENTITY_TYPES, defaultValue: 'plane', issues, allowEmpty: false });
+                const targetRaySpace = this.ensureOptionalString(firstPresent([safe.targetRaySpace, safe.targetSpace]), { field: 'targetRaySpace', issues });
+                const handedness = this.ensureOptionalEnum(firstPresent([safe.handedness, safe.inputHandedness]), { field: 'handedness', allowed: HANDEDNESS_VALUES, defaultValue: 'none', issues });
+                const transient = this.ensureBoolean(safe.transient ?? safe.transientInput, { field: 'transient', defaultValue: false, issues });
+                const profile = this.ensureOptionalString(firstPresent([safe.profile, safe.referenceSpaceType]), { field: 'profile', issues });
+
+                const initialResultsSource = Array.isArray(safe.initialResults) ? safe.initialResults : [];
+                const initialResults = [];
+                initialResultsSource.forEach((entry, index) => {
+                    const result = this.validate('spatial.hit-test-result', entry);
+                    initialResults.push(result.payload);
+                    if (result.issues?.length) {
+                        for (const issue of result.issues) {
+                            issues.push({
+                                field: `initialResults.${index}${issue.field && issue.field !== '*' ? `.${issue.field}` : ''}`,
+                                code: issue.code,
+                                message: issue.message
+                            });
+                        }
+                    }
+                });
+
+                const normalized = compactObject({
+                    id,
+                    space,
+                    offsetRay,
+                    entityTypes,
+                    targetRaySpace,
+                    handedness,
+                    transient,
+                    profile,
+                    initialResults: initialResults.length ? initialResults : undefined
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: {
+                id: 'hit-test-ray',
+                space: { type: 'viewer', id: null },
+                offsetRay: { origin: { x: 0, y: 0, z: 0 }, direction: { x: 0, y: 0, z: -1 } },
+                entityTypes: ['plane'],
+                transient: false
+            }
+        });
+
+        this.register('spatial.hit-test-result', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const rayId = this.ensureString(firstPresent([safe.rayId, safe.sourceId]), { field: 'rayId', allowEmpty: false, defaultValue: 'hit-test-ray', issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'local', issues });
+                const pose = this.ensurePose(firstPresent([safe.pose, safe.transform, safe]), { field: 'pose', issues });
+                const transformMatrix = this.ensureOptionalMatrix4(firstPresent([safe.transformMatrix, safe.matrix]), { field: 'transformMatrix', issues });
+                const distance = this.ensureNumber(firstPresent([safe.distance, safe.hitDistance]), { field: 'distance', min: 0, max: 1000, defaultValue: 0, precision: 5, issues });
+                const timestamp = this.ensureNumber(firstPresent([safe.timestamp, safe.time]), { field: 'timestamp', min: 0, defaultValue: 0, issues });
+                const type = this.ensureOptionalEnum(firstPresent([safe.type, safe.entityType]), { field: 'type', allowed: HIT_TEST_RESULT_TYPES, defaultValue: 'unknown', issues });
+                const normal = safe.normal ? this.ensureVector(safe.normal, { field: 'normal', min: -1, max: 1, defaultValue: 0, issues }) : undefined;
+                const anchors = this.ensureStringArray(firstPresent([safe.anchors, safe.anchorIds]), { field: 'anchors', allowEmpty: true, issues });
+                const confidence = this.ensureOptionalNumber(safe.confidence, { field: 'confidence', min: 0, max: 1, defaultValue: null, issues });
+                const inputSource = isPlainObject(safe.inputSource)
+                    ? compactObject({
+                        handedness: this.ensureOptionalEnum(firstPresent([safe.inputSource.handedness, safe.handedness]), { field: 'inputSource.handedness', allowed: HANDEDNESS_VALUES, defaultValue: 'none', issues }),
+                        targetRaySpace: this.ensureOptionalString(safe.inputSource.targetRaySpace, { field: 'inputSource.targetRaySpace', issues }),
+                        profiles: this.ensureStringArray(safe.inputSource.profiles, { field: 'inputSource.profiles', allowEmpty: true, issues })
+                    })
+                    : undefined;
+
+                const normalized = compactObject({
+                    rayId,
+                    space,
+                    pose,
+                    transformMatrix,
+                    distance,
+                    timestamp,
+                    type,
+                    normal,
+                    anchors: anchors.length ? anchors : undefined,
+                    inputSource,
+                    confidence
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: {
+                rayId: 'hit-test-ray',
+                space: { type: 'local', id: null },
+                pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+                distance: 0,
+                timestamp: 0,
+                type: 'unknown'
+            }
+        });
+
+        this.register('spatial.hit-test-results', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const timestamp = this.ensureNumber(firstPresent([safe.timestamp, safe.time]), { field: 'timestamp', min: 0, defaultValue: 0, issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'viewer', issues });
+                const resultsSource = Array.isArray(safe.results) ? safe.results : [];
+                const results = [];
+
+                resultsSource.forEach((entry, index) => {
+                    const result = this.validate('spatial.hit-test-result', entry);
+                    results.push(result.payload);
+                    if (result.issues?.length) {
+                        for (const issue of result.issues) {
+                            issues.push({
+                                field: `results.${index}${issue.field && issue.field !== '*' ? `.${issue.field}` : ''}`,
+                                code: issue.code,
+                                message: issue.message
+                            });
+                        }
+                    }
+                });
+
+                const normalized = compactObject({
+                    timestamp,
+                    space,
+                    results
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: { timestamp: 0, space: { type: 'viewer', id: null }, results: [] }
+        });
+
+        this.register('spatial.anchor', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const id = this.ensureString(firstPresent([safe.id, safe.anchorId]), { field: 'id', allowEmpty: false, defaultValue: 'anchor', issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'local', issues });
+                const pose = this.ensurePose(firstPresent([safe.pose, safe.transform, safe]), { field: 'pose', issues });
+                const lastChangedTime = this.ensureNumber(firstPresent([safe.lastChangedTime, safe.timestamp, safe.time]), { field: 'lastChangedTime', min: 0, defaultValue: 0, issues });
+                const trackingState = this.ensureOptionalEnum(firstPresent([safe.trackingState, safe.state]), { field: 'trackingState', allowed: TRACKING_STATES, defaultValue: 'tracked', issues });
+                const accuracy = this.ensureOptionalNumber(firstPresent([safe.accuracy, safe.error, safe.positionAccuracy]), { field: 'accuracy', min: 0, max: 5, defaultValue: null, precision: 4, issues });
+                const associatedRayId = this.ensureOptionalString(firstPresent([safe.associatedRayId, safe.rayId]), { field: 'associatedRayId', issues });
+                const classification = this.ensureOptionalEnum(firstPresent([safe.classification, safe.semanticLabel]), { field: 'classification', allowed: PLANE_CLASSIFICATIONS, defaultValue: 'unknown', issues });
+                const confidence = this.ensureOptionalNumber(safe.confidence, { field: 'confidence', min: 0, max: 1, defaultValue: null, issues });
+
+                const normalized = compactObject({
+                    id,
+                    space,
+                    pose,
+                    lastChangedTime,
+                    trackingState,
+                    accuracy,
+                    associatedRayId,
+                    classification,
+                    confidence
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: {
+                id: 'anchor',
+                space: { type: 'local', id: null },
+                pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+                lastChangedTime: 0,
+                trackingState: 'tracked'
+            }
+        });
+
+        this.register('spatial.anchors', {
+            normalize: payload => {
+                const issues = [];
+                const safe = isPlainObject(payload) ? payload : {};
+                const timestamp = this.ensureNumber(firstPresent([safe.timestamp, safe.time]), { field: 'timestamp', min: 0, defaultValue: 0, issues });
+                const space = this.ensureSpaceReference(firstPresent([safe.space, safe.referenceSpace]), { field: 'space', defaultType: 'local', issues });
+                const anchorsSource = Array.isArray(safe.anchors) ? safe.anchors : [];
+                const anchors = [];
+
+                anchorsSource.forEach((entry, index) => {
+                    const result = this.validate('spatial.anchor', entry);
+                    anchors.push(result.payload);
+                    if (result.issues?.length) {
+                        for (const issue of result.issues) {
+                            issues.push({
+                                field: `anchors.${index}${issue.field && issue.field !== '*' ? `.${issue.field}` : ''}`,
+                                code: issue.code,
+                                message: issue.message
+                            });
+                        }
+                    }
+                });
+
+                const removedIds = this.ensureStringArray(firstPresent([safe.removedIds, safe.removed, safe.deletedIds]), { field: 'removedIds', allowEmpty: true, issues });
+
+                const normalized = compactObject({
+                    timestamp,
+                    space,
+                    anchors,
+                    removedIds: removedIds.length ? removedIds : undefined
+                });
+
+                return { payload: normalized, issues };
+            },
+            fallback: { timestamp: 0, space: { type: 'local', id: null }, anchors: [] }
+        });
+    }
+
+    ensureNumber(value, { field, min = -Infinity, max = Infinity, defaultValue = 0, precision, issues } = {}) {
+        let numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            numeric = defaultValue;
+            issues?.push({ field, code: 'type', message: `${field} must be a finite number.` });
         }
 
-        const clamped = clamp(numberValue, min, max);
-        if (typeof min === 'number' && clamped === min && numberValue < min) {
-            issues?.push({ field, code: 'min', message: `Value below minimum; clamped to ${min}.` });
+        if (typeof min === 'number' && numeric < min) {
+            issues?.push({ field, code: 'min', message: `${field} must be ≥ ${min}.` });
+            numeric = min;
         }
-        if (typeof max === 'number' && clamped === max && numberValue > max) {
-            issues?.push({ field, code: 'max', message: `Value above maximum; clamped to ${max}.` });
+        if (typeof max === 'number' && numeric > max) {
+            issues?.push({ field, code: 'max', message: `${field} must be ≤ ${max}.` });
+            numeric = max;
         }
 
-        let finalValue = clamped;
-        if (typeof precision === 'number') {
+        if (typeof precision === 'number' && Number.isFinite(precision) && precision >= 0) {
             const factor = 10 ** precision;
-            finalValue = Math.round(finalValue * factor) / factor;
+            numeric = Math.round(numeric * factor) / factor;
         }
 
-        return finalValue;
+        return numeric;
     }
 
-    ensureInteger(value, { field, min, max, defaultValue = 0, issues }) {
-        const numberValue = this.ensureNumber(value, { field, min, max, defaultValue, issues });
-        return Math.round(numberValue);
+    ensureOptionalNumber(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue;
+        }
+        return this.ensureNumber(value, options);
     }
 
-    ensureString(value, { field, allowEmpty = false, fallback = null, issues }) {
-        if (typeof value !== 'string') {
-            if (value == null) {
-                if (!allowEmpty) {
-                    issues?.push({ field, code: 'type', message: 'Expected string value.' });
-                }
-                return fallback;
+    ensureInteger(value, options = {}) {
+        const numeric = this.ensureNumber(value, options);
+        return Math.round(numeric);
+    }
+
+    ensureOptionalInteger(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue;
+        }
+        return this.ensureInteger(value, options);
+    }
+
+    ensureBoolean(value, { field, defaultValue = false, issues } = {}) {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+        if (value === 'true' || value === 'false') {
+            return value === 'true';
+        }
+        if (Number.isFinite(Number(value))) {
+            return Boolean(Number(value));
+        }
+        issues?.push({ field, code: 'type', message: `${field} must be a boolean.` });
+        return defaultValue;
+    }
+
+    ensureString(value, { field, allowEmpty = false, defaultValue = '', issues } = {}) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!allowEmpty && trimmed === '') {
+                issues?.push({ field, code: 'empty', message: `${field} must not be empty.` });
+                return defaultValue;
             }
+            return trimmed;
+        }
 
-            try {
-                value = String(value);
-            } catch (error) {
-                issues?.push({ field, code: 'type', message: 'Value is not coercible to string.' });
-                return fallback;
+        if (value === undefined || value === null) {
+            if (defaultValue !== undefined) {
+                return defaultValue;
             }
+            issues?.push({ field, code: 'missing', message: `${field} is required.` });
+            return '';
         }
 
-        const normalized = value.trim();
-        if (!allowEmpty && normalized.length === 0) {
-            issues?.push({ field, code: 'empty', message: 'String value cannot be empty.' });
-            return fallback;
+        if (typeof value.toString === 'function') {
+            return this.ensureString(value.toString(), { field, allowEmpty, defaultValue, issues });
         }
 
-        return normalized.length === 0 ? fallback : normalized;
+        issues?.push({ field, code: 'type', message: `${field} must be a string.` });
+        return defaultValue;
     }
 
-    ensureVector(value, { field, min, max, defaultValue = 0, issues }) {
-        const base = value && typeof value === 'object' ? value : {};
+    ensureOptionalString(value, options = {}) {
+        if (value === undefined || value === null || value === '') {
+            return options.defaultValue ?? null;
+        }
+        return this.ensureString(value, { ...options, allowEmpty: true });
+    }
+
+    ensureEnum(value, { field, allowed = [], defaultValue, issues, allowUndefined = false } = {}) {
+        if ((value === undefined || value === null || value === '') && allowUndefined) {
+            return defaultValue ?? allowed[0];
+        }
+        const normalized = this.ensureString(value, { field, allowEmpty: false, defaultValue: defaultValue ?? allowed[0], issues });
+        if (allowed.length && !allowed.includes(normalized)) {
+            issues?.push({ field, code: 'enum', message: `${field} must be one of: ${allowed.join(', ')}.` });
+            return defaultValue ?? allowed[0];
+        }
+        return normalized;
+    }
+
+    ensureOptionalEnum(value, options = {}) {
+        return this.ensureEnum(value, { ...options, allowUndefined: true });
+    }
+
+    ensureStringArray(value, { field, allowEmpty = true, issues } = {}) {
+        if (value === undefined || value === null) {
+            return [];
+        }
+        if (!Array.isArray(value)) {
+            issues?.push({ field, code: 'type', message: `${field} must be an array.` });
+            return [];
+        }
+        const normalized = value.map((entry, index) => this.ensureString(entry, { field: `${field}.${index}`, allowEmpty, defaultValue: '', issues }))
+            .filter(entry => allowEmpty || entry !== '');
+        return Array.from(new Set(normalized));
+    }
+
+    ensureEnumArray(value, { field, allowed = [], defaultValue, allowEmpty = true, issues } = {}) {
+        if (!Array.isArray(value)) {
+            if (value === undefined || value === null) {
+                return allowEmpty ? [] : [defaultValue ?? allowed[0]];
+            }
+            issues?.push({ field, code: 'type', message: `${field} must be an array.` });
+            return allowEmpty ? [] : [defaultValue ?? allowed[0]];
+        }
+
+        const normalized = [];
+        value.forEach((entry, index) => {
+            const result = this.ensureEnum(entry, { field: `${field}.${index}`, allowed, defaultValue: defaultValue ?? allowed[0], issues });
+            if (!normalized.includes(result)) {
+                normalized.push(result);
+            }
+        });
+
+        if (!normalized.length && !allowEmpty) {
+            normalized.push(defaultValue ?? allowed[0]);
+        }
+
+        return normalized;
+    }
+
+    ensurePose(value, { field = 'pose', issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
+        const positionSource = firstPresent([safe.position, safe.translation, safe.origin]);
+        const orientationSource = firstPresent([safe.orientation, safe.rotation, safe.quaternion]);
         return {
-            x: this.ensureNumber(base.x, { field: `${field}.x`, min, max, defaultValue, issues }),
-            y: this.ensureNumber(base.y, { field: `${field}.y`, min, max, defaultValue, issues }),
-            z: this.ensureNumber(base.z, { field: `${field}.z`, min, max, defaultValue, issues })
+            position: this.ensureVector(positionSource ?? {}, { field: `${field}.position`, defaultValue: 0, issues }),
+            orientation: this.ensureQuaternion(orientationSource ?? {}, { field: `${field}.orientation`, issues })
+        };
+    }
+
+    ensureSpaceReference(value, { field = 'space', defaultType = 'local', issues } = {}) {
+        if (typeof value === 'string') {
+            const type = this.ensureEnum(value, { field, allowed: SPATIAL_SPACE_TYPES, defaultValue: defaultType, issues });
+            return { type, id: null };
+        }
+
+        if (!isPlainObject(value)) {
+            issues?.push({ field, code: 'type', message: `${field} must be a space reference.` });
+            return { type: defaultType, id: null };
+        }
+
+        const type = this.ensureEnum(firstPresent([value.type, value.referenceSpaceType, value.spaceType]), { field: `${field}.type`, allowed: SPATIAL_SPACE_TYPES, defaultValue: defaultType, issues });
+        const idSource = firstPresent([value.id, value.spaceId]);
+        const space = { type };
+        if (idSource !== undefined && idSource !== null && idSource !== '') {
+            space.id = this.ensureString(idSource, { field: `${field}.id`, allowEmpty: false, defaultValue: null, issues });
+        } else {
+            space.id = null;
+        }
+
+        if (value.pose) {
+            space.pose = this.ensurePose(value.pose, { field: `${field}.pose`, issues });
+        }
+
+        return space;
+    }
+
+    ensureMatrix4(value, { field, issues } = {}) {
+        if (!Array.isArray(value)) {
+            issues?.push({ field, code: 'type', message: `${field} must be a 4x4 matrix array.` });
+            return [...DEFAULT_MATRIX4];
+        }
+
+        const normalized = value.slice(0, 16).map((entry, index) => this.ensureNumber(entry, { field: `${field}.${index}`, defaultValue: DEFAULT_MATRIX4[index] ?? 0, issues }));
+        if (normalized.length < 16) {
+            for (let index = normalized.length; index < 16; index++) {
+                normalized.push(DEFAULT_MATRIX4[index] ?? 0);
+            }
+            issues?.push({ field, code: 'length', message: `${field} must contain 16 entries.` });
+        }
+        return normalized;
+    }
+
+    ensureOptionalMatrix4(value, options = {}) {
+        if (!value && value !== 0) {
+            return null;
+        }
+        return this.ensureMatrix4(value, options);
+    }
+
+    ensureVectorArray(value, { field, minLength = 0, issues } = {}) {
+        if (!Array.isArray(value)) {
+            if (minLength > 0) {
+                issues?.push({ field, code: 'type', message: `${field} must be an array of vectors.` });
+            }
+            return [];
+        }
+
+        const vectors = value.map((entry, index) => this.ensureVector(entry, { field: `${field}.${index}`, defaultValue: 0, issues }));
+        if (minLength > 0 && vectors.length < minLength) {
+            issues?.push({ field, code: 'length', message: `${field} must contain at least ${minLength} entries.` });
+        }
+        return vectors;
+    }
+
+    ensureRay(value, { field = 'offsetRay', issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
+        const origin = this.ensureVector(firstPresent([safe.origin, safe.position]) ?? {}, { field: `${field}.origin`, defaultValue: 0, issues });
+        const direction = this.ensureVector(firstPresent([safe.direction, safe.vector]) ?? { z: -1 }, { field: `${field}.direction`, defaultValue: 0, issues });
+        return { origin, direction };
+    }
+
+    ensureDepthBufferDescriptor(value, { field, issues } = {}) {
+        if (value === undefined || value === null) {
+            return { type: 'cpu', handle: null };
+        }
+
+        if (typeof value === 'string') {
+            return { type: 'cpu', handle: value };
+        }
+
+        if (ArrayBuffer.isView(value)) {
+            return { type: 'cpu', handle: '[inline]' };
+        }
+
+        if (!isPlainObject(value)) {
+            issues?.push({ field, code: 'type', message: `${field} must be a buffer descriptor.` });
+            return { type: 'cpu', handle: null };
+        }
+
+        const type = this.ensureEnum(firstPresent([value.type, value.kind]), { field: `${field}.type`, allowed: ['cpu', 'gpu'], defaultValue: 'cpu', issues });
+        const handleSource = firstPresent([value.handle, value.id, value.reference]);
+        const handle = handleSource !== undefined ? this.ensureString(handleSource, { field: `${field}.handle`, allowEmpty: true, defaultValue: null, issues }) : null;
+        const format = value.format !== undefined ? this.ensureOptionalString(value.format, { field: `${field}.format`, issues }) : undefined;
+        const usage = value.usage !== undefined ? this.ensureOptionalString(value.usage, { field: `${field}.usage`, issues }) : undefined;
+
+        return compactObject({ type, handle, format, usage });
+    }
+
+    ensureCameraIntrinsics(value, { field, issues } = {}) {
+        if (value === undefined || value === null) {
+            return undefined;
+        }
+
+        if (!isPlainObject(value)) {
+            issues?.push({ field, code: 'type', message: `${field} must be an object.` });
+            return undefined;
+        }
+
+        const normalized = {};
+        if (value.fx !== undefined) {
+            normalized.fx = this.ensureNumber(value.fx, { field: `${field}.fx`, min: 0, max: 10000, defaultValue: 0, precision: 4, issues });
+        }
+        if (value.fy !== undefined) {
+            normalized.fy = this.ensureNumber(value.fy, { field: `${field}.fy`, min: 0, max: 10000, defaultValue: 0, precision: 4, issues });
+        }
+        if (value.cx !== undefined) {
+            normalized.cx = this.ensureNumber(value.cx, { field: `${field}.cx`, min: -10000, max: 10000, defaultValue: 0, precision: 4, issues });
+        }
+        if (value.cy !== undefined) {
+            normalized.cy = this.ensureNumber(value.cy, { field: `${field}.cy`, min: -10000, max: 10000, defaultValue: 0, precision: 4, issues });
+        }
+
+        return Object.keys(normalized).length ? normalized : undefined;
+    }
+
+    ensureVector(value, { field, min = -Infinity, max = Infinity, defaultValue = 0, issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
+        return {
+            x: this.ensureNumber(safe.x, { field: `${field}.x`, min, max, defaultValue, issues }),
+            y: this.ensureNumber(safe.y, { field: `${field}.y`, min, max, defaultValue, issues }),
+            z: this.ensureNumber(safe.z, { field: `${field}.z`, min, max, defaultValue, issues })
+        };
+    }
+
+    ensureQuaternion(value, { field, issues } = {}) {
+        const safe = isPlainObject(value) ? value : {};
+        return {
+            x: this.ensureNumber(safe.x, { field: `${field}.x`, min: -1, max: 1, defaultValue: 0, issues }),
+            y: this.ensureNumber(safe.y, { field: `${field}.y`, min: -1, max: 1, defaultValue: 0, issues }),
+            z: this.ensureNumber(safe.z, { field: `${field}.z`, min: -1, max: 1, defaultValue: 0, issues }),
+            w: this.ensureNumber(safe.w, { field: `${field}.w`, min: -1, max: 1, defaultValue: 1, issues })
         };
     }
 }
+

--- a/src/ui/adaptive/sensors/WearableDeviceManager.js
+++ b/src/ui/adaptive/sensors/WearableDeviceManager.js
@@ -1,0 +1,159 @@
+import { SensoryInputBridge } from '../SensoryInputBridge.js';
+
+const deviceKey = (type, deviceId) => `${type}:${deviceId ?? 'wearable-device'}`;
+
+export class WearableDeviceManager {
+    constructor(options = {}) {
+        const {
+            bridge,
+            autoStart = false,
+            historyLimit,
+            wearableHistoryLimit,
+            bridgeOptions = {}
+        } = options;
+
+        if (bridge instanceof SensoryInputBridge) {
+            this.bridge = bridge;
+        } else {
+            this.bridge = new SensoryInputBridge({
+                ...bridgeOptions,
+                channelHistoryLimit: historyLimit ?? bridgeOptions.channelHistoryLimit,
+                wearableHistoryLimit: wearableHistoryLimit ?? bridgeOptions.wearableHistoryLimit
+            });
+        }
+
+        this.autoStart = autoStart;
+        this.deviceSubscriptions = new Map();
+        this.typeSubscriptions = new Map();
+
+        if (this.autoStart) {
+            this.start();
+        }
+    }
+
+    getBridge() {
+        return this.bridge;
+    }
+
+    registerAdapter(type, adapter) {
+        this.bridge.registerAdapter(type, adapter);
+        this.ensureTypeSubscription(type);
+        if (this.autoStart && !this.bridge.loopHandle) {
+            this.start();
+        }
+        return adapter;
+    }
+
+    unregisterAdapter(type) {
+        if (this.typeSubscriptions.has(type)) {
+            const unsubscribe = this.typeSubscriptions.get(type);
+            if (typeof unsubscribe === 'function') {
+                unsubscribe();
+            }
+            this.typeSubscriptions.delete(type);
+        }
+        for (const key of Array.from(this.deviceSubscriptions.keys())) {
+            if (key.startsWith(`${type}:`)) {
+                this.deviceSubscriptions.delete(key);
+            }
+        }
+        this.bridge.adapters.delete(type);
+        this.bridge.channels.delete(type);
+        this.bridge.adapterStates.delete(type);
+    }
+
+    start() {
+        this.bridge.start();
+    }
+
+    stop() {
+        this.bridge.stop();
+    }
+
+    ensureTypeSubscription(type) {
+        if (this.typeSubscriptions.has(type)) {
+            return;
+        }
+        const unsubscribe = this.bridge.subscribe(`${type}:update`, snapshot => {
+            if (!snapshot) return;
+            const key = deviceKey(type, snapshot.deviceId);
+            const listeners = this.deviceSubscriptions.get(key);
+            if (!listeners || listeners.size === 0) {
+                return;
+            }
+            for (const listener of listeners) {
+                try {
+                    listener({ ...snapshot, type });
+                } catch (error) {
+                    console.error('[WearableDeviceManager] device listener failed', error);
+                }
+            }
+        });
+        this.typeSubscriptions.set(type, unsubscribe);
+    }
+
+    subscribeToDevice(type, deviceId, callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('WearableDeviceManager.subscribeToDevice requires a callback function');
+        }
+        const key = deviceKey(type, deviceId);
+        if (!this.deviceSubscriptions.has(key)) {
+            this.deviceSubscriptions.set(key, new Set());
+        }
+        const listeners = this.deviceSubscriptions.get(key);
+        listeners.add(callback);
+        this.ensureTypeSubscription(type);
+
+        const snapshot = this.bridge.getWearableSnapshot(type, deviceId);
+        if (snapshot) {
+            try {
+                callback({ ...snapshot, type });
+            } catch (error) {
+                console.error('[WearableDeviceManager] initial snapshot callback failed', error);
+            }
+        }
+
+        return () => this.unsubscribeFromDevice(type, deviceId, callback);
+    }
+
+    unsubscribeFromDevice(type, deviceId, callback) {
+        const key = deviceKey(type, deviceId);
+        const listeners = this.deviceSubscriptions.get(key);
+        if (!listeners) return;
+        listeners.delete(callback);
+        if (listeners.size === 0) {
+            this.deviceSubscriptions.delete(key);
+        }
+        this.cleanupTypeSubscription(type);
+    }
+
+    cleanupTypeSubscription(type) {
+        const hasListeners = Array.from(this.deviceSubscriptions.keys()).some(key => key.startsWith(`${type}:`));
+        if (!hasListeners) {
+            const unsubscribe = this.typeSubscriptions.get(type);
+            if (typeof unsubscribe === 'function') {
+                unsubscribe();
+            }
+            this.typeSubscriptions.delete(type);
+        }
+    }
+
+    getDeviceSnapshot(type, deviceId) {
+        const snapshot = this.bridge.getWearableSnapshot(type, deviceId);
+        return snapshot ? { ...snapshot, type } : null;
+    }
+
+    listDevices(type) {
+        return this.bridge.listWearableDevices(type);
+    }
+
+    getDeviceHistory(type) {
+        return this.bridge.getWearableHistory(type);
+    }
+
+    ingest(type, payload, confidence) {
+        this.bridge.ingest(type, payload, confidence);
+    }
+}
+
+export default WearableDeviceManager;

--- a/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js
@@ -1,0 +1,391 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const assignIfDefined = (target, key, value, clone = false) => {
+    if (value === undefined || value === null) {
+        return;
+    }
+    if (clone && isPlainObject(value)) {
+        target[key] = { ...value };
+        return;
+    }
+    target[key] = value;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        if (numeric < 0) return 0;
+        if (numeric > 1) return 1;
+        return numeric;
+    }
+    const fallbackNumeric = Number(fallback);
+    if (!Number.isFinite(fallbackNumeric)) {
+        return 0;
+    }
+    if (fallbackNumeric < 0) return 0;
+    if (fallbackNumeric > 1) return 1;
+    return fallbackNumeric;
+};
+
+const deepCloneValue = value => {
+    if (Array.isArray(value)) {
+        return value.map(entry => deepCloneValue(entry));
+    }
+    if (isPlainObject(value)) {
+        const clone = {};
+        for (const [key, entry] of Object.entries(value)) {
+            clone[key] = deepCloneValue(entry);
+        }
+        return clone;
+    }
+    return value;
+};
+
+const unwrapSpatialSource = (source, arrayKey) => {
+    if (!source) {
+        return null;
+    }
+
+    if (Array.isArray(source)) {
+        if (!arrayKey) {
+            return null;
+        }
+        return {
+            payload: {
+                [arrayKey]: source.map(entry => deepCloneValue(entry))
+            }
+        };
+    }
+
+    if (!isPlainObject(source)) {
+        return null;
+    }
+
+    if (isPlainObject(source.payload)) {
+        return {
+            payload: deepCloneValue(source.payload),
+            confidence: source.confidence
+        };
+    }
+
+    const { confidence, ...rest } = source;
+    if (arrayKey && Array.isArray(rest)) {
+        return {
+            payload: {
+                [arrayKey]: rest.map(entry => deepCloneValue(entry))
+            },
+            confidence
+        };
+    }
+
+    return {
+        payload: deepCloneValue(rest),
+        confidence
+    };
+};
+
+const hasSpatialPayload = payload => {
+    if (!payload) {
+        return false;
+    }
+    if (Array.isArray(payload)) {
+        return payload.length > 0;
+    }
+    if (isPlainObject(payload)) {
+        return Object.keys(payload).length > 0;
+    }
+    return true;
+};
+
+export class ARVisorWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.ar-visor',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-ar-visor',
+            defaultConfidence: options.defaultConfidence ?? 0.82,
+            ...options
+        });
+
+        this.defaultFieldOfView = {
+            horizontal: 96,
+            vertical: 89,
+            diagonal: 110,
+            ...(options.defaultFieldOfView || {})
+        };
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const gazeSource = pickFirst(safe, ['channels.eye-tracking', 'gaze', 'focus']);
+        if (gazeSource) {
+            const payload = cloneChannelPayload(gazeSource);
+            const confidence = firstNumber(
+                gazeSource.confidence,
+                safe.focusConfidence,
+                getPath(safe, 'quality.focus')
+            );
+            composite.channels['eye-tracking'] = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const ambientSource = pickFirst(safe, ['channels.ambient', 'environment']);
+        if (ambientSource) {
+            const payload = cloneChannelPayload(ambientSource);
+            const confidence = firstNumber(
+                ambientSource.confidence,
+                getPath(safe, 'quality.environment')
+            );
+            composite.channels.ambient = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.8)
+            };
+        }
+
+        const gestureSource = pickFirst(safe, ['channels.gesture', 'gesture']);
+        if (gestureSource) {
+            const payload = cloneChannelPayload(gestureSource);
+            const confidence = firstNumber(
+                gestureSource.confidence,
+                getPath(safe, 'quality.gesture'),
+                getPath(safe, 'quality.focus')
+            );
+            composite.channels.gesture = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        const spatialChannels = {};
+        const spatialConfidences = [];
+        const addSpatialChannel = (key, paths, fallbackConfidence, confidencePaths = [], arrayKey) => {
+            const rawSource = pickFirst(safe, paths);
+            if (!rawSource) {
+                return;
+            }
+
+            const entry = unwrapSpatialSource(rawSource, arrayKey);
+            if (!entry || !hasSpatialPayload(entry.payload)) {
+                return;
+            }
+
+            const confidence = ensureConfidence(
+                firstNumber(
+                    entry.confidence,
+                    ...confidencePaths.map(path => getPath(safe, path)),
+                    getPath(safe, 'spatial.confidence'),
+                    getPath(safe, 'scene.confidence'),
+                    getPath(safe, 'quality.scene.overall'),
+                    getPath(safe, 'quality.scene'),
+                    getPath(safe, 'quality.sceneConfidence'),
+                    getPath(safe, 'sceneConfidence'),
+                    getPath(safe, 'quality.overall')
+                ),
+                fallbackConfidence
+            );
+
+            spatialChannels[key] = {
+                payload: entry.payload,
+                confidence
+            };
+            spatialConfidences.push(confidence);
+        };
+
+        addSpatialChannel(
+            'planes',
+            ['channels.spatial.planes', 'spatial.planes', 'scene.planes'],
+            0.78,
+            [
+                'spatial.planes.confidence',
+                'scene.planes.confidence',
+                'scene.planesConfidence',
+                'quality.scene.planes',
+                'quality.scene.planes.confidence',
+                'quality.scenePlanes',
+                'planesConfidence'
+            ],
+            'planes'
+        );
+
+        addSpatialChannel(
+            'depth',
+            ['channels.spatial.depth', 'spatial.depth', 'scene.depth'],
+            0.72,
+            [
+                'spatial.depth.confidence',
+                'scene.depth.confidence',
+                'scene.depthConfidence',
+                'quality.scene.depth',
+                'quality.scene.depth.confidence',
+                'quality.sceneDepth',
+                'depthConfidence'
+            ]
+        );
+
+        addSpatialChannel(
+            'hitTests',
+            ['channels.spatial.hitTests', 'spatial.hitTests', 'scene.hitTests'],
+            0.8,
+            [
+                'spatial.hitTests.confidence',
+                'scene.hitTests.confidence',
+                'scene.hitTestConfidence',
+                'quality.scene.hitTests',
+                'quality.scene.hitTests.confidence',
+                'quality.hitTests',
+                'hitTestConfidence'
+            ],
+            'results'
+        );
+
+        addSpatialChannel(
+            'anchors',
+            ['channels.spatial.anchors', 'spatial.anchors', 'scene.anchors'],
+            0.76,
+            [
+                'spatial.anchors.confidence',
+                'scene.anchors.confidence',
+                'scene.anchorConfidence',
+                'quality.scene.anchors',
+                'quality.scene.anchors.confidence',
+                'quality.anchors',
+                'anchorConfidence'
+            ],
+            'anchors'
+        );
+
+        if (Object.keys(spatialChannels).length > 0) {
+            composite.spatial = spatialChannels;
+        }
+
+        const fieldOfView = {
+            ...this.defaultFieldOfView,
+            ...(pickFirst(safe, ['metadata.fieldOfView', 'fieldOfView']) || {})
+        };
+        if (Object.keys(fieldOfView).length) {
+            composite.metadata.fieldOfView = fieldOfView;
+        }
+
+        const pose = pickFirst(safe, ['metadata.pose', 'pose']);
+        if (isPlainObject(pose)) {
+            const normalizedPose = {};
+            if (isPlainObject(pose.orientation)) {
+                normalizedPose.orientation = { ...pose.orientation };
+            }
+            if (isPlainObject(pose.position)) {
+                normalizedPose.position = { ...pose.position };
+            }
+            if (Object.keys(normalizedPose).length) {
+                composite.metadata.pose = normalizedPose;
+            }
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'batteryLevel',
+            firstNumber(safe.batteryLevel, getPath(safe, 'metadata.batteryLevel'))
+        );
+        assignIfDefined(
+            composite.metadata,
+            'deviceTemperature',
+            firstNumber(
+                safe.deviceTemperature,
+                getPath(safe, 'metadata.deviceTemperature'),
+                getPath(safe, 'environment.temperature')
+            )
+        );
+        assignIfDefined(
+            composite.metadata,
+            'uptimeSeconds',
+            firstNumber(safe.uptimeSeconds, getPath(safe, 'metadata.uptimeSeconds'))
+        );
+        assignIfDefined(composite.metadata, 'optics', pickFirst(safe, ['metadata.optics', 'optics']), true);
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const channelConfidences = Object.values(composite.channels)
+            .map(channel => channel?.confidence);
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'quality.overall'),
+                getPath(safe, 'quality.overallConfidence'),
+                getPath(safe, 'quality.focus'),
+                getPath(safe, 'quality.scene'),
+                getPath(safe, 'quality.scene.overall'),
+                ...channelConfidences,
+                ...spatialConfidences
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BaseWearableDeviceAdapter.js
@@ -1,0 +1,368 @@
+const clamp = (value, min, max) => {
+    if (!Number.isFinite(value)) return value;
+    if (typeof min === 'number' && value < min) return min;
+    if (typeof max === 'number' && value > max) return max;
+    return value;
+};
+
+const clampConfidence = (value, fallback = 0.75) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return clamp(fallback, 0, 1);
+    }
+    return clamp(numeric, 0, 1);
+};
+
+const clone = value => {
+    if (value == null || typeof value !== 'object') {
+        return value ?? null;
+    }
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(value);
+        } catch (error) {
+            // Fall back to JSON copy below
+        }
+    }
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+        return { ...value };
+    }
+};
+
+const compactObject = value => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return value;
+    }
+    const entries = Object.entries(value)
+        .map(([key, entryValue]) => {
+            if (entryValue == null) {
+                return null;
+            }
+            if (typeof entryValue === 'object' && !Array.isArray(entryValue)) {
+                const compacted = compactObject(entryValue);
+                if (compacted == null) {
+                    return null;
+                }
+                if (typeof compacted === 'object' && Object.keys(compacted).length === 0) {
+                    return null;
+                }
+                return [key, compacted];
+            }
+            if (Array.isArray(entryValue) && entryValue.length === 0) {
+                return null;
+            }
+            return [key, entryValue];
+        })
+        .filter(Boolean);
+
+    if (entries.length === 0) {
+        return null;
+    }
+
+    return Object.fromEntries(entries);
+};
+
+const compactChannels = (channels, fallbackConfidence) => {
+    if (!channels || typeof channels !== 'object') {
+        return {};
+    }
+    const normalized = {};
+    for (const [type, channel] of Object.entries(channels)) {
+        if (!channel) continue;
+        const payload = channel.payload && typeof channel.payload === 'object'
+            ? { ...channel.payload }
+            : (channel.payload ?? {});
+        normalized[type] = {
+            payload,
+            confidence: clampConfidence(channel.confidence, fallbackConfidence)
+        };
+    }
+    return normalized;
+};
+
+const summarizeMetadata = metadata => {
+    if (!metadata || typeof metadata !== 'object') {
+        return undefined;
+    }
+    const summary = {};
+    if (metadata.batteryLevel !== undefined) summary.batteryLevel = metadata.batteryLevel;
+    if (metadata.deviceTemperature !== undefined) summary.deviceTemperature = metadata.deviceTemperature;
+    if (metadata.skinContact !== undefined) summary.skinContact = metadata.skinContact;
+    if (metadata.signalQuality) summary.signalQuality = metadata.signalQuality;
+    if (metadata.uptimeSeconds !== undefined) summary.uptimeSeconds = metadata.uptimeSeconds;
+    if (metadata.fieldOfView) summary.fieldOfView = metadata.fieldOfView;
+    return Object.keys(summary).length > 0 ? summary : undefined;
+};
+
+export class BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        const {
+            deviceId = 'wearable-device',
+            firmwareVersion = null,
+            telemetry = null,
+            telemetryScope = 'sensors.adapter',
+            telemetryClassification = 'system',
+            licenseManager = null,
+            requiredLicenseFeature = null,
+            schemaType = 'wearable.generic',
+            defaultConfidence = 0.75,
+            sampleProvider,
+            transport = null,
+            trace,
+            traceLoop = true,
+            recordTelemetryMetadata = true
+        } = options;
+
+        this.deviceId = deviceId;
+        this.firmwareVersion = firmwareVersion;
+        this.telemetry = telemetry;
+        this.telemetryScope = telemetryScope;
+        this.telemetryClassification = telemetryClassification;
+        this.licenseManager = licenseManager;
+        this.requiredLicenseFeature = requiredLicenseFeature;
+        this.schemaType = schemaType;
+        this.defaultConfidence = defaultConfidence;
+        this.transport = transport || null;
+        this.recordTelemetryMetadata = recordTelemetryMetadata;
+
+        this.trace = Array.isArray(trace) ? [...trace] : null;
+        this.traceLoop = traceLoop !== false;
+        this.traceIndex = 0;
+
+        this.sampleProvider = typeof sampleProvider === 'function'
+            ? sampleProvider
+            : this.createDefaultSampleProvider();
+
+        this.connected = false;
+        this.lastLicenseBlock = null;
+    }
+
+    createDefaultSampleProvider() {
+        if (this.transport) {
+            return async () => {
+                if (typeof this.transport.nextSample === 'function') {
+                    return this.transport.nextSample();
+                }
+                if (typeof this.transport.read === 'function') {
+                    return this.transport.read();
+                }
+                return null;
+            };
+        }
+
+        if (!this.trace) {
+            return async () => null;
+        }
+
+        return async () => {
+            if (!this.trace.length) {
+                return null;
+            }
+            if (this.traceIndex >= this.trace.length) {
+                if (!this.traceLoop) {
+                    return null;
+                }
+                this.traceIndex = 0;
+            }
+            const entry = this.trace[this.traceIndex++];
+            if (typeof entry === 'function') {
+                return entry();
+            }
+            if (!entry || typeof entry !== 'object') {
+                return entry ?? null;
+            }
+            return clone(entry);
+        };
+    }
+
+    async connect() {
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return;
+        }
+
+        if (this.transport?.connect) {
+            await this.transport.connect();
+        }
+
+        this.resetTrace();
+        this.connected = true;
+        this.track('connected', { status: 'connected' });
+    }
+
+    async disconnect() {
+        if (this.transport?.disconnect) {
+            await this.transport.disconnect();
+        }
+        this.connected = false;
+        this.track('disconnected', { status: 'disconnected' });
+    }
+
+    async read() {
+        if (!this.connected) {
+            await this.connect();
+            if (!this.connected) {
+                return null;
+            }
+        }
+
+        const permitted = await this.ensureLicense();
+        if (!permitted) {
+            this.recordAudit('license_blocked', { reason: 'status', status: this.licenseManager?.getStatus?.() ?? null });
+            return null;
+        }
+
+        const raw = await this.sampleProvider();
+        if (!raw) {
+            return null;
+        }
+
+        const normalized = this.normalizeSample(raw);
+        if (!normalized || typeof normalized !== 'object') {
+            return null;
+        }
+
+        const confidence = clampConfidence(normalized.confidence, this.defaultConfidence);
+        const payload = this.decoratePayload(normalized.payload || {});
+
+        this.track('sample', {
+            confidence,
+            channels: Object.keys(payload.channels || {}),
+            metadata: this.recordTelemetryMetadata ? summarizeMetadata(payload.metadata) : undefined
+        });
+
+        return { confidence, payload };
+    }
+
+    normalizeSample(raw) {
+        return {
+            confidence: this.defaultConfidence,
+            payload: raw
+        };
+    }
+
+    decoratePayload(payload) {
+        const base = payload && typeof payload === 'object' ? { ...payload } : {};
+        if (!base.deviceId) {
+            base.deviceId = this.deviceId;
+        }
+        if (base.firmwareVersion == null && this.firmwareVersion != null) {
+            base.firmwareVersion = this.firmwareVersion;
+        }
+        if (base.channels) {
+            base.channels = compactChannels(base.channels, this.defaultConfidence);
+        }
+        if (base.metadata) {
+            const compacted = compactObject(base.metadata);
+            base.metadata = compacted || {};
+        }
+        return base;
+    }
+
+    async ensureLicense() {
+        if (!this.licenseManager) {
+            return true;
+        }
+
+        let status = typeof this.licenseManager.getStatus === 'function'
+            ? this.licenseManager.getStatus()
+            : null;
+
+        if (!status || status.state !== 'valid') {
+            if (typeof this.licenseManager.validate === 'function') {
+                try {
+                    status = await this.licenseManager.validate({
+                        scope: this.schemaType,
+                        deviceId: this.deviceId
+                    });
+                } catch (error) {
+                    this.noteLicenseBlock('validation', { error: error?.message || 'validation_failed' });
+                    return false;
+                }
+            }
+        }
+
+        if (!status || status.state !== 'valid') {
+            this.noteLicenseBlock('status', { status });
+            return false;
+        }
+
+        if (this.requiredLicenseFeature) {
+            try {
+                if (typeof this.licenseManager.requireFeature === 'function') {
+                    this.licenseManager.requireFeature(this.requiredLicenseFeature);
+                } else if (typeof this.licenseManager.hasFeature === 'function') {
+                    if (!this.licenseManager.hasFeature(this.requiredLicenseFeature)) {
+                        const error = new Error(`License missing feature: ${this.requiredLicenseFeature}`);
+                        error.code = 'LICENSE_FEATURE_MISSING';
+                        throw error;
+                    }
+                }
+            } catch (error) {
+                this.noteLicenseBlock('feature', {
+                    status,
+                    feature: this.requiredLicenseFeature,
+                    error: error?.message,
+                    code: error?.code
+                });
+                return false;
+            }
+        }
+
+        this.lastLicenseBlock = null;
+        return true;
+    }
+
+    noteLicenseBlock(reason, details) {
+        const payload = {
+            reason,
+            ...(details && typeof details === 'object' ? details : { details })
+        };
+        const snapshot = JSON.stringify(payload);
+        if (snapshot === this.lastLicenseBlock) {
+            return;
+        }
+        this.lastLicenseBlock = snapshot;
+        this.recordAudit('license_blocked', payload);
+    }
+
+    recordAudit(eventSuffix, payload) {
+        if (!this.telemetry?.recordAudit) {
+            return;
+        }
+        this.telemetry.recordAudit(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            }
+        );
+    }
+
+    track(eventSuffix, payload) {
+        if (!this.telemetry?.track) {
+            return;
+        }
+        this.telemetry.track(
+            `${this.telemetryScope}.${this.schemaType}.${eventSuffix}`,
+            {
+                deviceId: this.deviceId,
+                firmwareVersion: this.firmwareVersion ?? undefined,
+                ...payload
+            },
+            { classification: this.telemetryClassification }
+        );
+    }
+
+    resetTrace() {
+        this.traceIndex = 0;
+        if (this.transport?.reset) {
+            this.transport.reset();
+        }
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js
@@ -1,0 +1,175 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+    return fallback;
+};
+
+const assignIfDefined = (target, key, value, clone = false) => {
+    if (value === undefined || value === null) {
+        return;
+    }
+    if (clone && isPlainObject(value)) {
+        target[key] = { ...value };
+        return;
+    }
+    target[key] = value;
+};
+
+export class BiometricWristWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.biometric-wrist',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-biometric',
+            defaultConfidence: options.defaultConfidence ?? 0.78,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const vitalsSource = pickFirst(safe, ['channels.biometric', 'vitals', 'biometric']);
+        if (vitalsSource) {
+            const payload = cloneChannelPayload(vitalsSource);
+            const confidence = firstNumber(
+                vitalsSource.confidence,
+                getPath(safe, 'quality.vitals'),
+                getPath(safe, 'quality.overall')
+            );
+            composite.channels.biometric = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const ambientSource = pickFirst(safe, ['channels.ambient', 'environment']);
+        if (ambientSource) {
+            const payload = cloneChannelPayload(ambientSource);
+            const confidence = firstNumber(
+                ambientSource.confidence,
+                getPath(safe, 'quality.environment'),
+                getPath(safe, 'quality.motion')
+            );
+            composite.channels.ambient = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'batteryLevel',
+            firstNumber(safe.batteryLevel, getPath(safe, 'metadata.batteryLevel'))
+        );
+        if (safe.skinContact !== undefined || getPath(safe, 'metadata.skinContact') !== undefined) {
+            const value = pickFirst(safe, ['skinContact', 'metadata.skinContact']);
+            composite.metadata.skinContact = Boolean(value);
+        }
+        assignIfDefined(composite.metadata, 'lastSync', pickFirst(safe, ['lastSync', 'metadata.lastSync']));
+
+        const motion = pickFirst(safe, ['metadata.motion', 'motion']);
+        if (isPlainObject(motion)) {
+            composite.metadata.motion = {};
+            if (isPlainObject(motion.acceleration)) {
+                composite.metadata.motion.acceleration = { ...motion.acceleration };
+            }
+        }
+
+        assignIfDefined(
+            composite.metadata,
+            'deviceTemperature',
+            firstNumber(safe.deviceTemperature, getPath(safe, 'metadata.deviceTemperature'))
+        );
+
+        const alerts = pickFirst(safe, ['metadata.alerts', 'alerts']);
+        if (Array.isArray(alerts)) {
+            const sanitized = alerts
+                .filter(value => typeof value === 'string' && value.trim().length > 0)
+                .map(value => value.trim());
+            if (sanitized.length) {
+                composite.metadata.alerts = sanitized;
+            }
+        }
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'quality.overall'),
+                composite.channels.biometric?.confidence
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
+++ b/src/ui/adaptive/sensors/adapters/NeuralBandWearableAdapter.js
@@ -1,0 +1,166 @@
+import { BaseWearableDeviceAdapter } from './BaseWearableDeviceAdapter.js';
+
+const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const getPath = (source, path) => {
+    if (!path) return undefined;
+    const parts = String(path).split('.');
+    let current = source;
+    for (const part of parts) {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+        current = current[part];
+    }
+    return current;
+};
+
+const pickFirst = (source, paths) => {
+    for (const path of paths) {
+        const value = getPath(source, path);
+        if (value !== undefined && value !== null) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const cloneChannelPayload = value => {
+    if (!isPlainObject(value)) {
+        return {};
+    }
+    if (isPlainObject(value.payload)) {
+        return { ...value.payload };
+    }
+    const { confidence, ...rest } = value;
+    return { ...rest };
+};
+
+const firstNumber = (...candidates) => {
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return undefined;
+};
+
+const ensureConfidence = (value, fallback) => {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+        return numeric;
+    }
+    return fallback;
+};
+
+const cloneArray = value => Array.isArray(value) ? [...value] : undefined;
+
+export class NeuralBandWearableAdapter extends BaseWearableDeviceAdapter {
+    constructor(options = {}) {
+        super({
+            schemaType: 'wearable.neural-band',
+            requiredLicenseFeature: options.requiredLicenseFeature || 'wearables-neural-band',
+            defaultConfidence: options.defaultConfidence ?? 0.7,
+            ...options
+        });
+    }
+
+    normalizeSample(raw = {}) {
+        const safe = isPlainObject(raw) ? raw : {};
+        const composite = {
+            deviceId: safe.deviceId ?? this.deviceId,
+            firmwareVersion: pickFirst(safe, ['firmwareVersion', 'metadata.firmwareVersion']) ?? this.firmwareVersion ?? null,
+            channels: {},
+            metadata: {}
+        };
+
+        const intentSource = pickFirst(safe, ['channels.neural-intent', 'intent', 'signal']);
+        if (intentSource) {
+            const payload = cloneChannelPayload(intentSource);
+            const confidence = firstNumber(
+                intentSource.confidence,
+                getPath(safe, 'signalQuality.overall'),
+                getPath(safe, 'quality.intent')
+            );
+            composite.channels['neural-intent'] = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence)
+            };
+        }
+
+        const gestureSource = pickFirst(safe, ['channels.gesture', 'gesture']);
+        if (gestureSource) {
+            const payload = cloneChannelPayload(gestureSource);
+            const confidence = firstNumber(
+                gestureSource.confidence,
+                getPath(safe, 'quality.gesture')
+            );
+            composite.channels.gesture = {
+                payload,
+                confidence: ensureConfidence(confidence, this.defaultConfidence * 0.75)
+            };
+        }
+
+        const signalQuality = pickFirst(safe, ['metadata.signalQuality', 'signalQuality']);
+        if (isPlainObject(signalQuality)) {
+            composite.metadata.signalQuality = { ...signalQuality };
+            if (Array.isArray(signalQuality.contacts)) {
+                composite.metadata.signalQuality.contacts = cloneArray(signalQuality.contacts);
+            }
+        }
+
+        const impedance = pickFirst(safe, ['metadata.impedance', 'impedance']);
+        if (isPlainObject(impedance)) {
+            composite.metadata.impedance = { ...impedance };
+        }
+
+        const contactState = pickFirst(safe, ['metadata.contact.state', 'contactState']);
+        const electrodes = pickFirst(safe, ['metadata.contact.electrodes', 'electrodes']);
+        if (contactState !== undefined || electrodes !== undefined) {
+            composite.metadata.contact = {};
+            if (contactState !== undefined) {
+                composite.metadata.contact.state = contactState;
+            }
+            if (Array.isArray(electrodes)) {
+                composite.metadata.contact.electrodes = cloneArray(electrodes);
+            }
+        }
+
+        const band = pickFirst(safe, ['metadata.band', 'band']);
+        if (isPlainObject(band)) {
+            composite.metadata.band = { ...band };
+        }
+
+        const temperature = firstNumber(safe.temperature, getPath(safe, 'metadata.deviceTemperature'));
+        if (temperature !== undefined) {
+            composite.metadata.deviceTemperature = temperature;
+        }
+
+        if (Object.keys(composite.metadata).length === 0) {
+            delete composite.metadata;
+        }
+
+        for (const channel of Object.values(composite.channels)) {
+            if (channel.confidence === undefined) {
+                channel.confidence = this.defaultConfidence;
+            }
+        }
+
+        const confidence = ensureConfidence(
+            firstNumber(
+                safe.confidence,
+                getPath(safe, 'signalQuality.overall'),
+                getPath(safe, 'quality.overall'),
+                composite.channels['neural-intent']?.confidence
+            ),
+            this.defaultConfidence
+        );
+
+        return {
+            confidence,
+            payload: composite
+        };
+    }
+}
+

--- a/tests/vitest/quaternion-cluster-toolkit.test.js
+++ b/tests/vitest/quaternion-cluster-toolkit.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+    averageQuaternionSamples,
+    blendAnchorCluster,
+    blendHitTestCluster
+} from '../../src/ui/adaptive/renderers/QuaternionClusterToolkit.js';
+
+function quaternionFromEuler(roll, pitch, yaw) {
+    const cy = Math.cos(yaw / 2);
+    const sy = Math.sin(yaw / 2);
+    const cp = Math.cos(pitch / 2);
+    const sp = Math.sin(pitch / 2);
+    const cr = Math.cos(roll / 2);
+    const sr = Math.sin(roll / 2);
+
+    return {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy
+    };
+}
+
+describe('QuaternionClusterToolkit', () => {
+    it('averages quaternion samples with hemisphere alignment', () => {
+        const a = quaternionFromEuler(0, 0, 0);
+        const b = { x: -a.x, y: -a.y, z: -a.z, w: -a.w }; // opposite hemisphere
+        const result = averageQuaternionSamples([
+            { orientation: a, weight: 1 },
+            { orientation: b, weight: 1 }
+        ]);
+
+        expect(result).toEqual({ x: 0, y: 0, z: 0, w: 1 });
+    });
+
+    it('blends anchor clusters into aggregate orientation and confidence', () => {
+        const anchors = [
+            {
+                confidence: 0.9,
+                pose: { orientation: quaternionFromEuler(0, 0, 0.2), position: { x: 0, y: 0, z: 0 } }
+            },
+            {
+                confidence: 0.6,
+                pose: { orientation: quaternionFromEuler(0, 0, 0.4), position: { x: 1, y: 0, z: 0 } }
+            }
+        ];
+
+        const blended = blendAnchorCluster(anchors);
+        expect(blended).not.toBeNull();
+        expect(blended?.orientation?.w).toBeTypeOf('number');
+        expect(blended?.confidence).toBeGreaterThan(0.6);
+        expect(blended?.sampleCount).toBe(2);
+        expect(blended?.variance).toBeGreaterThanOrEqual(0);
+    });
+
+    it('weights hit-test results by confidence and distance', () => {
+        const hits = [
+            {
+                confidence: 0.8,
+                distance: 0.1,
+                pose: { orientation: quaternionFromEuler(0, 0, 0.3), position: { x: 0, y: 0, z: 0.1 } }
+            },
+            {
+                confidence: 0.4,
+                distance: 0.8,
+                pose: { orientation: quaternionFromEuler(0, 0, 0.9), position: { x: 0, y: 0, z: 0.8 } }
+            }
+        ];
+
+        const blended = blendHitTestCluster(hits, { distanceFalloff: 0.5 });
+        expect(blended).not.toBeNull();
+        expect(blended?.averageDistance).toBeLessThan(0.4);
+        expect(blended?.confidence).toBeGreaterThan(0.5);
+        expect(blended?.variance).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/tests/vitest/shader-quaternion-diagnostics.test.js
+++ b/tests/vitest/shader-quaternion-diagnostics.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ShaderQuaternionSynchronizer } from '../../src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js';
+import { ShaderQuaternionDiagnosticsOverlay } from '../../src/ui/adaptive/renderers/ShaderQuaternionDiagnosticsOverlay.js';
+
+function quaternionFromEuler(roll, pitch, yaw) {
+    const cy = Math.cos(yaw / 2);
+    const sy = Math.sin(yaw / 2);
+    const cp = Math.cos(pitch / 2);
+    const sp = Math.sin(pitch / 2);
+    const cr = Math.cos(roll / 2);
+    const sr = Math.sin(roll / 2);
+
+    return {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy
+    };
+}
+
+function createStubSystem(defaults = {}) {
+    const parameters = new Map(Object.entries(defaults));
+    return {
+        parameters,
+        updateParameter(param, value) {
+            parameters.set(param, value);
+        }
+    };
+}
+
+describe('ShaderQuaternionDiagnosticsOverlay', () => {
+    let bridge;
+    let container;
+
+    beforeEach(() => {
+        bridge = {
+            subscribe() {
+                return () => {};
+            }
+        };
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('renders quaternion telemetry from the synchronizer', () => {
+        const quantum = createStubSystem({ rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum },
+            baseAlpha: 1,
+            rotationScale: 1,
+            energySmoothing: 1
+        });
+
+        const overlay = new ShaderQuaternionDiagnosticsOverlay({
+            synchronizer: sync,
+            container,
+            document
+        });
+
+        overlay.mount();
+
+        const orientation = quaternionFromEuler(0.15, 0.25, -0.35);
+        sync.applyOrientation(orientation, { confidence: 0.9, timestamp: 1000, source: 'spatial.pose' });
+
+        const yaw = container.querySelector('[data-testid="shader-q-yaw"]');
+        const params = container.querySelector('[data-testid="shader-q-params-quantum"]');
+        const source = container.querySelector('[data-testid="shader-q-source"]');
+
+        expect(yaw?.textContent).not.toBe('0.0°');
+        expect(params?.textContent || '').toContain('rot4dXW');
+        expect(source?.textContent).toBe('spatial.pose');
+
+        overlay.unmount();
+        expect(container.querySelector('[data-testid="shader-q-yaw"]')).toBeNull();
+    });
+});

--- a/tests/vitest/shader-quaternion-sync.test.js
+++ b/tests/vitest/shader-quaternion-sync.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ShaderQuaternionSynchronizer } from '../../src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js';
+
+function quaternionFromEuler(roll, pitch, yaw) {
+    const cy = Math.cos(yaw / 2);
+    const sy = Math.sin(yaw / 2);
+    const cp = Math.cos(pitch / 2);
+    const sp = Math.sin(pitch / 2);
+    const cr = Math.cos(roll / 2);
+    const sr = Math.sin(roll / 2);
+
+    return {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy
+    };
+}
+
+function createStubSystem(defaults = {}) {
+    const parameters = new Map(Object.entries(defaults));
+    const updates = [];
+    return {
+        parameters,
+        updates,
+        updateParameter(param, value) {
+            parameters.set(param, value);
+            updates.push({ param, value });
+        }
+    };
+}
+
+describe('ShaderQuaternionSynchronizer', () => {
+    let bridge;
+    let callbacks;
+
+    beforeEach(() => {
+        callbacks = new Map();
+        bridge = {
+            subscribe(channel, handler) {
+                callbacks.set(channel, handler);
+                return () => callbacks.delete(channel);
+            }
+        };
+    });
+
+    it('applies spatial anchor orientation across shader systems', () => {
+        const quantum = createStubSystem({ chaos: 0.2, intensity: 0.7, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const holographic = createStubSystem({ hue: 320, saturation: 0.9, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const faceted = createStubSystem({ speed: 1, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum, holographic, faceted },
+            baseAlpha: 1,
+            rotationScale: 2,
+            energySmoothing: 1
+        });
+        sync.start();
+
+        const handler = callbacks.get('spatial.anchors');
+        expect(handler).toBeTypeOf('function');
+
+        const orientation = quaternionFromEuler(-0.1, 0.2, 0.3);
+        handler({
+            payload: { anchors: [{ confidence: 0.9, pose: { orientation } }] },
+            confidence: 0.9,
+            timestamp: 1000
+        });
+
+        expect(quantum.parameters.get('rot4dXW')).toBeCloseTo(0.4, 5);
+        expect(quantum.parameters.get('rot4dYW')).toBeCloseTo(0.6, 5);
+        expect(quantum.parameters.get('rot4dZW')).toBeCloseTo(-0.2, 5);
+
+        expect(holographic.parameters.get('hue')).toBe(360);
+        expect(holographic.parameters.get('saturation')).toBeCloseTo(0.9, 5);
+        expect(faceted.parameters.get('speed')).toBeCloseTo(1, 5);
+    });
+
+    it('blends anchor clusters using weighted quaternion averages', () => {
+        const quantum = createStubSystem({ rot4dYW: 0 });
+
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum },
+            baseAlpha: 1,
+            rotationScale: 1,
+            energySmoothing: 1
+        });
+        sync.start();
+
+        const handler = callbacks.get('spatial.anchors');
+        expect(handler).toBeTypeOf('function');
+
+        const anchorA = quaternionFromEuler(0, 0, 0);
+        const anchorB = quaternionFromEuler(0, 0, Math.PI / 2);
+
+        handler({
+            payload: {
+                anchors: [
+                    { confidence: 0.9, pose: { orientation: anchorA, position: { x: 0, y: 0, z: 0 } } },
+                    { confidence: 0.9, pose: { orientation: anchorB, position: { x: 1, y: 0, z: 0 } } }
+                ]
+            },
+            confidence: 0.9,
+            timestamp: 42
+        });
+
+        expect(quantum.parameters.get('rot4dYW')).toBeCloseTo(Math.PI / 4, 2);
+    });
+
+    it('derives motion energy from subsequent samples to modulate parameters', () => {
+        const quantum = createStubSystem({ chaos: 0.25, intensity: 0.6, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const holographic = createStubSystem({ hue: 300, saturation: 0.85, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const faceted = createStubSystem({ speed: 0.8, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum, holographic, faceted },
+            baseAlpha: 1,
+            rotationScale: 2,
+            energySmoothing: 1,
+            velocityReference: 2
+        });
+
+        const first = quaternionFromEuler(0, 0, 0);
+        const second = quaternionFromEuler(0.5, 0.4, 0.3);
+
+        sync.applyOrientation(first, { confidence: 1, timestamp: 0 });
+        sync.applyOrientation(second, { confidence: 1, timestamp: 1000 });
+
+        expect(quantum.parameters.get('chaos')).toBeGreaterThan(0.25);
+        expect(quantum.parameters.get('intensity')).toBeGreaterThan(0.6);
+        expect(faceted.parameters.get('speed')).toBeGreaterThan(0.8);
+    });
+
+    it('attenuates updates when confidence falls below the threshold', () => {
+        const quantum = createStubSystem({ rot4dXW: 0 });
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum },
+            rotationScale: 2,
+            baseAlpha: 0.5,
+            minConfidence: 0.6,
+            energySmoothing: 1
+        });
+
+        const orientation = quaternionFromEuler(0, 0.5, 0);
+        sync.applyOrientation(orientation, { confidence: 0.2, timestamp: 0 });
+
+        expect(quantum.parameters.get('rot4dXW')).toBeCloseTo(0.1666666, 4);
+    });
+
+    it('notifies observers with quaternion diagnostics payloads', () => {
+        const quantum = createStubSystem({ rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 });
+        const sync = new ShaderQuaternionSynchronizer({
+            bridge,
+            systems: { quantum },
+            rotationScale: 1,
+            baseAlpha: 1,
+            energySmoothing: 1
+        });
+
+        let payload = null;
+        sync.addObserver(update => {
+            payload = update;
+        });
+
+        const orientation = quaternionFromEuler(0.1, -0.2, 0.05);
+        sync.applyOrientation(orientation, { confidence: 0.8, timestamp: 420, source: 'spatial.pose' });
+
+        expect(payload).not.toBeNull();
+        expect(payload?.source).toBe('spatial.pose');
+        expect(payload?.motionEnergy).toBeGreaterThanOrEqual(0);
+        expect(Number.isFinite(payload?.systems?.[0]?.parameters?.rot4dXW ?? NaN)).toBe(true);
+        expect(payload?.metadata).toBeNull();
+
+        let anchorPayload = null;
+        sync.addObserver(update => {
+            if (update.source === 'spatial.anchors') {
+                anchorPayload = update;
+            }
+        });
+
+        sync.handleEvent('spatial.anchors', {
+            payload: {
+                anchors: [
+                    { confidence: 0.8, pose: { orientation: quaternionFromEuler(0, 0, 0.1) } },
+                    { confidence: 0.6, pose: { orientation: quaternionFromEuler(0, 0, 0.2) } }
+                ]
+            },
+            confidence: 0.8,
+            timestamp: 1000
+        });
+
+        expect(anchorPayload?.metadata?.anchorCluster?.sampleCount).toBe(2);
+        expect(anchorPayload?.metadata?.anchorCluster?.orientation).toBeDefined();
+    });
+});

--- a/tests/vitest/wearables-adapters.test.js
+++ b/tests/vitest/wearables-adapters.test.js
@@ -1,0 +1,554 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { SensorSchemaRegistry } from '../../src/ui/adaptive/sensors/SensorSchemaRegistry.js';
+import { SensoryInputBridge } from '../../src/ui/adaptive/SensoryInputBridge.js';
+import { WearableDeviceManager } from '../../src/ui/adaptive/sensors/WearableDeviceManager.js';
+import { BiometricWristWearableAdapter } from '../../src/ui/adaptive/sensors/adapters/BiometricWristWearableAdapter.js';
+import { ARVisorWearableAdapter } from '../../src/ui/adaptive/sensors/adapters/ARVisorWearableAdapter.js';
+import { LicenseManager } from '../../src/product/licensing/LicenseManager.js';
+
+describe('Wearable sensor schemas', () => {
+    let registry;
+
+    beforeEach(() => {
+        registry = new SensorSchemaRegistry();
+    });
+
+    it('normalizes AR visor payloads and reports range violations', () => {
+        const result = registry.validate('wearable.ar-visor', {
+            deviceId: 'visor-alpha',
+            gaze: { x: 1.4, y: -0.3, depth: 0.9, vergence: 6.2, stability: -0.4 },
+            environment: { luminance: 1.3, noiseLevel: -0.1, motion: 0.4, temperature: 82 },
+            gesture: { intent: 'swipe-right', vector: { x: 1.4, y: -1.2, z: 0.8 } },
+            fieldOfView: { horizontal: 190, vertical: 15, diagonal: 220 },
+            batteryLevel: 1.2,
+            deviceTemperature: 92,
+            uptimeSeconds: -5
+        });
+
+        const eye = result.payload.channels['eye-tracking'];
+        expect(eye.confidence).toBeCloseTo(0.82, 5);
+        expect(eye.payload.x).toBeLessThanOrEqual(1);
+        expect(eye.payload.y).toBeGreaterThanOrEqual(0);
+        expect(eye.payload.vergence).toBeLessThanOrEqual(5);
+
+        const ambient = result.payload.channels.ambient;
+        expect(ambient.payload.luminance).toBeLessThanOrEqual(1);
+        expect(ambient.payload.noiseLevel).toBeGreaterThanOrEqual(0);
+        expect(ambient.payload.temperature).toBeLessThanOrEqual(60);
+
+        const gesture = result.payload.channels.gesture;
+        expect(gesture.payload.vector.x).toBeLessThanOrEqual(1);
+        expect(gesture.payload.vector.y).toBeGreaterThanOrEqual(-1);
+
+        const metadata = result.payload.metadata;
+        expect(metadata.batteryLevel).toBeLessThanOrEqual(1);
+        expect(metadata.deviceTemperature).toBeLessThanOrEqual(90);
+        expect(metadata.uptimeSeconds).toBeGreaterThanOrEqual(0);
+        expect(metadata.fieldOfView.horizontal).toBeLessThanOrEqual(160);
+        expect(metadata.fieldOfView.vertical).toBeGreaterThanOrEqual(30);
+
+        const issueFields = result.issues.map(issue => issue.field);
+        expect(issueFields).toContain('channels.eye-tracking.vergence');
+        expect(issueFields).toContain('channels.ambient.luminance');
+        expect(issueFields).toContain('metadata.batteryLevel');
+    });
+
+    it('normalizes spatial schemas for planes, depth, hit tests, and anchors', () => {
+        const planes = registry.validate('spatial.scene-planes', {
+            timestamp: 120,
+            space: { type: 'local-floor', id: 'room-1' },
+            planes: [
+                {
+                    id: 'plane-1',
+                    space: 'local-floor',
+                    pose: {
+                        position: { x: 1, y: 1.4, z: 0.5 },
+                        orientation: { x: 0, y: 0, z: 0, w: 1 }
+                    },
+                    alignment: 'horizontal',
+                    extent: { width: 2.5, height: 1.5 },
+                    polygon: [
+                        { x: 0, y: 0, z: 0 },
+                        { x: 1, y: 0, z: 0 },
+                        { x: 1, y: 0, z: 1 }
+                    ],
+                    classification: 'floor',
+                    lastChangedTime: 110
+                }
+            ],
+            removedIds: ['stale-plane']
+        });
+
+        expect(planes.payload.planes[0].alignment).toBe('horizontal');
+        expect(planes.payload.planes[0].polygon?.length).toBe(3);
+        expect(planes.payload.removedIds).toEqual(['stale-plane']);
+        expect(planes.issues).toHaveLength(0);
+
+        const depth = registry.validate('spatial.depth-buffer', {
+            timestamp: 130,
+            space: { type: 'viewer', id: 'viewer-1' },
+            format: 'r16u',
+            width: 256,
+            height: 192,
+            rawValueToMeters: 0.001,
+            near: -2,
+            far: 3000,
+            buffer: { type: 'cpu', handle: 'buffer-1' },
+            intrinsics: { fx: 450.5, fy: 449.9 },
+            confidence: 1.2
+        });
+
+        expect(depth.payload.buffer.type).toBe('cpu');
+        expect(depth.payload.near).toBeGreaterThanOrEqual(0);
+        expect(depth.payload.far).toBeLessThanOrEqual(1000);
+        expect(depth.payload.confidence).toBeLessThanOrEqual(1);
+        expect(depth.issues.find(issue => issue.field === 'near')).toBeDefined();
+        expect(depth.issues.find(issue => issue.field === 'far')).toBeDefined();
+        expect(depth.issues.find(issue => issue.field === 'confidence')).toBeDefined();
+
+        const hitTests = registry.validate('spatial.hit-test-results', {
+            timestamp: 140,
+            space: 'viewer',
+            results: [
+                {
+                    rayId: 'ray-1',
+                    space: { type: 'local', id: 'origin' },
+                    pose: {
+                        position: { x: 0, y: 1, z: 2 },
+                        orientation: { x: 0, y: 0, z: 0, w: 1 }
+                    },
+                    distance: 2.4,
+                    timestamp: 140,
+                    type: 'plane',
+                    normal: { x: 0, y: 1, z: 0 },
+                    anchors: ['anchor-1'],
+                    inputSource: { handedness: 'left', profiles: ['touch'] },
+                    confidence: 0.9
+                }
+            ]
+        });
+
+        expect(hitTests.payload.results).toHaveLength(1);
+        expect(hitTests.payload.results[0].rayId).toBe('ray-1');
+        expect(hitTests.payload.results[0].inputSource?.handedness).toBe('left');
+
+        const anchors = registry.validate('spatial.anchors', {
+            timestamp: 150,
+            space: 'local',
+            anchors: [
+                {
+                    id: 'anchor-1',
+                    space: { type: 'local', id: 'origin' },
+                    pose: {
+                        position: { x: 0.2, y: 0.5, z: 0.8 },
+                        orientation: { x: 0, y: 0, z: 0, w: 1 }
+                    },
+                    classification: 'desk',
+                    lastChangedTime: 150
+                }
+            ]
+        });
+
+        expect(anchors.payload.anchors[0].classification).toBe('unknown');
+        expect(anchors.issues.some(issue => issue.field === 'anchors.0.classification')).toBe(true);
+    });
+
+    it('injects spatial channels into AR visor composite normalization', () => {
+        const result = registry.validate('wearable.ar-visor', {
+            deviceId: 'visor-gamma',
+            gaze: { x: 0.45, y: 0.55, depth: 0.38 },
+            gesture: { intent: 'tap', vector: { x: 0.01, y: 0.02, z: -0.03 } },
+            environment: { luminance: 0.5, noiseLevel: 0.2, motion: 0.1 },
+            spatial: {
+                planes: {
+                    timestamp: 200,
+                    space: { type: 'local-floor', id: 'room-2' },
+                    planes: [
+                        {
+                            id: 'plane-1',
+                            space: 'local-floor',
+                            pose: {
+                                position: { x: 0, y: 0, z: 0 },
+                                orientation: { x: 0, y: 0, z: 0, w: 1 }
+                            },
+                            alignment: 'horizontal',
+                            extent: { width: 3, height: 2 },
+                            polygon: [
+                                { x: 0, y: 0, z: 0 },
+                                { x: 1, y: 0, z: 0 },
+                                { x: 1, y: 0, z: 1 }
+                            ],
+                            lastChangedTime: 200
+                        }
+                    ]
+                },
+                depth: {
+                    timestamp: 200,
+                    space: 'viewer',
+                    format: 'r16u',
+                    width: 128,
+                    height: 128,
+                    rawValueToMeters: 0.001,
+                    buffer: { type: 'cpu', handle: 'depth-buffer' }
+                },
+                hitTests: {
+                    timestamp: 200,
+                    space: 'viewer',
+                    results: [
+                        {
+                            rayId: 'ray-1',
+                            space: 'local',
+                            pose: {
+                                position: { x: 0, y: 1, z: 0 },
+                                orientation: { x: 0, y: 0, z: 0, w: 1 }
+                            },
+                            distance: 1.2,
+                            timestamp: 200
+                        }
+                    ]
+                },
+                anchors: {
+                    timestamp: 200,
+                    space: 'local',
+                    anchors: [
+                        {
+                            id: 'anchor-1',
+                            space: 'local',
+                            pose: {
+                                position: { x: 0.1, y: 0.4, z: 0.2 },
+                                orientation: { x: 0, y: 0, z: 0, w: 1 }
+                            },
+                            lastChangedTime: 200
+                        }
+                    ]
+                }
+            }
+        });
+
+        const planesChannel = result.payload.channels['spatial.planes'];
+        expect(planesChannel).toBeDefined();
+        expect(planesChannel.payload.planes[0].space.type).toBe('local-floor');
+        expect(planesChannel.confidence).toBeCloseTo(0.78, 2);
+
+        const depthChannel = result.payload.channels['spatial.depth'];
+        expect(depthChannel.payload.format).toBe('r16u');
+        expect(depthChannel.confidence).toBeCloseTo(0.72, 2);
+
+        const hitTestChannel = result.payload.channels['spatial.hit-tests'];
+        expect(hitTestChannel.payload.results).toHaveLength(1);
+
+        const anchorChannel = result.payload.channels['spatial.anchors'];
+        expect(anchorChannel.payload.anchors[0].id).toBe('anchor-1');
+        expect(anchorChannel.confidence).toBeCloseTo(0.76, 2);
+    });
+});
+
+describe('SensoryInputBridge wearable multiplexing', () => {
+    it('routes wearable payloads into semantic channels and emits metadata events', () => {
+        const bridge = new SensoryInputBridge({ autoConnectAdapters: false, confidenceThreshold: 0 });
+        let metadataEvent = null;
+        bridge.subscribe('wearable.ar-visor:metadata', event => {
+            metadataEvent = event;
+        });
+
+        const payload = {
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            channels: {
+                'eye-tracking': { confidence: 0.9, payload: { x: 0.35, y: 0.62, depth: 0.42 } },
+                ambient: { confidence: 0.5, payload: { luminance: 0.58, noiseLevel: 0.24, motion: 0.16 } },
+                gesture: { confidence: 0.61, payload: { intent: 'tap', vector: { x: 0.1, y: 0.2, z: -0.05 } } }
+            },
+            metadata: { batteryLevel: 0.82 }
+        };
+
+        bridge.processSample('wearable.ar-visor', { confidence: 0.94, payload });
+
+        const snapshot = bridge.getSnapshot();
+        const expectedFocusX = 0.5 + (0.35 - 0.5) * 0.9;
+        const expectedFocusY = 0.5 + (0.62 - 0.5) * 0.9;
+        const expectedLuminance = 0.5 + (0.58 - 0.5) * 0.5;
+
+        expect(snapshot.focusVector.x).toBeCloseTo(expectedFocusX, 5);
+        expect(snapshot.focusVector.y).toBeCloseTo(expectedFocusY, 5);
+        expect(snapshot.environment.luminance).toBeCloseTo(expectedLuminance, 5);
+        expect(snapshot.gestureIntent).toBe('tap');
+
+        expect(metadataEvent).toMatchObject({
+            deviceId: 'visor-beta',
+            firmwareVersion: '2.0.1',
+            metadata: expect.objectContaining({ batteryLevel: 0.82 }),
+            confidence: 0.94,
+            timestamp: expect.any(Number)
+        });
+    });
+});
+
+describe('Wearable adapters', () => {
+    it('enforces licensing before streaming biometric wrist samples', async () => {
+        const telemetry = {
+            track: vi.fn(),
+            recordAudit: vi.fn()
+        };
+        const licenseManager = new LicenseManager();
+
+        const adapter = new BiometricWristWearableAdapter({
+            telemetry,
+            licenseManager,
+            deviceId: 'wrist-01',
+            trace: [
+                {
+                    vitals: { stress: 0.44, heartRate: 72, temperature: 37.4, oxygen: 0.97, hrv: 54 },
+                    environment: { luminance: 0.32, noiseLevel: 0.18, motion: 0.2, temperature: 24, humidity: 0.41 },
+                    quality: { overall: 0.91, vitals: 0.9, environment: 0.6 },
+                    batteryLevel: 0.76,
+                    skinContact: true
+                }
+            ]
+        });
+
+        const blocked = await adapter.read();
+        expect(blocked).toBeNull();
+        expect(telemetry.recordAudit).toHaveBeenCalled();
+        const auditPayload = telemetry.recordAudit.mock.calls[0][1];
+        expect(auditPayload.reason).toBe('status');
+
+        telemetry.recordAudit.mockClear();
+
+        licenseManager.setLicense({ key: 'valid-key', features: ['wearables-biometric'] });
+        await licenseManager.validate();
+
+        const sample = await adapter.read();
+        expect(sample?.payload.channels.biometric).toBeDefined();
+        expect(sample?.payload.channels.biometric.payload.heartRate).toBe(72);
+        expect(telemetry.track).toHaveBeenCalled();
+        const trackCall = telemetry.track.mock.calls.find(([event]) => event.includes('wearable.biometric-wrist.sample'));
+        expect(trackCall).toBeDefined();
+        expect(trackCall[1].channels).toContain('biometric');
+        expect(trackCall[2]).toEqual({ classification: 'system' });
+        expect(telemetry.recordAudit).not.toHaveBeenCalled();
+    });
+
+    it('normalizes AR visor spatial traces into schema-ready payloads', () => {
+        const adapter = new ARVisorWearableAdapter({
+            deviceId: 'visor-spatial',
+            defaultConfidence: 0.8
+        });
+
+        const raw = {
+            deviceId: 'visor-spatial',
+            channels: {
+                'eye-tracking': {
+                    payload: { x: 0.52, y: 0.47, depth: 0.36 },
+                    confidence: 0.9
+                },
+                spatial: {
+                    planes: {
+                        payload: {
+                            timestamp: 12,
+                            space: { type: 'local-floor', id: 'room' },
+                            planes: [
+                                {
+                                    id: 'plane-a',
+                                    space: { type: 'local-floor', id: 'room' },
+                                    pose: {
+                                        position: { x: 0, y: 0, z: 0 },
+                                        orientation: { x: 0, y: 0, z: 0, w: 1 }
+                                    },
+                                    alignment: 'horizontal',
+                                    extent: { width: 3, height: 2 },
+                                    polygon: [
+                                        { x: 0, y: 0, z: 0 },
+                                        { x: 3, y: 0, z: 0 },
+                                        { x: 3, y: 0, z: 2 }
+                                    ],
+                                    lastChangedTime: 12
+                                }
+                            ]
+                        },
+                        confidence: 0.66
+                    }
+                }
+            },
+            spatial: {
+                depth: {
+                    timestamp: 12,
+                    space: 'viewer',
+                    format: 'r16u',
+                    width: 128,
+                    height: 128,
+                    rawValueToMeters: 0.001,
+                    buffer: { type: 'cpu', handle: 'depth-buffer' },
+                    confidence: 1.2
+                }
+            },
+            scene: {
+                hitTests: {
+                    timestamp: 12,
+                    space: { type: 'viewer' },
+                    results: [
+                        {
+                            rayId: 'ray-alpha',
+                            space: { type: 'local', id: 'origin' },
+                            pose: {
+                                position: { x: 0, y: 1, z: 0 },
+                                orientation: { x: 0, y: 0, z: 0, w: 1 }
+                            },
+                            distance: 1.1,
+                            timestamp: 12
+                        }
+                    ]
+                },
+                anchors: {
+                    timestamp: 12,
+                    space: { type: 'local' },
+                    anchors: [
+                        {
+                            id: 'anchor-a',
+                            space: { type: 'local', id: 'origin' },
+                            pose: {
+                                position: { x: 0.1, y: 0.2, z: 0.3 },
+                                orientation: { x: 0, y: 0, z: 0, w: 1 }
+                            },
+                            lastChangedTime: 12
+                        }
+                    ]
+                }
+            },
+            quality: {
+                overall: 0.64,
+                scene: 0.7,
+                scenePlanes: 0.68,
+                depth: 0.73,
+                hitTests: 0.72,
+                anchors: 0.74
+            },
+            sceneConfidence: 0.71
+        };
+
+        const normalized = adapter.normalizeSample(raw);
+        expect(normalized.confidence).toBeCloseTo(0.64, 5);
+        expect(normalized.payload.deviceId).toBe('visor-spatial');
+        expect(normalized.payload.spatial?.planes?.confidence).toBeCloseTo(0.66, 5);
+        expect(normalized.payload.spatial?.depth?.confidence).toBeLessThanOrEqual(1);
+        expect(normalized.payload.spatial?.hitTests?.payload?.results).toHaveLength(1);
+        expect(normalized.payload.spatial?.anchors?.payload?.anchors).toHaveLength(1);
+
+        const registry = new SensorSchemaRegistry();
+        const { payload: sanitized, issues } = registry.validate('wearable.ar-visor', normalized.payload);
+
+        expect(issues).toHaveLength(0);
+        expect(sanitized.channels['spatial.planes'].payload.planes).toHaveLength(1);
+        expect(sanitized.channels['spatial.depth'].payload.format).toBe('r16u');
+        expect(sanitized.channels['spatial.hit-tests'].payload.results).toHaveLength(1);
+        expect(sanitized.channels['spatial.anchors'].payload.anchors).toHaveLength(1);
+    });
+});
+
+describe('SensoryInputBridge history and wearable snapshots', () => {
+    it('retains bounded channel history and publishes wearable snapshots', () => {
+        const bridge = new SensoryInputBridge({
+            autoConnectAdapters: false,
+            confidenceThreshold: 0,
+            channelHistoryLimit: 2
+        });
+
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.1, y: 0.2, depth: 0.3 } });
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.4, y: 0.5, depth: 0.6 } });
+        bridge.processSample('eye-tracking', { confidence: 0.9, payload: { x: 0.8, y: 0.9, depth: 0.2 } });
+
+        const history = bridge.getChannelHistory('eye-tracking');
+        expect(history).toHaveLength(2);
+        expect(history[0].payload.x).toBeCloseTo(0.4, 5);
+        expect(history[1].payload.x).toBeCloseTo(0.8, 5);
+
+        const wearablePayload = {
+            deviceId: 'visor-history',
+            channels: {
+                'eye-tracking': { confidence: 0.6, payload: { x: 0.25, y: 0.5, depth: 0.4 } }
+            },
+            metadata: { batteryLevel: 0.9 }
+        };
+
+        const updates = [];
+        const globalUpdates = [];
+        bridge.subscribe('wearable.ar-visor:update', snapshot => updates.push(snapshot));
+        bridge.subscribe('wearable:update', snapshot => globalUpdates.push(snapshot));
+
+        bridge.processSample('wearable.ar-visor', { confidence: 0.82, payload: wearablePayload });
+
+        const snapshot = bridge.getWearableSnapshot('wearable.ar-visor', 'visor-history');
+        expect(snapshot?.channels['eye-tracking'].payload.x).toBeCloseTo(0.25, 5);
+        expect(snapshot?.metadata?.batteryLevel).toBeCloseTo(0.9, 5);
+        expect(bridge.listWearableDevices('wearable.ar-visor')).toContain('visor-history');
+
+        const wearableHistory = bridge.getWearableHistory('wearable.ar-visor');
+        expect(wearableHistory).toHaveLength(1);
+        expect(wearableHistory[0].composite.channels['eye-tracking'].payload.depth).toBeCloseTo(0.4, 5);
+
+        expect(updates).toHaveLength(1);
+        expect(globalUpdates).toHaveLength(1);
+        expect(globalUpdates[0].type).toBe('wearable.ar-visor');
+    });
+});
+
+describe('WearableDeviceManager orchestration', () => {
+    it('relays composite updates to subscribers and exposes snapshots', () => {
+        const bridge = new SensoryInputBridge({
+            autoConnectAdapters: false,
+            confidenceThreshold: 0,
+            channelHistoryLimit: 3
+        });
+        const manager = new WearableDeviceManager({ bridge });
+
+        const adapter = {
+            read: vi.fn()
+        };
+        manager.registerAdapter('wearable.neural-band', adapter);
+
+        const updates = [];
+        const unsubscribe = manager.subscribeToDevice('wearable.neural-band', 'band-x', snapshot => {
+            updates.push(snapshot);
+        });
+
+        manager.ingest('wearable.neural-band', {
+            deviceId: 'band-x',
+            channels: {
+                'neural-intent': {
+                    confidence: 0.85,
+                    payload: { x: 0.12, y: -0.1, z: 0.05, w: 0.9, engagement: 0.75 }
+                }
+            },
+            metadata: { signalQuality: { overall: 0.92 } }
+        }, 0.88);
+
+        expect(updates).toHaveLength(1);
+        expect(updates[0].type).toBe('wearable.neural-band');
+        expect(updates[0].metadata.signalQuality.overall).toBeCloseTo(0.92, 5);
+
+        const snapshot = manager.getDeviceSnapshot('wearable.neural-band', 'band-x');
+        expect(snapshot).not.toBeNull();
+        expect(snapshot.channels['neural-intent'].payload.w).toBeCloseTo(0.9, 5);
+
+        unsubscribe();
+
+        manager.ingest('wearable.neural-band', {
+            deviceId: 'band-x',
+            channels: {
+                'neural-intent': {
+                    confidence: 0.5,
+                    payload: { x: 0.3, y: 0.1, z: 0.15, w: 0.6, engagement: 0.5 }
+                }
+            }
+        }, 0.6);
+
+        expect(updates).toHaveLength(1);
+        expect(manager.listDevices('wearable.neural-band')).toContain('band-x');
+
+        const history = manager.getDeviceHistory('wearable.neural-band');
+        expect(history.length).toBeGreaterThanOrEqual(2);
+        expect(history[history.length - 1].composite.channels['neural-intent'].payload.w).toBeCloseTo(0.6, 5);
+    });
+});
+

--- a/types/adaptive-sdk.d.ts
+++ b/types/adaptive-sdk.d.ts
@@ -26,6 +26,542 @@ export interface SensorAdapter<TPayload = unknown> {
   test?(): Promise<boolean> | boolean;
 }
 
+export interface SpatialVector3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface SpatialQuaternion {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+export type SpatialSpaceType =
+  | 'viewer'
+  | 'local'
+  | 'local-floor'
+  | 'bounded-floor'
+  | 'unbounded'
+  | 'stage'
+  | 'device'
+  | 'custom';
+
+export interface SpatialPose {
+  position: SpatialVector3;
+  orientation: SpatialQuaternion;
+}
+
+export interface SpatialSpaceReference {
+  type: SpatialSpaceType;
+  id: string | null;
+  pose?: SpatialPose;
+}
+
+export type SpatialTrackingState = 'tracked' | 'emulated' | 'paused' | 'unknown';
+
+export type SpatialPlaneAlignment = 'horizontal' | 'vertical' | 'slanted' | 'unknown';
+
+export type SpatialPlaneClassification =
+  | 'floor'
+  | 'ceiling'
+  | 'wall'
+  | 'table'
+  | 'seat'
+  | 'screen'
+  | 'platform'
+  | 'unknown';
+
+export interface SpatialPlane {
+  id: string;
+  space: SpatialSpaceReference;
+  pose: SpatialPose;
+  alignment: SpatialPlaneAlignment;
+  extent: { width: number; height: number };
+  polygon?: SpatialVector3[];
+  lastChangedTime: number;
+  trackingState?: SpatialTrackingState;
+  classification?: SpatialPlaneClassification;
+}
+
+export interface SpatialPlaneCollection {
+  timestamp: number;
+  space: SpatialSpaceReference;
+  planes: SpatialPlane[];
+  removedIds?: string[];
+}
+
+export interface SpatialDepthBufferDescriptor {
+  type: 'cpu' | 'gpu';
+  handle: string | null;
+  format?: string | null;
+  usage?: string | null;
+}
+
+export interface SpatialCameraIntrinsics {
+  fx?: number;
+  fy?: number;
+  cx?: number;
+  cy?: number;
+}
+
+export interface SpatialDepthBuffer {
+  timestamp: number;
+  space: SpatialSpaceReference;
+  viewId?: string | null;
+  format: string;
+  width: number;
+  height: number;
+  rawValueToMeters: number;
+  near?: number | null;
+  far?: number | null;
+  intrinsics?: SpatialCameraIntrinsics;
+  buffer: SpatialDepthBufferDescriptor;
+  confidence?: number | null;
+}
+
+export interface SpatialRay {
+  origin: SpatialVector3;
+  direction: SpatialVector3;
+}
+
+export type SpatialHitTestEntityType = 'plane' | 'mesh' | 'point' | 'feature-point' | 'unknown';
+export type SpatialHitTestResultType = SpatialHitTestEntityType;
+export type SpatialInputHandedness = 'none' | 'left' | 'right';
+
+export interface SpatialHitTestResultInputSource {
+  handedness?: SpatialInputHandedness;
+  targetRaySpace?: string | null;
+  profiles?: string[];
+}
+
+export interface SpatialHitTestRay {
+  id: string;
+  space: SpatialSpaceReference;
+  offsetRay: SpatialRay;
+  entityTypes: SpatialHitTestEntityType[];
+  targetRaySpace?: string | null;
+  handedness?: SpatialInputHandedness;
+  transient: boolean;
+  profile?: string | null;
+  initialResults?: SpatialHitTestResult[];
+}
+
+export interface SpatialHitTestResult {
+  rayId: string;
+  space: SpatialSpaceReference;
+  pose: SpatialPose;
+  transformMatrix?: number[] | null;
+  distance: number;
+  timestamp: number;
+  type?: SpatialHitTestResultType;
+  normal?: SpatialVector3;
+  anchors?: string[];
+  inputSource?: SpatialHitTestResultInputSource;
+  confidence?: number | null;
+}
+
+export interface SpatialHitTestResultCollection {
+  timestamp: number;
+  space: SpatialSpaceReference;
+  results: SpatialHitTestResult[];
+}
+
+export interface SpatialAnchor {
+  id: string;
+  space: SpatialSpaceReference;
+  pose: SpatialPose;
+  lastChangedTime: number;
+  trackingState?: SpatialTrackingState;
+  accuracy?: number | null;
+  associatedRayId?: string | null;
+  classification?: SpatialPlaneClassification;
+  confidence?: number | null;
+}
+
+export interface SpatialAnchorCollection {
+  timestamp: number;
+  space: SpatialSpaceReference;
+  anchors: SpatialAnchor[];
+  removedIds?: string[];
+}
+
+export interface QuaternionClusterBlendResult {
+  orientation: SpatialQuaternion;
+  confidence?: number | null;
+  position?: SpatialVector3 | null;
+  weight: number;
+  sampleCount: number;
+  variance?: number | null;
+  averageDistance?: number | null;
+  space?: SpatialSpaceReference | null;
+}
+
+export interface AnchorClusterReducerOptions {
+  space?: SpatialSpaceReference | null;
+}
+
+export type AnchorClusterReducer = (
+  anchors: ReadonlyArray<SpatialAnchor>,
+  options?: AnchorClusterReducerOptions
+) => QuaternionClusterBlendResult | null;
+
+export interface HitTestClusterReducerOptions {
+  space?: SpatialSpaceReference | null;
+  distanceFalloff?: number;
+}
+
+export type HitTestClusterReducer = (
+  results: ReadonlyArray<SpatialHitTestResult>,
+  options?: HitTestClusterReducerOptions
+) => (QuaternionClusterBlendResult & { averageDistance?: number | null }) | null;
+
+export interface QuaternionSample {
+  orientation?: SpatialQuaternion;
+  quaternion?: SpatialQuaternion;
+  weight?: number;
+  confidence?: number;
+}
+
+export interface QuaternionAverageOptions {
+  fallbackIdentity?: boolean;
+}
+
+export function averageQuaternionSamples(
+  samples: ReadonlyArray<QuaternionSample>,
+  options?: QuaternionAverageOptions
+): SpatialQuaternion | null;
+
+export function blendAnchorCluster(
+  anchors: ReadonlyArray<SpatialAnchor>,
+  options?: AnchorClusterReducerOptions
+): QuaternionClusterBlendResult | null;
+
+export function blendHitTestCluster(
+  results: ReadonlyArray<SpatialHitTestResult>,
+  options?: HitTestClusterReducerOptions
+): (QuaternionClusterBlendResult & { averageDistance?: number | null }) | null;
+
+export interface QuaternionToolkit {
+  averageQuaternionSamples: typeof averageQuaternionSamples;
+  blendAnchorCluster: typeof blendAnchorCluster;
+  blendHitTestCluster: typeof blendHitTestCluster;
+}
+
+export const QuaternionClusterToolkit: QuaternionToolkit;
+
+export class SensorSchemaRegistry {
+  constructor(options?: {
+    registerDefaults?: boolean;
+    schemas?: Array<[string, SensorSchema]> | Record<string, SensorSchema>;
+  });
+  register(type: string, schema: SensorSchema): void;
+  loadCustomSchemas(
+    schemas: Array<[string, SensorSchema]> | Record<string, SensorSchema> | undefined
+  ): void;
+  validate<TInput = Record<string, unknown>, TNormalized = TInput>(
+    type: string,
+    payload: TInput
+  ): SensorSchemaNormalizationResult<TNormalized>;
+}
+
+export interface WearableChannelSample<TPayload = Record<string, unknown>> {
+  payload: TPayload;
+  confidence?: number;
+}
+
+export interface WearableCompositePayload<TChannels extends Record<string, WearableChannelSample> = Record<string, WearableChannelSample>> {
+  deviceId: string;
+  firmwareVersion?: string | null;
+  channels: TChannels;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ARVisorSpatialChannels {
+  'spatial.planes'?: WearableChannelSample<SpatialPlaneCollection>;
+  'spatial.depth'?: WearableChannelSample<SpatialDepthBuffer>;
+  'spatial.hit-tests'?: WearableChannelSample<SpatialHitTestResultCollection>;
+  'spatial.anchors'?: WearableChannelSample<SpatialAnchorCollection>;
+}
+
+export type ARVisorWearableChannels = Record<string, WearableChannelSample> & ARVisorSpatialChannels;
+
+export type ARVisorWearableComposite = WearableCompositePayload<ARVisorWearableChannels>;
+
+export interface WearableTelemetryHarness {
+  track?(
+    event: string,
+    payload?: Record<string, unknown>,
+    options?: { classification?: string }
+  ): void;
+  recordAudit?(
+    event: string,
+    payload?: Record<string, unknown>,
+    classification?: string
+  ): void;
+}
+
+export interface WearableTransport<TRawSample = Record<string, unknown>> {
+  connect?(): Promise<void> | void;
+  disconnect?(): Promise<void> | void;
+  nextSample?(): Promise<TRawSample | null | undefined> | TRawSample | null | undefined;
+  read?(): Promise<TRawSample | null | undefined> | TRawSample | null | undefined;
+  reset?(): void;
+}
+
+export interface BaseWearableDeviceAdapterOptions<TRawSample = Record<string, unknown>> {
+  deviceId?: string;
+  firmwareVersion?: string | null;
+  telemetry?: WearableTelemetryHarness | null;
+  telemetryScope?: string;
+  telemetryClassification?: string;
+  licenseManager?: LicenseManager | null;
+  requiredLicenseFeature?: string | null;
+  schemaType?: string;
+  defaultConfidence?: number;
+  sampleProvider?: () => Promise<TRawSample | null | undefined> | TRawSample | null | undefined;
+  transport?: WearableTransport<TRawSample> | null;
+  trace?: Array<TRawSample | (() => TRawSample | Promise<TRawSample>)>;
+  traceLoop?: boolean;
+  recordTelemetryMetadata?: boolean;
+}
+
+export class BaseWearableDeviceAdapter<TComposite extends WearableCompositePayload = WearableCompositePayload>
+  implements SensorAdapter<TComposite>
+{
+  constructor(options?: BaseWearableDeviceAdapterOptions);
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  read(): Promise<SensorAdapterSample<TComposite> | null>;
+  normalizeSample(
+    raw: Record<string, unknown>
+  ): { confidence?: number; payload?: Partial<TComposite> } | null;
+}
+
+export interface ARVisorWearableAdapterOptions extends BaseWearableDeviceAdapterOptions {
+  defaultFieldOfView?: { horizontal?: number; vertical?: number; diagonal?: number };
+  requiredLicenseFeature?: string;
+}
+
+export class ARVisorWearableAdapter extends BaseWearableDeviceAdapter {
+  constructor(options?: ARVisorWearableAdapterOptions);
+}
+
+export interface NeuralBandWearableAdapterOptions extends BaseWearableDeviceAdapterOptions {
+  requiredLicenseFeature?: string;
+}
+
+export class NeuralBandWearableAdapter extends BaseWearableDeviceAdapter {
+  constructor(options?: NeuralBandWearableAdapterOptions);
+}
+
+export interface BiometricWristWearableAdapterOptions extends BaseWearableDeviceAdapterOptions {
+  requiredLicenseFeature?: string;
+}
+
+export class BiometricWristWearableAdapter extends BaseWearableDeviceAdapter {
+  constructor(options?: BiometricWristWearableAdapterOptions);
+}
+
+export interface SensoryInputBridgeOptions {
+  pollingInterval?: number;
+  decayHalfLife?: number;
+  confidenceThreshold?: number;
+  schemaRegistry?: SensorSchemaRegistry;
+  schemas?: Array<[string, SensorSchema]> | Record<string, SensorSchema>;
+  issueReporter?: (
+    entry: {
+      type: string;
+      issues: SensorSchemaIssue[];
+      payload: Record<string, unknown>;
+      timestamp: number;
+    }
+  ) => void;
+  autoConnectAdapters?: boolean;
+  validationLogLimit?: number;
+  timeSource?: () => number;
+  channelHistoryLimit?: number;
+  wearableHistoryLimit?: number;
+}
+
+export interface WearableSnapshot<TComposite extends WearableCompositePayload = WearableCompositePayload> {
+  type: string;
+  deviceId: string;
+  timestamp: number;
+  confidence: number;
+  firmwareVersion: string | null;
+  composite: TComposite;
+  metadata?: Record<string, unknown> | null;
+  channels?: Record<string, WearableChannelSample>;
+}
+
+export class SensoryInputBridge {
+  constructor(options?: SensoryInputBridgeOptions);
+  registerAdapter(type: string, adapter: SensorAdapter): void;
+  connectAdapter(type: string): Promise<void>;
+  disconnectAdapter(type: string): Promise<void>;
+  testAdapter(type: string): Promise<boolean>;
+  connectAllAdapters(): Promise<void>;
+  disconnectAllAdapters(): Promise<void>;
+  subscribe(channel: string, callback: (payload: unknown) => void): () => void;
+  ingest(type: string, payload: unknown, confidence?: number): void;
+  start(): void;
+  stop(): void;
+  processSample(type: string, sample: SensorAdapterSample): void;
+  getSnapshot(): Record<string, unknown>;
+  registerSchema(type: string, schema: SensorSchema): void;
+  getSchemaRegistry(): SensorSchemaRegistry;
+  setValidationReporter(
+    reporter?: (
+      entry: {
+        type: string;
+        issues: SensorSchemaIssue[];
+        payload: Record<string, unknown>;
+        timestamp: number;
+      }
+    ) => void
+  ): void;
+  getValidationLog(): Array<{
+    type: string;
+    issues: SensorSchemaIssue[];
+    payload: Record<string, unknown>;
+    timestamp: number;
+  }>;
+  getAdapterState(type: string): { status: string; lastError: unknown } | undefined;
+  getChannelHistory(type: string): SensorAdapterSample[];
+  setChannelHistoryLimit(limit: number): void;
+  getWearableSnapshot(type: string, deviceId: string): WearableSnapshot | null;
+  listWearableDevices(type: string): string[];
+  getWearableHistory(type: string): WearableSnapshot[];
+}
+
+export interface WearableDeviceManagerOptions {
+  bridge?: SensoryInputBridge;
+  autoStart?: boolean;
+  historyLimit?: number;
+  wearableHistoryLimit?: number;
+  bridgeOptions?: SensoryInputBridgeOptions;
+}
+
+export class WearableDeviceManager {
+  constructor(options?: WearableDeviceManagerOptions);
+  getBridge(): SensoryInputBridge;
+  registerAdapter(type: string, adapter: SensorAdapter): SensorAdapter;
+  unregisterAdapter(type: string): void;
+  start(): void;
+  stop(): void;
+  subscribeToDevice(
+    type: string,
+    deviceId: string,
+    callback: (snapshot: WearableSnapshot & { type: string }) => void
+  ): () => void;
+  getDeviceSnapshot(type: string, deviceId: string): (WearableSnapshot & { type: string }) | null;
+  listDevices(type: string): string[];
+  getDeviceHistory(type: string): WearableSnapshot[];
+  ingest(type: string, payload: unknown, confidence?: number): void;
+}
+
+export interface ShaderQuaternionSynchronizerLogger {
+  warn?: (message?: any, ...optionalParams: any[]) => void;
+}
+
+export interface ShaderQuaternionSynchronizerOptions {
+  bridge: SensoryInputBridge;
+  systems?: Record<string, unknown>;
+  systemResolver?: (name: string) => unknown;
+  rotationScale?: number;
+  minConfidence?: number;
+  baseAlpha?: number;
+  energySmoothing?: number;
+  velocityReference?: number;
+  logger?: ShaderQuaternionSynchronizerLogger;
+  anchorReducer?: AnchorClusterReducer;
+  hitTestReducer?: HitTestClusterReducer;
+}
+
+export interface ShaderQuaternionOrientationContext {
+  confidence?: number;
+  timestamp?: number;
+  source?: string;
+  metadata?: ShaderQuaternionOrientationMetadata | null;
+}
+
+export interface ShaderQuaternionOrientationMetadata {
+  anchorCluster?: QuaternionClusterBlendResult | null;
+  hitTestCluster?: (QuaternionClusterBlendResult & { averageDistance?: number | null }) | null;
+  [key: string]: unknown;
+}
+
+export interface ShaderQuaternionSynchronizerSystemState {
+  system: string;
+  parameters: Record<string, number>;
+  confidence: number;
+  motionEnergy: number;
+  euler: { roll: number; pitch: number; yaw: number };
+}
+
+export interface ShaderQuaternionSynchronizerUpdate {
+  quaternion: SpatialQuaternion;
+  euler: { roll: number; pitch: number; yaw: number };
+  motionEnergy: number;
+  confidence: number;
+  timestamp: number;
+  source: string | null;
+  systems: ShaderQuaternionSynchronizerSystemState[];
+  metadata: ShaderQuaternionOrientationMetadata | null;
+}
+
+export class ShaderQuaternionSynchronizer {
+  constructor(options: ShaderQuaternionSynchronizerOptions);
+  start(): this;
+  stop(): void;
+  setEnabled(enabled: boolean): void;
+  applyOrientation(
+    quaternion: SpatialQuaternion,
+    context?: ShaderQuaternionOrientationContext
+  ): void;
+  addObserver(
+    observer: (update: ShaderQuaternionSynchronizerUpdate) => void
+  ): () => void;
+  removeObserver(observer: (update: ShaderQuaternionSynchronizerUpdate) => void): void;
+  clearObservers(): void;
+}
+
+export interface ShaderQuaternionDiagnosticsOverlayFormatOptions {
+  angleDecimals?: number;
+  energyDecimals?: number;
+  confidenceDecimals?: number;
+}
+
+export interface ShaderQuaternionDiagnosticsOverlayOptions {
+  synchronizer: ShaderQuaternionSynchronizer;
+  container?: HTMLElement | string | null;
+  document?: Document;
+  theme?: 'dark' | 'light';
+  format?: ShaderQuaternionDiagnosticsOverlayFormatOptions;
+}
+
+export interface CreateShaderQuaternionDiagnosticsOverlayOptions
+  extends Partial<Omit<ShaderQuaternionDiagnosticsOverlayOptions, 'synchronizer'>> {
+  synchronizer?: ShaderQuaternionSynchronizer;
+  synchronizerOptions?: Omit<ShaderQuaternionSynchronizerOptions, 'bridge'> & {
+    systems?: Record<string, unknown>;
+    systemResolver?: (name: string) => unknown;
+  };
+  autoMount?: boolean;
+}
+
+export class ShaderQuaternionDiagnosticsOverlay {
+  constructor(options: ShaderQuaternionDiagnosticsOverlayOptions);
+  mount(): this;
+  unmount(): void;
+  render(payload: ShaderQuaternionSynchronizerUpdate): void;
+}
+
+export default WearableDeviceManager;
+
 export interface TelemetryConsentMap {
   [classification: string]: boolean;
 }
@@ -512,6 +1048,18 @@ export interface AdaptiveSDK {
   projectionSimulator: ProjectionScenarioSimulator;
   licenseManager?: LicenseManager;
   licenseAttestor?: RemoteLicenseAttestor;
+  ShaderQuaternionSynchronizer: typeof ShaderQuaternionSynchronizer;
+  ShaderQuaternionDiagnosticsOverlay: typeof ShaderQuaternionDiagnosticsOverlay;
+  quaternionToolkit: QuaternionToolkit;
+  createShaderQuaternionSynchronizer(
+    options?: Omit<ShaderQuaternionSynchronizerOptions, 'bridge'> & {
+      systems?: Record<string, unknown>;
+      systemResolver?: (name: string) => unknown;
+    }
+  ): ShaderQuaternionSynchronizer;
+  createShaderQuaternionDiagnosticsOverlay(
+    options?: CreateShaderQuaternionDiagnosticsOverlayOptions
+  ): ShaderQuaternionDiagnosticsOverlay;
   registerLayoutStrategy(strategy: any): any;
   registerLayoutAnnotation(annotation: any): any;
   registerTelemetryProvider(provider: any): any;
@@ -1273,6 +1821,72 @@ declare module '../src/ui/adaptive/renderers/LayoutBlueprintRenderer.js' {
     LayoutBlueprintZoneSummary,
     LayoutBlueprintMotion,
     LayoutBlueprintMotionBias,
+  };
+}
+
+declare module './src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js' {
+  export {
+    ShaderQuaternionSynchronizer,
+    ShaderQuaternionSynchronizerOptions,
+    ShaderQuaternionOrientationContext,
+    ShaderQuaternionOrientationMetadata,
+    ShaderQuaternionSynchronizerLogger,
+    ShaderQuaternionSynchronizerUpdate,
+    ShaderQuaternionSynchronizerSystemState,
+    ShaderQuaternionDiagnosticsOverlay,
+    ShaderQuaternionDiagnosticsOverlayOptions,
+    ShaderQuaternionDiagnosticsOverlayFormatOptions,
+    CreateShaderQuaternionDiagnosticsOverlayOptions,
+  };
+}
+
+declare module '../src/ui/adaptive/renderers/ShaderQuaternionSynchronizer.js' {
+  export {
+    ShaderQuaternionSynchronizer,
+    ShaderQuaternionSynchronizerOptions,
+    ShaderQuaternionOrientationContext,
+    ShaderQuaternionOrientationMetadata,
+    ShaderQuaternionSynchronizerLogger,
+    ShaderQuaternionSynchronizerUpdate,
+    ShaderQuaternionSynchronizerSystemState,
+    ShaderQuaternionDiagnosticsOverlay,
+    ShaderQuaternionDiagnosticsOverlayOptions,
+    ShaderQuaternionDiagnosticsOverlayFormatOptions,
+    CreateShaderQuaternionDiagnosticsOverlayOptions,
+  };
+}
+
+declare module './src/ui/adaptive/renderers/QuaternionClusterToolkit.js' {
+  export {
+    QuaternionClusterToolkit,
+    QuaternionToolkit,
+    QuaternionClusterBlendResult,
+    AnchorClusterReducer,
+    AnchorClusterReducerOptions,
+    HitTestClusterReducer,
+    HitTestClusterReducerOptions,
+    QuaternionSample,
+    QuaternionAverageOptions,
+    averageQuaternionSamples,
+    blendAnchorCluster,
+    blendHitTestCluster,
+  };
+}
+
+declare module '../src/ui/adaptive/renderers/QuaternionClusterToolkit.js' {
+  export {
+    QuaternionClusterToolkit,
+    QuaternionToolkit,
+    QuaternionClusterBlendResult,
+    AnchorClusterReducer,
+    AnchorClusterReducerOptions,
+    HitTestClusterReducer,
+    HitTestClusterReducerOptions,
+    QuaternionSample,
+    QuaternionAverageOptions,
+    averageQuaternionSamples,
+    blendAnchorCluster,
+    blendHitTestCluster,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a reusable quaternion cluster toolkit to blend anchor and hit-test samples with weighted quaternion averaging and expose the helpers through the Adaptive SDK typings
- integrate the cluster reducers into ShaderQuaternionSynchronizer so spatial events emit blended orientations and observer metadata, and extend vitest coverage for cluster blending and diagnostics payloads
- document the new toolkit in the quaternion research brief and log the spatial execution turn in the wearables roadmap

## Testing
- `npx vitest run tests/vitest/quaternion-cluster-toolkit.test.js tests/vitest/shader-quaternion-sync.test.js tests/vitest/shader-quaternion-diagnostics.test.js` *(fails: vitest dependency is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e947fe80b883299276fde55e59b349