### PR TITLE
Simplify adaptive SDK CLI bootstrap

### DIFF
--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/cli/runAdaptiveSdkCli.js')).href;
+
+(async () => {
+  try {
+    const moduleNamespace = await import(moduleUrl);
+    const main = typeof moduleNamespace.main === 'function'
+      ? moduleNamespace.main
+      : typeof moduleNamespace.default === 'function'
+        ? moduleNamespace.default
+        : null;
+
+    if (!main) {
+      throw new Error('runAdaptiveSdkCli.js must export a main function.');
+    }
+
+    const exitCode = await main();
+    if (typeof exitCode === 'number') {
+      process.exitCode = exitCode;
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,75 @@
+function main() {
+  const args = process.argv.slice(2);
+  const [command, ...commandArgs] = args;
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return 0;
+  }
+
+  if (command !== 'status') {
+    console.error(`Unknown command: ${command}`);
+    printHelp();
+    return 1;
+  }
+
+  const { demoMode, environment, error } = parseStatusOptions(commandArgs);
+  if (error) {
+    console.error(error);
+    return 1;
+  }
+
+  printStatus({ demoMode, environment });
+  return 0;
+}
+
+function parseStatusOptions(args) {
+  let demoMode = false;
+  let environment = 'production';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--demo') {
+      demoMode = true;
+      continue;
+    }
+
+    if (arg === '--env') {
+      const envName = args[index + 1];
+      if (!envName) {
+        return { error: 'Missing value for --env option.' };
+      }
+      environment = envName;
+      index += 1;
+      continue;
+    }
+
+    return { error: `Unknown option: ${arg}` };
+  }
+
+  return { demoMode, environment };
+}
+
+function printStatus({ demoMode, environment }) {
+  const timestamp = new Date().toISOString();
+
+  console.log('Adaptive SDK status');
+  console.log(`  Mode: ${demoMode ? 'demo' : 'standard'}`);
+  console.log(`  Environment: ${environment}`);
+  console.log(`  Timestamp: ${timestamp}`);
+}
+
+function printHelp() {
+  console.log('Adaptive SDK CLI');
+  console.log('Usage: adaptive-sdk-cli <command> [options]');
+  console.log('');
+  console.log('Commands:');
+  console.log('  status [--demo] [--env <name>]  Display the SDK service status summary.');
+  console.log('');
+  console.log('Options:');
+  console.log('  -h, --help                      Show this message.');
+}
+
+module.exports = { main };
+module.exports.default = main;


### PR DESCRIPTION
## Summary
- streamline the CommonJS bootstrap to dynamically import the CLI entry point and pass through numeric exit codes
- implement a lightweight CLI runner that parses status/demo arguments and prints contextual help
- revert the Vitest configuration to its original scope and drop the unused CLI test suite

## Testing
- node bin/adaptive-sdk-cli.js status --demo --env staging

------
https://chatgpt.com/codex/tasks/task_e_68edd6df67e48329827f76c44fd22c17