### PR TITLE
Enhance adaptive SDK CLI and add tests

### DIFF
--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/cli/runAdaptiveSdkCli.js'));
+
+function resolveMainExport(moduleNamespace) {
+  if (!moduleNamespace) {
+    return null;
+  }
+
+  if (typeof moduleNamespace === 'function') {
+    return moduleNamespace;
+  }
+
+  if (typeof moduleNamespace.main === 'function') {
+    return moduleNamespace.main;
+  }
+
+  if (typeof moduleNamespace.default === 'function') {
+    return moduleNamespace.default;
+  }
+
+  if (moduleNamespace.default && typeof moduleNamespace.default.main === 'function') {
+    return moduleNamespace.default.main;
+  }
+
+  return null;
+}
+
+(async () => {
+  try {
+    const importedModule = await import(moduleUrl.href);
+    const main = resolveMainExport(importedModule);
+
+    if (typeof main !== 'function') {
+      throw new Error('runAdaptiveSdkCli.js does not export a main function');
+    }
+
+    const result = await main();
+
+    if (result && typeof result.exitCode === 'number') {
+      process.exitCode = result.exitCode;
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,106 @@
+class CliUsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CliUsageError';
+  }
+}
+
+function writeLine(stream, message = '') {
+  stream.write(`${message}\n`);
+}
+
+async function main(options = {}) {
+  const {
+    argv = process.argv.slice(2),
+    stdout = process.stdout,
+    stderr = process.stderr,
+    now = () => new Date()
+  } = options;
+
+  const [command, ...args] = argv;
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp(stdout);
+    return { exitCode: 0 };
+  }
+
+  switch (command) {
+    case 'status':
+      try {
+        const report = await handleStatus(args, stdout, now);
+        return { exitCode: 0, report };
+      } catch (error) {
+        if (error instanceof CliUsageError) {
+          writeLine(stderr, error.message);
+          return { exitCode: 1 };
+        }
+        throw error;
+      }
+    default:
+      writeLine(stderr, `Unknown command: ${command}`);
+      printHelp(stdout);
+      return { exitCode: 1 };
+  }
+}
+
+async function handleStatus(args, stdout, now) {
+  const { demoMode, environment } = parseStatusArguments(args);
+
+  const statusReport = {
+    mode: demoMode ? 'demo' : 'standard',
+    environment,
+    timestamp: now().toISOString(),
+    services: {
+      holographicRenderer: 'operational',
+      adaptiveLayoutEngine: 'operational',
+      commercializationTelemetry: 'operational'
+    }
+  };
+
+  writeLine(stdout, 'Adaptive SDK status report');
+  writeLine(stdout, JSON.stringify(statusReport, null, 2));
+
+  return statusReport;
+}
+
+function parseStatusArguments(args) {
+  let demoMode = false;
+  let environment = 'production';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--demo') {
+      demoMode = true;
+      continue;
+    }
+
+    if (arg === '--env') {
+      const envName = args[index + 1];
+      if (!envName) {
+        throw new CliUsageError('Missing value for --env option.');
+      }
+      environment = envName;
+      index += 1;
+      continue;
+    }
+
+    throw new CliUsageError(`Unknown option for status command: ${arg}`);
+  }
+
+  return { demoMode, environment };
+}
+
+function printHelp(stdout) {
+  writeLine(stdout, 'Adaptive SDK CLI');
+  writeLine(stdout, 'Usage: adaptive-sdk-cli <command> [options]');
+  writeLine(stdout);
+  writeLine(stdout, 'Commands:');
+  writeLine(stdout, '  status [--demo] [--env <name>]  Display the SDK service status summary.');
+  writeLine(stdout);
+  writeLine(stdout, 'Options:');
+  writeLine(stdout, '  -h, --help                      Show this message.');
+}
+
+module.exports = { main };
+module.exports.default = main;

--- a/tests/cli/runAdaptiveSdkCli.test.js
+++ b/tests/cli/runAdaptiveSdkCli.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { main } from '../../src/cli/runAdaptiveSdkCli.js';
+
+function createWritableBuffer() {
+  let buffer = '';
+  return {
+    write(chunk = '') {
+      buffer += chunk;
+    },
+    toString() {
+      return buffer;
+    }
+  };
+}
+
+describe('runAdaptiveSdkCli', () => {
+  it('prints a demo status report and returns exit code 0', async () => {
+    const stdout = createWritableBuffer();
+    const stderr = createWritableBuffer();
+
+    const { exitCode, report } = await main({
+      argv: ['status', '--demo', '--env', 'staging'],
+      stdout,
+      stderr,
+      now: () => new Date('2025-01-02T03:04:05.678Z')
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr.toString()).toBe('');
+    expect(report).toEqual({
+      mode: 'demo',
+      environment: 'staging',
+      timestamp: '2025-01-02T03:04:05.678Z',
+      services: {
+        holographicRenderer: 'operational',
+        adaptiveLayoutEngine: 'operational',
+        commercializationTelemetry: 'operational'
+      }
+    });
+
+    const output = stdout.toString();
+    expect(output).toContain('Adaptive SDK status report');
+
+    const [, ...jsonLines] = output.trim().split('\n');
+    const parsedReport = JSON.parse(jsonLines.join('\n'));
+    expect(parsedReport).toEqual(report);
+  });
+
+  it('prints help when no command is provided', async () => {
+    const stdout = createWritableBuffer();
+    const stderr = createWritableBuffer();
+
+    const { exitCode } = await main({ argv: [], stdout, stderr });
+
+    expect(exitCode).toBe(0);
+    expect(stderr.toString()).toBe('');
+    expect(stdout.toString()).toContain('Usage: adaptive-sdk-cli <command> [options]');
+  });
+
+  it('reports an error when using an unknown command', async () => {
+    const stdout = createWritableBuffer();
+    const stderr = createWritableBuffer();
+
+    const { exitCode } = await main({ argv: ['unknown'], stdout, stderr });
+
+    expect(exitCode).toBe(1);
+    expect(stderr.toString()).toContain('Unknown command: unknown');
+    expect(stdout.toString()).toContain('Commands:');
+  });
+
+  it('reports an error when the env option is missing a value', async () => {
+    const stdout = createWritableBuffer();
+    const stderr = createWritableBuffer();
+
+    const { exitCode } = await main({ argv: ['status', '--env'], stdout, stderr });
+
+    expect(exitCode).toBe(1);
+    expect(stderr.toString()).toContain('Missing value for --env option.');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    include: ['tests/vitest/**/*.test.js'],
+    environmentMatchGlobs: [['tests/cli/**/*.test.js', 'node']],
+    include: ['tests/vitest/**/*.test.js', 'tests/cli/**/*.test.js'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html']


### PR DESCRIPTION
## Summary
- harden the CommonJS bootstrap so it resolves the CLI main export consistently and propagates exit codes
- refactor the Adaptive SDK CLI runner for injectable I/O, better option parsing, and clearer error reporting
- add focused Vitest coverage for the CLI and update the Vitest config to include the new test suite

## Testing
- npx vitest run tests/cli/runAdaptiveSdkCli.test.js
- node bin/adaptive-sdk-cli.js status --demo --env staging

------
https://chatgpt.com/codex/tasks/task_e_68edd6df67e48329827f76c44fd22c17