### PR TITLE
Add adaptive overlay sync controls to wearable designer

### DIFF
--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/cli/runAdaptiveSdkCli.js')).href;
+
+(async () => {
+  try {
+    const moduleNamespace = await import(moduleUrl);
+    const main = typeof moduleNamespace.main === 'function'
+      ? moduleNamespace.main
+      : typeof moduleNamespace.default === 'function'
+        ? moduleNamespace.default
+        : null;
+
+    if (!main) {
+      throw new Error('runAdaptiveSdkCli.js must export a main function.');
+    }
+
+    const exitCode = await main();
+    if (typeof exitCode === 'number') {
+      process.exitCode = exitCode;
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/loaders/srcModuleLoader.mjs
+++ b/src/cli/loaders/srcModuleLoader.mjs
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+const srcRoot = path.join(projectRoot, 'src');
+
+export async function load(url, context, defaultLoad) {
+  if (url.startsWith('file://')) {
+    const filePath = fileURLToPath(url);
+    if (filePath.startsWith(srcRoot) && filePath.endsWith('.js')) {
+      return defaultLoad(url, { ...context, format: 'module' });
+    }
+  }
+  return defaultLoad(url, context);
+}

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+let modulePromise = null;
+
+function loadModule() {
+  if (!modulePromise) {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, './runAdaptiveSdkCli.mjs')).href;
+    modulePromise = import(moduleUrl);
+  }
+  return modulePromise;
+}
+
+async function main(argv = process.argv.slice(2), streams) {
+  const moduleNamespace = await loadModule();
+  if (typeof moduleNamespace.main !== 'function') {
+    throw new Error('runAdaptiveSdkCli.mjs must export a main function.');
+  }
+  return moduleNamespace.main(argv, streams);
+}
+
+module.exports = { main };
+module.exports.default = main;

--- a/src/cli/runAdaptiveSdkCli.mjs
+++ b/src/cli/runAdaptiveSdkCli.mjs
@@ -1,0 +1,645 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageManifest = safeReadPackageManifest();
+
+function createIo(streams = {}) {
+  return {
+    stdout: streams.stdout || process.stdout,
+    stderr: streams.stderr || process.stderr
+  };
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepMerge(base, overrides) {
+  if (!isPlainObject(overrides)) {
+    return overrides === undefined ? base : overrides;
+  }
+
+  const result = { ...(isPlainObject(base) ? base : {}) };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (Array.isArray(value)) {
+      const baseArray = Array.isArray(result[key]) ? result[key] : [];
+      result[key] = [...baseArray, ...value];
+      continue;
+    }
+
+    if (isPlainObject(value) && isPlainObject(result[key])) {
+      result[key] = deepMerge(result[key], value);
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function parseArguments(argv = []) {
+  const result = {
+    command: null,
+    options: {},
+    positionals: [],
+    errors: []
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!result.command && !token.startsWith('-')) {
+      result.command = token;
+      continue;
+    }
+
+    switch (token) {
+      case '--help':
+      case '-h':
+        result.options.help = true;
+        continue;
+      case '--demo':
+        result.options.demo = true;
+        continue;
+      case '--no-demo':
+        result.options.demo = false;
+        continue;
+      case '--env':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --env option.');
+        } else {
+          result.options.environment = argv[index];
+        }
+        continue;
+      case '--format':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --format option.');
+        } else {
+          result.options.format = argv[index];
+        }
+        continue;
+      case '--config':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --config option.');
+        } else {
+          result.options.configPath = argv[index];
+        }
+        continue;
+      case '--verbose':
+      case '-v':
+        result.options.verbose = true;
+        continue;
+      case '--no-validate':
+        result.options.validate = false;
+        continue;
+      case '--validate':
+        result.options.validate = true;
+        continue;
+      case '--strict-license':
+        result.options.strictLicense = true;
+        continue;
+      case '--no-strict-license':
+        result.options.strictLicense = false;
+        continue;
+      default:
+        if (token.startsWith('-')) {
+          result.errors.push(`Unknown option: ${token}`);
+        } else {
+          result.positionals.push(token);
+        }
+    }
+  }
+
+  return result;
+}
+
+async function main(argv = process.argv.slice(2), streams) {
+  const io = createIo(streams);
+  const { command, options, positionals, errors } = parseArguments(argv);
+
+  if (errors.length > 0) {
+    for (const message of errors) {
+      io.stderr.write(`${message}\n`);
+    }
+    printHelp(io.stdout);
+    return 1;
+  }
+
+  if (!command || options.help) {
+    printHelp(io.stdout);
+    return 0;
+  }
+
+  switch (command) {
+    case 'status':
+      return runStatusCommand({ ...options, args: positionals }, io);
+    default:
+      io.stderr.write(`Unknown command: ${command}\n`);
+      printHelp(io.stdout);
+      return 1;
+  }
+}
+
+async function runStatusCommand(options, io) {
+  if (options.args && options.args.length > 0) {
+    io.stderr.write(`Unexpected arguments for status command: ${options.args.join(' ')}\n`);
+    return 1;
+  }
+
+  const format = (options.format || 'text').toLowerCase();
+  if (!['text', 'json'].includes(format)) {
+    io.stderr.write(`Unsupported format: ${options.format}. Use "text" or "json".\n`);
+    return 1;
+  }
+
+  try {
+    const report = await buildStatusReport({
+      environment: options.environment,
+      demo: options.demo,
+      configPath: options.configPath,
+      validate: options.validate,
+      strictLicense: options.strictLicense,
+      verbose: options.verbose
+    });
+
+    if (format === 'json') {
+      io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      formatTextReport(report, options, io.stdout, io.stderr);
+    }
+
+    const licenseState = report.license?.status?.state;
+    const licenseValid = licenseState === 'valid';
+    if (options.strictLicense && !licenseValid) {
+      io.stderr.write('License validation failed while --strict-license is enabled.\n');
+      return 3;
+    }
+
+    return 0;
+  } catch (error) {
+    io.stderr.write(`[adaptive-sdk-cli] ${error.message}\n`);
+    if (options.verbose && error.stack) {
+      io.stderr.write(`${error.stack}\n`);
+    }
+    return 1;
+  }
+}
+
+async function buildStatusReport(options = {}) {
+  const environmentName = String(options.environment || 'production');
+  const payload = {
+    environment: environmentName,
+    demo: Boolean(options.demo),
+    configPath: options.configPath ? path.resolve(options.configPath) : null,
+    validate: options.validate !== false,
+    packageVersion: packageManifest.version || '0.0.0'
+  };
+
+  return runStatusWorker(payload);
+}
+
+async function runStatusWorker(payload) {
+  const loaderPath = path.resolve(moduleDirectory, './loaders/srcModuleLoader.mjs');
+  const workerPath = path.resolve(moduleDirectory, './status/statusWorker.mjs');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--experimental-loader', loaderPath, workerPath],
+      { stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+
+    child.on('close', code => {
+      if (code !== 0) {
+        const error = new Error(stderr.trim() || `Status worker exited with code ${code}`);
+        error.code = code;
+        reject(error);
+        return;
+      }
+
+      try {
+        const result = stdout.trim() ? JSON.parse(stdout) : {};
+        resolve(result);
+      } catch (parseError) {
+        parseError.message = `Failed to parse status worker output: ${parseError.message}`;
+        reject(parseError);
+      }
+    });
+
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
+async function buildAdaptiveSdkConfig(options = {}) {
+  const environmentName = String(options.environment || 'production');
+  const baseConfig = {
+    environment: {
+      mode: 'headless',
+      skipVisualization: true,
+      skipUiBindings: true,
+      skipGallery: true,
+      skipExport: true,
+      skipStatus: true,
+      autoStart: false
+    },
+    sensory: {
+      autoConnectAdapters: false,
+      pollingInterval: 120000,
+      confidenceThreshold: 0.35
+    },
+    telemetry: {
+      enabled: true,
+      auditLogLimit: 400,
+      classificationRules: [
+        { prefix: 'adaptive.', classification: 'interaction' },
+        { prefix: 'design.', classification: 'analytics' },
+        { prefix: 'sensors.', classification: 'system' },
+        { prefix: 'privacy.', classification: 'compliance' }
+      ],
+      defaultConsent: {
+        system: true,
+        compliance: true,
+        interaction: true,
+        analytics: false,
+        biometric: false
+      },
+      commercialization: {
+        captureInitialSnapshot: true,
+        snapshotStore: {
+          maxSnapshots: 24
+        },
+        snapshotIntervalMs: undefined
+      },
+      licenseAttestationProfilePacks: [
+        { id: 'enterprise-saas', options: { applyDefault: false } },
+        { id: 'studio-collab', options: { applyDefault: false } },
+        'indie-lab'
+      ]
+    },
+    sensorAdapters: createDemoSensorAdapters(environmentName),
+    consentOptions: createConsentOptions(environmentName)
+  };
+
+  if (options.demo) {
+    baseConfig.license = createDemoLicenseConfig(environmentName);
+    baseConfig.telemetry.defaultConsent.analytics = true;
+    baseConfig.telemetry.defaultConsent.biometric = true;
+    baseConfig.telemetry.defaultConsent.interaction = true;
+  }
+
+  if (options.configPath) {
+    const overrides = await readConfigOverrides(options.configPath);
+    if (overrides) {
+      return deepMerge(baseConfig, overrides);
+    }
+  }
+
+  return baseConfig;
+}
+
+function createConsentOptions(environmentName) {
+  const tier = environmentName.toLowerCase();
+  return [
+    {
+      id: 'analytics',
+      label: 'Share anonymized adaptive analytics',
+      defaultState: tier === 'production'
+    },
+    {
+      id: 'biometric',
+      label: 'Allow biometric-derived insights for personalization',
+      defaultState: tier !== 'production'
+    },
+    {
+      id: 'interaction',
+      label: 'Record adaptive interaction gestures',
+      defaultState: true
+    }
+  ];
+}
+
+function createDemoLicenseConfig(environmentName) {
+  const now = new Date();
+  const expiry = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+  const normalizedEnv = environmentName.toLowerCase();
+  const seats = normalizedEnv === 'production' ? 500 : 75;
+
+  return {
+    key: `DEMO-${normalizedEnv.toUpperCase()}-ADAPTIVE-${now.getUTCFullYear()}`,
+    tenantId: normalizedEnv === 'production' ? 'wearable-enterprise' : `demo-${normalizedEnv}`,
+    features: [
+      'adaptive-layout',
+      'projection-scenarios',
+      'telemetry-hardened',
+      'commercialization-reports'
+    ],
+    issuedAt: now.toISOString(),
+    expiresAt: expiry.toISOString(),
+    managerOptions: {
+      logger: console
+    },
+    validators: [async license => {
+      const valid = typeof license.key === 'string' && license.key.startsWith('DEMO-');
+      if (!valid) {
+        return { valid: false, reason: 'DEMO_KEY_REQUIRED' };
+      }
+      return {
+        valid: true,
+        metadata: {
+          tier: normalizedEnv === 'production' ? 'enterprise-evaluation' : 'sandbox',
+          seats,
+          entitlements: ['adaptive-layout', 'telemetry-hardened', 'commercialization-reports'],
+          lastValidatedBy: 'adaptive-sdk-cli'
+        }
+      };
+    }],
+    attestor: createDemoLicenseAttestor(environmentName),
+    autoValidate: true
+  };
+}
+
+function createDemoLicenseAttestor(environmentName) {
+  const normalizedEnv = environmentName.toLowerCase();
+  return {
+    id: `demo-attestor-${normalizedEnv}`,
+    createValidator() {
+      return async (license, context = {}) => {
+        const valid = typeof license.key === 'string' && license.key.startsWith('DEMO-');
+        if (!valid) {
+          return { valid: false, reason: 'ATTESTATION_KEY_MISMATCH' };
+        }
+        return {
+          valid: true,
+          metadata: {
+            remote: {
+              attestedAt: new Date().toISOString(),
+              region: normalizedEnv,
+              entitlements: ['adaptive-layout', 'projection-scenarios'],
+              context
+            }
+          }
+        };
+      };
+    },
+    bindToLicenseManager(manager) {
+      const validator = this.createValidator();
+      const detach = manager.registerValidator(async (license, context) => validator(license, context));
+      return () => {
+        if (typeof detach === 'function') {
+          detach();
+        }
+      };
+    }
+  };
+}
+
+function createDemoSensorAdapters(environmentName) {
+  const adapters = [
+    {
+      type: 'eye-tracking',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.92,
+        payload: { x: 0.48, y: 0.52, depth: 0.31 }
+      }))
+    },
+    {
+      type: 'neural-intent',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.88,
+        payload: { x: 0.04, y: -0.03, z: 0.02, w: 0.15, engagement: 0.62 }
+      }))
+    },
+    {
+      type: 'biometric',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.9,
+        payload: { stress: 0.22, heartRate: 72, temperature: 36.6 }
+      }))
+    },
+    {
+      type: 'ambient',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.86,
+        payload: { luminance: 0.58, noiseLevel: 0.18, motion: 0.14 }
+      }))
+    },
+    {
+      type: 'gesture',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.83,
+        payload: { intent: 'focus-hold', vector: { x: 0.42, y: 0.38, z: 0.21 } }
+      }))
+    }
+  ];
+
+  return adapters.map(entry => ({
+    type: entry.type,
+    instance: entry.instance,
+    autoConnect: false
+  }));
+}
+
+function createStaticSensorAdapter(sampleFactory) {
+  let connected = false;
+  return {
+    async connect() {
+      connected = true;
+    },
+    async disconnect() {
+      connected = false;
+    },
+    async read() {
+      if (!connected) {
+        return { confidence: 0, payload: {} };
+      }
+      const sample = sampleFactory();
+      return {
+        confidence: sample.confidence ?? 1,
+        payload: sample.payload || {}
+      };
+    },
+    async test() {
+      return { ok: true, latencyMs: 8 };
+    }
+  };
+}
+
+async function readConfigOverrides(configPath) {
+  try {
+    const absolutePath = path.resolve(configPath);
+    const content = await fs.readFile(absolutePath, 'utf8');
+    const parsed = JSON.parse(content);
+    if (!isPlainObject(parsed)) {
+      throw new Error('Configuration override must be a JSON object.');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to load configuration from ${configPath}: ${error.message}`);
+  }
+}
+
+function formatTextReport(report, options, stdout, stderr) {
+  const header = `Adaptive SDK CLI ${report.metadata.version} — Status (${report.metadata.environment})`;
+  stdout.write(`${header}\n`);
+  stdout.write(`${'-'.repeat(header.length)}\n`);
+  stdout.write(`Generated: ${report.metadata.generatedAt}\n`);
+  stdout.write(`Demo mode: ${report.metadata.demo ? 'enabled' : 'disabled'}\n`);
+  stdout.write(`Configuration: ${report.metadata.configSource}\n`);
+  stdout.write(`Strict license check: ${options.strictLicense ? 'enabled' : 'disabled'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Environment\n');
+  stdout.write(`  Mode: ${report.environment.mode}\n`);
+  stdout.write(`  Visualization skipped: ${report.environment.skipVisualization ? 'yes' : 'no'}\n`);
+  stdout.write(`  UI bindings skipped: ${report.environment.skipUiBindings ? 'yes' : 'no'}\n`);
+  stdout.write(`  Gallery disabled: ${report.environment.skipGallery ? 'yes' : 'no'}\n`);
+  stdout.write(`  Export disabled: ${report.environment.skipExport ? 'yes' : 'no'}\n`);
+  stdout.write('\n');
+
+  stdout.write('License\n');
+  const licenseStatus = report.license.status || {};
+  stdout.write(`  State: ${licenseStatus.state || 'unknown'}\n`);
+  stdout.write(`  Reason: ${licenseStatus.reason || 'n/a'}\n`);
+  if (licenseStatus.validatedAt) {
+    stdout.write(`  Validated at: ${licenseStatus.validatedAt}\n`);
+  }
+  const licenseDetails = report.license.details || {};
+  if (licenseDetails.key) {
+    stdout.write(`  License key: ${licenseDetails.key}\n`);
+  }
+  if (Array.isArray(licenseDetails.features)) {
+    stdout.write(`  Features: ${licenseDetails.features.join(', ')}\n`);
+  }
+  if (licenseDetails.expiresAt) {
+    stdout.write(`  Expires at: ${licenseDetails.expiresAt}\n`);
+  }
+  if (licenseStatus.metadata) {
+    stdout.write(`  Metadata: ${JSON.stringify(licenseStatus.metadata)}\n`);
+  }
+  stdout.write('\n');
+
+  stdout.write('Telemetry\n');
+  stdout.write(`  Enabled: ${report.telemetry.enabled ? 'yes' : 'no'}\n`);
+  stdout.write(`  Providers: ${report.telemetry.providers.map(provider => provider.id).join(', ') || 'none'}\n`);
+  stdout.write(`  Consent: ${formatConsent(report.telemetry.consent)}\n`);
+  stdout.write(`  Audit entries: ${report.telemetry.auditTrail.totalEntries}\n`);
+  stdout.write(`  Buffer size: ${report.telemetry.bufferSize}\n`);
+  stdout.write(`  Attestation profiles: ${report.telemetry.licenseAttestation.profiles.length}\n`);
+  if (report.telemetry.licenseAttestation.defaultProfileId) {
+    stdout.write(`  Default profile: ${report.telemetry.licenseAttestation.defaultProfileId}\n`);
+  }
+  const commercialization = report.telemetry.commercialization;
+  stdout.write(`  Commercialization packs: ${commercialization.summary.packs?.length || 0}\n`);
+  stdout.write(`  Commercialization snapshots: ${commercialization.snapshotCount}\n`);
+  stdout.write('\n');
+
+  stdout.write('Sensors\n');
+  stdout.write(`  Auto-connect adapters: ${report.sensors.autoConnect ? 'yes' : 'no'}\n`);
+  stdout.write(`  Polling interval: ${report.sensors.pollingIntervalMs} ms\n`);
+  stdout.write(`  Registered schemas: ${report.sensors.registeredSchemas.join(', ') || 'none'}\n`);
+  stdout.write(`  Registered adapters: ${report.sensors.adapters.map(adapter => adapter.type).join(', ') || 'none'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Layout & Design\n');
+  stdout.write(`  Layout strategies (${report.layout.strategyCount}): ${report.layout.strategies.join(', ') || 'none'}\n`);
+  stdout.write(`  Layout annotations: ${report.layout.annotations.join(', ') || 'none'}\n`);
+  stdout.write(`  Active design language: ${report.design.activeLanguage ? report.design.activeLanguage.name : 'none'}\n`);
+  stdout.write(`  Available design languages: ${report.design.languages.map(language => language.name).join(', ') || 'none'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Projection\n');
+  stdout.write(`  Registered scenarios: ${report.projection.scenarioCount}\n`);
+  if (report.projection.scenarioCount > 0) {
+    stdout.write(`  Scenario ids: ${report.projection.scenarios.map(scenario => scenario.id).join(', ')}\n`);
+  }
+
+  if (options.verbose && report.telemetry.auditTrail.recent.length > 0) {
+    stdout.write('\nRecent audit trail entries:\n');
+    for (const entry of report.telemetry.auditTrail.recent) {
+      stdout.write(`  • ${entry.event || entry.type || 'event'} at ${entry.timestamp}\n`);
+    }
+  }
+
+  if (options.strictLicense && licenseStatus.state !== 'valid') {
+    stderr.write('\nLicense is not valid. Enable a valid key or disable --strict-license to continue.\n');
+  }
+}
+
+function formatConsent(consentMap) {
+  const entries = Object.entries(consentMap);
+  if (entries.length === 0) {
+    return 'none';
+  }
+  return entries.map(([key, value]) => `${key}=${value ? 'granted' : 'revoked'}`).join(', ');
+}
+
+function printHelp(stdout = process.stdout) {
+  const lines = [
+    'Adaptive SDK CLI',
+    '',
+    'Usage:',
+    '  adaptive-sdk-cli <command> [options]',
+    '',
+    'Commands:',
+    '  status             Display a synthesized Adaptive SDK runtime report.',
+    '',
+    'Status options:',
+    '  --demo                 Bootstrap using demo instrumentation and license.',
+    '  --env <name>           Label the target environment (default: production).',
+    '  --format <text|json>   Output the report as formatted text or JSON.',
+    '  --config <path>        Merge additional SDK configuration overrides (JSON).',
+    '  --strict-license       Exit with a non-zero code when the license is not valid.',
+    '  --no-validate          Skip license validation before reporting.',
+    '  --verbose              Include expanded diagnostics on failure.',
+    '',
+    'Global options:',
+    '  -h, --help             Show this help message.'
+  ];
+
+  for (const line of lines) {
+    stdout.write(`${line}\n`);
+  }
+}
+
+function safeReadPackageManifest() {
+  try {
+    const require = createRequire(import.meta.url);
+    // eslint-disable-next-line import/no-dynamic-require
+    return require('../../package.json');
+  } catch (error) {
+    return { name: 'adaptive-sdk-cli', version: '0.0.0' };
+  }
+}
+
+export {
+  main,
+  parseArguments,
+  buildStatusReport,
+  buildAdaptiveSdkConfig
+};
+
+export default main;

--- a/src/cli/status/statusWorker.mjs
+++ b/src/cli/status/statusWorker.mjs
@@ -1,0 +1,211 @@
+import { stdin, exit } from 'node:process';
+
+async function readPayload() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    stdin.setEncoding('utf8');
+    stdin.on('data', chunk => {
+      data += chunk;
+    });
+    stdin.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    stdin.on('error', reject);
+  });
+}
+
+async function main() {
+  const payload = await readPayload();
+  const { buildAdaptiveSdkConfig } = await import('../runAdaptiveSdkCli.mjs');
+  const { createAdaptiveSDK } = await import('../../core/AdaptiveSDK.js');
+
+  const config = await buildAdaptiveSdkConfig({
+    environment: payload.environment,
+    demo: payload.demo,
+    configPath: payload.configPath
+  });
+
+  const sdk = createAdaptiveSDK(config);
+  const report = {
+    metadata: {
+      environment: payload.environment,
+      demo: Boolean(payload.demo),
+      generatedAt: new Date().toISOString(),
+      configSource: payload.configPath || 'embedded',
+      version: payload.packageVersion || '0.0.0'
+    }
+  };
+
+  try {
+    const licenseManager = sdk.licenseManager || null;
+    let licenseStatus = licenseManager ? licenseManager.getStatus() : { state: 'unconfigured', reason: 'NO_LICENSE' };
+
+    if (licenseManager && payload.validate !== false) {
+      licenseStatus = await licenseManager.validate({
+        source: 'adaptive-sdk-cli',
+        environment: payload.environment,
+        demo: Boolean(payload.demo)
+      });
+    }
+
+    const telemetry = sdk.telemetry;
+    telemetry.track('cli.status.invoked', {
+      environment: payload.environment,
+      demo: Boolean(payload.demo),
+      version: report.metadata.version
+    }, { classification: 'system' });
+    telemetry.identify('adaptive-sdk-cli', {
+      environment: payload.environment,
+      mode: payload.demo ? 'demo' : 'standard'
+    }, { classification: 'system' });
+
+    const consentEntries = telemetry.consent instanceof Map
+      ? Object.fromEntries(telemetry.consent)
+      : {};
+
+    const providers = telemetry.providers instanceof Map
+      ? Array.from(telemetry.providers.values()).map(provider => ({
+          id: provider.id,
+          metadata: provider.metadata || {}
+        }))
+      : [];
+
+    const auditTrail = telemetry.getAuditTrail();
+
+    if (telemetry.getCommercializationSnapshotStore()) {
+      telemetry.captureCommercializationSnapshot({
+        trigger: 'cli-status',
+        environment: payload.environment,
+        demo: Boolean(payload.demo)
+      });
+    }
+
+    const commercializationSummary = telemetry.getCommercializationSummary();
+    const snapshotStore = telemetry.getCommercializationSnapshotStore();
+    const snapshots = snapshotStore ? snapshotStore.getSnapshots({ limit: 3 }) : [];
+    const kpiReport = snapshotStore ? snapshotStore.getKpiReport({ limit: 2 }) : null;
+
+    const attestationProfiles = telemetry.licenseAttestationProfiles?.getProfiles?.() || [];
+    const defaultProfileId = telemetry.licenseAttestationProfiles?.getDefaultProfileId?.() || null;
+
+    const sensoryBridge = sdk.sensoryBridge;
+    const schemaRegistry = sensoryBridge.getSchemaRegistry();
+    const registeredSchemas = schemaRegistry?.schemas instanceof Map
+      ? Array.from(schemaRegistry.schemas.keys())
+      : [];
+    const registeredAdapters = sensoryBridge.adapters instanceof Map
+      ? Array.from(sensoryBridge.adapters.entries()).map(([type, adapter]) => ({
+          type,
+          hasConnect: typeof adapter.connect === 'function',
+          hasDisconnect: typeof adapter.disconnect === 'function',
+          hasTest: typeof adapter.test === 'function'
+        }))
+      : [];
+
+    const layoutStrategies = Array.isArray(sdk.layoutSynthesizer?.strategies)
+      ? sdk.layoutSynthesizer.strategies.map(strategy => strategy.id || 'unknown')
+      : [];
+    const layoutAnnotations = Array.isArray(sdk.layoutSynthesizer?.annotations)
+      ? sdk.layoutSynthesizer.annotations.map(annotation => annotation.id || 'unknown')
+      : [];
+
+    const designLanguages = sdk.designLanguageManager?.languages instanceof Map
+      ? Array.from(sdk.designLanguageManager.languages.entries()).map(([id, descriptor]) => ({
+          id,
+          name: descriptor?.name || id
+        }))
+      : [];
+    const activeDesignLanguage = sdk.designLanguageManager?.getActiveLanguage?.();
+
+    const projectionScenarios = sdk.projectionSimulator?.listScenarios?.() || [];
+
+    const telemetryBufferSize = Array.isArray(telemetry.buffer) ? telemetry.buffer.length : 0;
+
+    report.environment = {
+      mode: sdk.engine?.environment?.mode || 'headless',
+      skipVisualization: Boolean(sdk.engine?.environment?.skipVisualization),
+      skipUiBindings: Boolean(sdk.engine?.environment?.skipUiBindings),
+      skipStatus: Boolean(sdk.engine?.environment?.skipStatus),
+      skipGallery: Boolean(sdk.engine?.environment?.skipGallery),
+      skipExport: Boolean(sdk.engine?.environment?.skipExport),
+      autoStart: Boolean(sdk.engine?.environment?.autoStart)
+    };
+
+    report.license = {
+      status: licenseStatus,
+      details: licenseManager ? licenseManager.getLicense() : null,
+      history: licenseManager ? licenseManager.getValidationHistory() : []
+    };
+
+    report.telemetry = {
+      enabled: telemetry.enabled,
+      consent: consentEntries,
+      providers,
+      bufferSize: telemetryBufferSize,
+      auditTrail: {
+        totalEntries: auditTrail.length,
+        recent: auditTrail.slice(-5)
+      },
+      commercialization: {
+        summary: commercializationSummary,
+        snapshotCount: snapshots.length,
+        snapshots,
+        kpiReport
+      },
+      licenseAttestation: {
+        defaultProfileId,
+        profiles: attestationProfiles
+      }
+    };
+
+    report.sensors = {
+      autoConnect: Boolean(sensoryBridge.autoConnectAdapters),
+      pollingIntervalMs: sensoryBridge.pollingInterval,
+      confidenceThreshold: sensoryBridge.confidenceThreshold,
+      registeredSchemas,
+      adapters: registeredAdapters,
+      snapshot: sensoryBridge.getSnapshot()
+    };
+
+    report.layout = {
+      strategyCount: layoutStrategies.length,
+      strategies: layoutStrategies,
+      annotations: layoutAnnotations
+    };
+
+    report.design = {
+      activeLanguage: activeDesignLanguage ? {
+        id: sdk.designLanguageManager.activeLanguage,
+        name: activeDesignLanguage.name,
+        description: activeDesignLanguage.description
+      } : null,
+      languages: designLanguages
+    };
+
+    report.projection = {
+      scenarioCount: projectionScenarios.length,
+      scenarios: projectionScenarios
+    };
+
+    if (typeof telemetry.flush === 'function') {
+      await telemetry.flush();
+    }
+
+    console.log(JSON.stringify(report));
+  } finally {
+    try {
+      sdk.engine?.dispose?.();
+    } catch (error) {
+      // ignore disposal errors
+    }
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  exit(1);
+});

--- a/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
+++ b/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
@@ -97,6 +97,19 @@ export class LayoutBlueprintRenderer {
         this.layers = new Map();
         this.zoneColors = { ...DEFAULT_ZONE_COLORS, ...(options.zoneColors || {}) };
         this.background = { ...DEFAULT_BACKGROUND, ...(options.background || {}) };
+        this.backgroundBlendMode = options.backgroundBlendMode || 'source-over';
+        this.backgroundOpacity = typeof options.backgroundOpacity === 'number'
+            ? clamp(options.backgroundOpacity, 0, 1)
+            : 1;
+        this.zoneOpacityFactor = typeof options.zoneOpacityFactor === 'number'
+            ? clamp(options.zoneOpacityFactor, 0, 1)
+            : 1;
+        this.highlightOpacityFactor = typeof options.highlightOpacityFactor === 'number'
+            ? clamp(options.highlightOpacityFactor, 0, 1)
+            : 1;
+        this.accentOpacityFactor = typeof options.accentOpacityFactor === 'number'
+            ? clamp(options.accentOpacityFactor, 0, 1)
+            : 1;
         this.devicePadding = options.devicePadding ?? 0.12;
         this.lastSize = 0;
         this.lastRenderPayload = null;
@@ -180,6 +193,55 @@ export class LayoutBlueprintRenderer {
         }
     }
 
+    setVisualOptions(options = {}) {
+        let shouldRerender = false;
+
+        if (Object.prototype.hasOwnProperty.call(options, 'backgroundOpacity')) {
+            const next = clamp(toNumber(options.backgroundOpacity, this.backgroundOpacity), 0, 1);
+            if (next !== this.backgroundOpacity) {
+                this.backgroundOpacity = next;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'backgroundBlendMode')) {
+            const nextBlend = options.backgroundBlendMode || 'source-over';
+            if (nextBlend !== this.backgroundBlendMode) {
+                this.backgroundBlendMode = nextBlend;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'zoneOpacityFactor')) {
+            const nextZone = clamp(toNumber(options.zoneOpacityFactor, this.zoneOpacityFactor), 0, 1);
+            if (nextZone !== this.zoneOpacityFactor) {
+                this.zoneOpacityFactor = nextZone;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'highlightOpacityFactor')) {
+            const nextHighlight = clamp(toNumber(options.highlightOpacityFactor, this.highlightOpacityFactor), 0, 1);
+            if (nextHighlight !== this.highlightOpacityFactor) {
+                this.highlightOpacityFactor = nextHighlight;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'accentOpacityFactor')) {
+            const nextAccent = clamp(toNumber(options.accentOpacityFactor, this.accentOpacityFactor), 0, 1);
+            if (nextAccent !== this.accentOpacityFactor) {
+                this.accentOpacityFactor = nextAccent;
+                shouldRerender = true;
+            }
+        }
+
+        if (shouldRerender && this.lastRenderPayload) {
+            const { layout, design, context } = this.lastRenderPayload;
+            this.render(layout, design, context);
+        }
+    }
+
     render(layout, design, context) {
         if (!layout) return;
         this.lastRenderPayload = { layout, design, context };
@@ -203,11 +265,17 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        context.save();
+        if (this.backgroundBlendMode && this.backgroundBlendMode !== 'source-over') {
+            context.globalCompositeOperation = this.backgroundBlendMode;
+        }
+        context.globalAlpha = this.backgroundOpacity;
         const gradient = context.createRadialGradient(size / 2, size / 2, size * 0.1, size / 2, size / 2, size * 0.55);
         gradient.addColorStop(0, this.background.inner);
         gradient.addColorStop(1, this.background.outer);
         context.fillStyle = gradient;
         context.fillRect(0, 0, canvas.width, canvas.height);
+        context.restore();
     }
 
     drawShadow(size, center, radius) {
@@ -250,7 +318,13 @@ export class LayoutBlueprintRenderer {
             context.save();
             context.strokeStyle = color;
             context.lineWidth = thickness;
-            context.globalAlpha = 0.65 + (occupancy * 0.25);
+            const zoneAlpha = clamp((0.65 + occupancy * 0.25) * this.zoneOpacityFactor, 0, 1);
+            if (zoneAlpha <= 0) {
+                context.restore();
+                currentRadius -= thickness * 0.8;
+                continue;
+            }
+            context.globalAlpha = zoneAlpha;
             context.lineCap = 'round';
             context.beginPath();
             context.arc(center, center, currentRadius, start, end);
@@ -263,11 +337,14 @@ export class LayoutBlueprintRenderer {
                 const x = center + Math.cos(angle) * pointRadius;
                 const y = center + Math.sin(angle) * pointRadius;
                 context.save();
-                context.fillStyle = color;
-                context.globalAlpha = 0.6;
-                context.beginPath();
-                context.arc(x, y, Math.max(4, thickness * 0.15), 0, Math.PI * 2);
-                context.fill();
+                const markerAlpha = clamp(this.zoneOpacityFactor * 0.8, 0, 1);
+                if (markerAlpha > 0) {
+                    context.fillStyle = color;
+                    context.globalAlpha = markerAlpha;
+                    context.beginPath();
+                    context.arc(x, y, Math.max(4, thickness * 0.15), 0, Math.PI * 2);
+                    context.fill();
+                }
                 context.restore();
             }
 
@@ -280,6 +357,10 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        const highlightAlpha = clamp(this.highlightOpacityFactor, 0, 1);
+        if (highlightAlpha <= 0) {
+            return;
+        }
         const focus = normalizeFocusVector(contextSnapshot?.focusVector);
         const radius = size * 0.12;
         const x = focus.x * size;
@@ -288,10 +369,14 @@ export class LayoutBlueprintRenderer {
         const gradient = context.createRadialGradient(x, y, size * 0.01, x, y, radius);
         gradient.addColorStop(0, 'rgba(76, 159, 255, 0.5)');
         gradient.addColorStop(1, 'rgba(76, 159, 255, 0)');
+        context.save();
+        context.globalAlpha = highlightAlpha;
         context.fillStyle = gradient;
         context.fillRect(0, 0, canvas.width, canvas.height);
+        context.restore();
 
         context.save();
+        context.globalAlpha = clamp(this.highlightOpacityFactor * 1.15, 0, 1);
         context.fillStyle = 'rgba(255, 255, 255, 0.9)';
         context.beginPath();
         context.arc(x, y, size * (0.01 + clamp(toNumber(layout.intensity, 0.5), 0, 1) * 0.015), 0, Math.PI * 2);
@@ -304,6 +389,10 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        const accentAlpha = clamp(this.accentOpacityFactor, 0, 1);
+        if (accentAlpha <= 0) {
+            return;
+        }
 
         const patternName = design?.pattern?.name || 'Adaptive Pattern';
         const tier = design?.monetization?.tier || 'starter';
@@ -318,6 +407,7 @@ export class LayoutBlueprintRenderer {
         const componentLine = Array.from(components).join('  •  ');
 
         context.save();
+        context.globalAlpha = accentAlpha;
         context.fillStyle = 'rgba(255, 255, 255, 0.82)';
         context.textAlign = 'center';
         context.font = `${Math.round(size * 0.04)}px "Inter", "Segoe UI", sans-serif`;

--- a/wearable-designer.html
+++ b/wearable-designer.html
@@ -30,6 +30,29 @@
             overflow: hidden;
         }
 
+        .canvas-stack::before,
+        .canvas-stack::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 45% 55%, rgba(46, 132, 255, 0.18), transparent 62%),
+                        radial-gradient(circle at 65% 35%, rgba(255, 122, 255, 0.14), transparent 58%),
+                        radial-gradient(circle at 25% 25%, rgba(76, 255, 196, 0.12), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.4;
+            transform: scale(1.1);
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .canvas-stack::before {
+            animation: vib3Pulse 18s ease-in-out infinite;
+        }
+
+        .canvas-stack::after {
+            animation: vib3Drift 24s ease-in-out infinite;
+        }
+
         .canvas-stack canvas {
             position: absolute;
             width: 88vmin;
@@ -38,13 +61,48 @@
             max-height: 880px;
             border-radius: 28px;
             backdrop-filter: blur(20px);
+            z-index: 1;
         }
 
-        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.35; }
-        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.45; }
+        .canvas-stack canvas.vib3-layer {
+            z-index: 2;
+            filter: saturate(1.25) brightness(1.1);
+        }
+
+        .canvas-stack .blueprint-overlay {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            pointer-events: none;
+            z-index: 4;
+        }
+
+        .canvas-stack canvas.blueprint-layer {
+            mix-blend-mode: screen;
+            opacity: 0.6;
+            filter: drop-shadow(0 0 32px rgba(76, 159, 255, 0.35));
+            z-index: 5;
+        }
+
+        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.38; }
+        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.48; }
         .canvas-stack canvas:nth-child(3) { mix-blend-mode: normal; }
-        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.6; }
-        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.8; }
+        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.62; }
+        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.82; }
+
+        @keyframes vib3Pulse {
+            0% { transform: scale(1.08) rotate(0deg); opacity: 0.28; }
+            50% { transform: scale(1.16) rotate(4deg); opacity: 0.44; }
+            100% { transform: scale(1.08) rotate(-2deg); opacity: 0.32; }
+        }
+
+        @keyframes vib3Drift {
+            0% { transform: scale(1.05) translate(0, 0); opacity: 0.22; }
+            40% { transform: scale(1.15) translate(2%, -1%); opacity: 0.36; }
+            70% { transform: scale(1.12) translate(-1%, 2%); opacity: 0.3; }
+            100% { transform: scale(1.05) translate(0, 0); opacity: 0.24; }
+        }
 
         aside {
             padding: 32px;
@@ -155,6 +213,112 @@
             color: rgba(255, 255, 255, 0.55);
             margin-top: 4px;
             letter-spacing: 0.03em;
+        }
+
+        .overlay-control {
+            margin: 16px 0 18px;
+            display: grid;
+            gap: 10px;
+        }
+
+        .overlay-control__header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .overlay-control__header label {
+            font-size: 0.72rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .overlay-control__mode {
+            font-size: 0.7rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.45);
+            padding: 2px 10px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .overlay-control__range {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .overlay-control input[type="range"] {
+            flex: 1;
+            accent-color: var(--accent);
+            cursor: pointer;
+        }
+
+        .overlay-control input[type="range"]:disabled {
+            opacity: 0.35;
+            cursor: not-allowed;
+        }
+
+        .overlay-control__value {
+            min-width: 3ch;
+            text-align: right;
+            font-size: 0.72rem;
+            letter-spacing: 0.06em;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .overlay-control__footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .overlay-control__sync {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.6);
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .overlay-control__sync input {
+            accent-color: var(--accent);
+            width: 16px;
+            height: 16px;
+        }
+
+        .overlay-control__sync span {
+            letter-spacing: 0.03em;
+        }
+
+        .overlay-control__reset {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            color: rgba(255, 255, 255, 0.72);
+            border-radius: 12px;
+            font-size: 0.7rem;
+            padding: 6px 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            cursor: pointer;
+            transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
+        }
+
+        .overlay-control__reset:hover:not(:disabled) {
+            border-color: rgba(76, 159, 255, 0.65);
+            color: var(--accent);
+        }
+
+        .overlay-control__reset:disabled {
+            opacity: 0.35;
+            cursor: not-allowed;
         }
 
         .meta-line {
@@ -569,11 +733,18 @@
 </head>
 <body>
     <div class="canvas-stack" id="canvasStack">
-        <canvas id="background-canvas"></canvas>
-        <canvas id="shadow-canvas"></canvas>
-        <canvas id="content-canvas"></canvas>
-        <canvas id="highlight-canvas"></canvas>
-        <canvas id="accent-canvas"></canvas>
+        <canvas id="background-canvas" class="vib3-layer"></canvas>
+        <canvas id="shadow-canvas" class="vib3-layer"></canvas>
+        <canvas id="content-canvas" class="vib3-layer"></canvas>
+        <canvas id="highlight-canvas" class="vib3-layer"></canvas>
+        <canvas id="accent-canvas" class="vib3-layer"></canvas>
+        <div class="blueprint-overlay" aria-hidden="true">
+            <canvas id="blueprint-background" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-shadow" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-content" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-highlight" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-accent" class="blueprint-layer"></canvas>
+        </div>
     </div>
     <aside>
         <section class="panel">
@@ -601,6 +772,23 @@
                 <div class="blueprint-metric"><span>Velocity</span><span id="blueprintVelocity">0.00</span></div>
                 <div class="blueprint-metric"><span>Engagement</span><span id="blueprintEngagement">0.40</span></div>
                 <div class="blueprint-metric"><span>Stress</span><span id="blueprintStress">0.20</span></div>
+            </div>
+            <div class="overlay-control">
+                <div class="overlay-control__header">
+                    <label for="blueprintOverlayOpacity">Overlay intensity</label>
+                    <span class="overlay-control__mode" id="blueprintOverlayMode">Adaptive</span>
+                </div>
+                <div class="overlay-control__range">
+                    <input type="range" min="10" max="100" value="70" id="blueprintOverlayOpacity">
+                    <span class="overlay-control__value" id="blueprintOverlayOpacityValue">70%</span>
+                </div>
+                <div class="overlay-control__footer">
+                    <label class="overlay-control__sync" for="blueprintOverlaySync">
+                        <input type="checkbox" id="blueprintOverlaySync" checked>
+                        <span>Sync with adaptive intensity</span>
+                    </label>
+                    <button class="overlay-control__reset" id="blueprintOverlayReset" type="button">Reset</button>
+                </div>
             </div>
             <ul class="blueprint-zone-list" id="blueprintZoneList"></ul>
             <button class="secondary" id="downloadBlueprintBtn" type="button">Download Blueprint</button>
@@ -687,6 +875,12 @@
         const blueprintStress = document.getElementById('blueprintStress');
         const blueprintZoneList = document.getElementById('blueprintZoneList');
         const downloadBlueprintBtn = document.getElementById('downloadBlueprintBtn');
+        const blueprintOverlayElement = document.querySelector('.blueprint-overlay');
+        const blueprintOverlayOpacitySlider = document.getElementById('blueprintOverlayOpacity');
+        const blueprintOverlayOpacityValue = document.getElementById('blueprintOverlayOpacityValue');
+        const blueprintOverlayModeLabel = document.getElementById('blueprintOverlayMode');
+        const blueprintOverlaySyncToggle = document.getElementById('blueprintOverlaySync');
+        const blueprintOverlayResetButton = document.getElementById('blueprintOverlayReset');
         const projectionHaloRadius = document.getElementById('projectionHaloRadius');
         const projectionDepthBias = document.getElementById('projectionDepthBias');
         const projectionContourCount = document.getElementById('projectionContourCount');
@@ -694,14 +888,56 @@
         const projectionScenarioSelect = document.getElementById('projectionScenarioSelect');
         const projectionSimulateBtn = document.getElementById('projectionSimulateBtn');
         const projectionLegend = document.getElementById('projectionLegend');
+        const variationSlider = document.getElementById('variationSlider');
+        const randomizeBtn = document.getElementById('randomizeBtn');
+        const variationLabel = document.getElementById('variationLabel');
+        const focusMetric = document.getElementById('focusMetric');
+        const engagementMetric = document.getElementById('engagementMetric');
+        const velocityMetric = document.getElementById('velocityMetric');
+        const stressMetric = document.getElementById('stressMetric');
+        const consentPanelContainer = document.getElementById('telemetryConsentPanel');
 
-        let adaptiveSDKRef;
+        let adaptiveSDKRef = null;
+        // Maintain a backward-compatible alias for legacy inline handlers or
+        // diagnostics snippets that still expect a global `adaptiveSDK`
+        // reference. Initializing it up front avoids temporal dead zone
+        // lookups before the SDK instance is created.
+        let adaptiveSDKGlobal = null;
         let stopSnapshotSchedule = null;
 
         const remoteUploadLog = [];
         let latestBlueprint = null;
         let latestProjectionComposition = null;
         let activeProjectionScenario = '__realtime__';
+
+        const OVERLAY_PREFERENCES_KEY = 'vib34d:wearableDesigner:overlayPreferences';
+        const overlayState = {
+            manualNormalized: 0.7,
+            currentNormalized: 0.7,
+            syncEnabled: true
+        };
+
+        (function loadOverlayPreferences() {
+            if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+                return;
+            }
+            try {
+                const raw = window.localStorage.getItem(OVERLAY_PREFERENCES_KEY);
+                if (!raw) return;
+                const stored = JSON.parse(raw);
+                if (typeof stored.manualNormalized === 'number' && Number.isFinite(stored.manualNormalized)) {
+                    overlayState.manualNormalized = clamp(stored.manualNormalized, 0.1, 1);
+                }
+                if (typeof stored.syncEnabled === 'boolean') {
+                    overlayState.syncEnabled = stored.syncEnabled;
+                }
+                overlayState.currentNormalized = overlayState.manualNormalized;
+            } catch (error) {
+                console.warn('Unable to restore overlay preferences', error);
+            }
+        }());
+
+        const getAdaptiveSDK = () => adaptiveSDKRef || adaptiveSDKGlobal || window.adaptiveSDK || null;
 
         const formatTime = (value) => {
             if (!value) return 'unknown';
@@ -814,35 +1050,30 @@
 
         const blueprintRenderer = createLayoutBlueprintRenderer({
             layers: {
-                background: document.getElementById('background-canvas'),
-                shadow: document.getElementById('shadow-canvas'),
-                content: document.getElementById('content-canvas'),
-                highlight: document.getElementById('highlight-canvas'),
-                accent: document.getElementById('accent-canvas')
-            }
+                background: document.getElementById('blueprint-background'),
+                shadow: document.getElementById('blueprint-shadow'),
+                content: document.getElementById('blueprint-content'),
+                highlight: document.getElementById('blueprint-highlight'),
+                accent: document.getElementById('blueprint-accent')
+            },
+            background: {
+                inner: 'rgba(64, 148, 255, 0.24)',
+                outer: 'rgba(10, 24, 48, 0.48)'
+            },
+            zoneColors: {
+                primary: 'rgba(76, 159, 255, 0.85)',
+                peripheral: 'rgba(178, 107, 255, 0.8)',
+                ambient: 'rgba(255, 196, 122, 0.75)'
+            },
+            backgroundBlendMode: 'screen',
+            backgroundOpacity: 0.72,
+            devicePadding: 0.1
         });
 
         blueprintRenderer.resize();
         window.addEventListener('resize', () => blueprintRenderer.resize());
 
         renderBlueprintPanel(null);
-
-        const projectionComposer = adaptiveSDKRef?.projectionComposer || adaptiveSDK.projectionComposer;
-        const projectionBaseCanvas = document.getElementById('projection-base');
-        const projectionBandCanvas = document.getElementById('projection-bands');
-        const projectionHaloCanvas = document.getElementById('projection-halo');
-        const projectionContourCanvas = document.getElementById('projection-contours');
-
-        projectionComposer.attachLayer('base', projectionBaseCanvas);
-        projectionComposer.attachLayer('bands', projectionBandCanvas);
-        projectionComposer.attachLayer('halo', projectionHaloCanvas);
-        projectionComposer.attachLayer('contours', projectionContourCanvas);
-        projectionComposer.observeResize?.();
-        projectionComposer.resize();
-        window.addEventListener('resize', () => projectionComposer.resize());
-
-        renderProjectionPanel(null);
-        initializeProjectionScenarios();
 
         const formatLabel = (value) => {
             if (!value) return 'Unspecified';
@@ -856,6 +1087,125 @@
         };
 
         const formatPercent = (value) => `${Math.round(clamp(value, 0, 1) * 100)}%`;
+
+        function persistOverlayPreferences() {
+            if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+                return;
+            }
+            try {
+                window.localStorage.setItem(OVERLAY_PREFERENCES_KEY, JSON.stringify({
+                    manualNormalized: Number(overlayState.manualNormalized.toFixed(3)),
+                    syncEnabled: overlayState.syncEnabled
+                }));
+            } catch (error) {
+                console.warn('Unable to persist overlay preferences', error);
+            }
+        }
+
+        function deriveOverlayFromBlueprint(blueprint) {
+            if (!blueprint) {
+                return overlayState.manualNormalized;
+            }
+            const intensity = clamp(blueprint.intensity, 0, 1);
+            const engagement = clamp(blueprint.engagementLevel, 0, 1);
+            const stress = clamp(blueprint.biometricStress, 0, 1);
+            const derived = 0.35 + intensity * 0.4 + engagement * 0.2 - stress * 0.25;
+            return clamp(derived, 0.15, 0.95);
+        }
+
+        function applyBlueprintOverlayIntensity(rawValue, options = {}) {
+            if (!blueprintRenderer) {
+                return;
+            }
+            const { updateSlider = false } = options;
+            const numeric = clamp(Number(rawValue), 0.1, 1);
+            overlayState.currentNormalized = numeric;
+            const overlayOpacity = 0.25 + numeric * 0.75;
+            if (blueprintOverlayElement) {
+                blueprintOverlayElement.style.opacity = overlayOpacity.toFixed(2);
+            }
+
+            const layerOpacity = 0.35 + numeric * 0.6;
+            blueprintRenderer.setVisualOptions({
+                backgroundOpacity: overlayOpacity,
+                zoneOpacityFactor: layerOpacity,
+                highlightOpacityFactor: layerOpacity,
+                accentOpacityFactor: layerOpacity
+            });
+
+            if (blueprintOverlayOpacityValue) {
+                blueprintOverlayOpacityValue.textContent = `${Math.round(numeric * 100)}%`;
+            }
+
+            if (updateSlider && blueprintOverlayOpacitySlider) {
+                const sliderValue = Math.max(10, Math.min(100, Math.round(numeric * 100)));
+                blueprintOverlayOpacitySlider.value = String(sliderValue);
+            }
+        }
+
+        function setOverlaySyncEnabled(enabled, options = {}) {
+            const { reapply = true, persist = true } = options;
+            overlayState.syncEnabled = Boolean(enabled);
+            if (blueprintOverlaySyncToggle) {
+                blueprintOverlaySyncToggle.checked = overlayState.syncEnabled;
+            }
+            if (blueprintOverlayModeLabel) {
+                blueprintOverlayModeLabel.textContent = overlayState.syncEnabled ? 'Adaptive' : 'Manual';
+            }
+            if (blueprintOverlayOpacitySlider) {
+                blueprintOverlayOpacitySlider.disabled = overlayState.syncEnabled;
+            }
+            if (blueprintOverlayResetButton) {
+                blueprintOverlayResetButton.disabled = overlayState.syncEnabled;
+            }
+
+            if (reapply) {
+                const target = overlayState.syncEnabled
+                    ? deriveOverlayFromBlueprint(latestBlueprint)
+                    : overlayState.manualNormalized;
+                applyBlueprintOverlayIntensity(target, { updateSlider: true });
+            }
+
+            if (persist) {
+                persistOverlayPreferences();
+            }
+        }
+
+        function initializeOverlayControls() {
+            if (blueprintOverlayOpacitySlider) {
+                const sliderValue = Math.max(10, Math.min(100, Math.round(overlayState.manualNormalized * 100)));
+                blueprintOverlayOpacitySlider.value = String(sliderValue);
+                blueprintOverlayOpacitySlider.addEventListener('input', event => {
+                    const raw = Number(event.target.value);
+                    const next = Number.isFinite(raw) ? raw / 100 : overlayState.manualNormalized;
+                    overlayState.manualNormalized = clamp(next, 0.1, 1);
+                    applyBlueprintOverlayIntensity(overlayState.manualNormalized);
+                    persistOverlayPreferences();
+                });
+            }
+
+            if (blueprintOverlayResetButton) {
+                blueprintOverlayResetButton.addEventListener('click', () => {
+                    overlayState.manualNormalized = 0.7;
+                    applyBlueprintOverlayIntensity(overlayState.manualNormalized, { updateSlider: true });
+                    persistOverlayPreferences();
+                });
+            }
+
+            if (blueprintOverlaySyncToggle) {
+                blueprintOverlaySyncToggle.addEventListener('change', event => {
+                    setOverlaySyncEnabled(Boolean(event.target.checked));
+                });
+            }
+
+            setOverlaySyncEnabled(overlayState.syncEnabled, { reapply: false, persist: false });
+            const initial = overlayState.syncEnabled && latestBlueprint
+                ? deriveOverlayFromBlueprint(latestBlueprint)
+                : overlayState.manualNormalized;
+            applyBlueprintOverlayIntensity(initial, { updateSlider: true });
+        }
+
+        initializeOverlayControls();
 
         function renderBlueprintPanel(blueprint) {
             if (!blueprint) {
@@ -1063,8 +1413,13 @@
             realtimeOption.textContent = 'Realtime Field';
             projectionScenarioSelect.appendChild(realtimeOption);
 
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
+                return;
+            }
+
             for (const scenario of scenarios) {
-                adaptiveSDK.registerProjectionScenario(scenario);
+                sdk.registerProjectionScenario(scenario);
                 const option = document.createElement('option');
                 option.value = scenario.id;
                 option.textContent = scenario.name;
@@ -1078,23 +1433,27 @@
                 if (activeProjectionScenario === '__realtime__') {
                     return;
                 }
-                adaptiveSDK.setActiveProjectionScenario(activeProjectionScenario);
+                sdk.setActiveProjectionScenario(activeProjectionScenario);
             });
 
             projectionSimulateBtn?.addEventListener('click', () => {
+                const activeSdk = getAdaptiveSDK();
+                if (!activeSdk) {
+                    return;
+                }
                 if (!latestBlueprint) {
                     return;
                 }
                 if (activeProjectionScenario === '__realtime__') {
-                    const projectionContext = buildProjectionContextFromAdaptive(adaptiveSDK.engine?.sensoryBridge?.getSnapshot?.());
-                    const composition = adaptiveSDK.composeProjectionField(latestBlueprint, null, projectionContext);
-                    adaptiveSDK.projectionComposer.render(latestBlueprint, projectionContext);
+                    const projectionContext = buildProjectionContextFromAdaptive(activeSdk.engine?.sensoryBridge?.getSnapshot?.());
+                    const composition = activeSdk.composeProjectionField(latestBlueprint, null, projectionContext);
+                    activeSdk.projectionComposer.render(latestBlueprint, projectionContext);
                     renderProjectionPanel(composition, { mode: 'realtime' });
                     return;
                 }
-                const frame = adaptiveSDK.stepProjectionSimulation({});
+                const frame = activeSdk.stepProjectionSimulation({});
                 if (frame?.composition) {
-                    adaptiveSDK.projectionComposer.render(frame.blueprint, frame.context);
+                    activeSdk.projectionComposer.render(frame.blueprint, frame.context);
                     renderProjectionPanel(frame.composition, {
                         mode: 'scenario',
                         scenario: frame.name,
@@ -1154,7 +1513,7 @@
                 commercializationKpiSummary.innerHTML = '';
                 snapshotList.innerHTML = '';
                 commercializationUpdated.textContent = 'No commercialization activity yet';
-                if (adaptiveSDKRef) {
+                if (getAdaptiveSDK()) {
                     refreshCommercializationSnapshots();
                 }
                 return;
@@ -1224,7 +1583,7 @@
                 commercializationUpdated.textContent = 'No commercialization activity yet';
             }
 
-            if (adaptiveSDKRef) {
+            if (getAdaptiveSDK()) {
                 refreshCommercializationSnapshots();
             }
         }
@@ -1319,18 +1678,19 @@
         }
 
         function refreshCommercializationSnapshots() {
-            if (!adaptiveSDKRef) {
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
                 commercializationKpiSummary.innerHTML = '';
                 snapshotList.innerHTML = '';
                 return;
             }
-            const snapshots = adaptiveSDKRef.getLicenseCommercializationSnapshots({ limit: 5, withSummary: false });
+            const snapshots = sdk.getLicenseCommercializationSnapshots({ limit: 5, withSummary: false });
             renderSnapshotHistory(snapshots);
-            const kpiReport = adaptiveSDKRef.getLicenseCommercializationKpiReport();
+            const kpiReport = sdk.getLicenseCommercializationKpiReport();
             renderKpiSummary(kpiReport);
         }
 
-        const adaptiveSDK = (adaptiveSDKRef = createAdaptiveSDK({
+        const adaptiveSDKInstance = createAdaptiveSDK({
             telemetry: {
                 enabled: true,
                 defaultConsent: { analytics: false, biometric: false },
@@ -1351,7 +1711,11 @@
                 onPatternChange: updatePatternPanel,
                 onAdaptiveUpdate: handleAdaptiveUpdate
             }
-        }));
+        });
+
+        adaptiveSDKRef = adaptiveSDKInstance;
+        adaptiveSDKGlobal = adaptiveSDKInstance;
+        window.adaptiveSDK = adaptiveSDKInstance;
 
         const {
             engine,
@@ -1360,14 +1724,34 @@
             getTelemetryConsent,
             getTelemetryAuditTrail,
             getLicenseCommercializationSummary,
-            setLicenseAttestorFromProfile,
             registerLicenseAttestationProfilePack
-        } = adaptiveSDK;
+        } = adaptiveSDKInstance;
 
-        const telemetryHarness = adaptiveSDK.telemetry;
+        const setLicenseAttestorFromProfile = (...args) => adaptiveSDKInstance.setLicenseAttestorFromProfile(...args);
+
+        const projectionComposer = adaptiveSDKInstance.projectionComposer;
+        const projectionBaseCanvas = document.getElementById('projection-base');
+        const projectionBandCanvas = document.getElementById('projection-bands');
+        const projectionHaloCanvas = document.getElementById('projection-halo');
+        const projectionContourCanvas = document.getElementById('projection-contours');
+
+        projectionComposer.attachLayer('base', projectionBaseCanvas);
+        projectionComposer.attachLayer('bands', projectionBandCanvas);
+        projectionComposer.attachLayer('halo', projectionHaloCanvas);
+        projectionComposer.attachLayer('contours', projectionContourCanvas);
+        projectionComposer.observeResize?.();
+        projectionComposer.resize();
+        window.addEventListener('resize', () => projectionComposer.resize());
+
+        renderProjectionPanel(null);
+        initializeProjectionScenarios();
+
+        const telemetryHarness = adaptiveSDKInstance.telemetry;
 
         captureSnapshotBtn?.addEventListener('click', () => {
-            adaptiveSDKRef?.captureLicenseCommercializationSnapshot({
+            const sdk = getAdaptiveSDK();
+            if (!sdk) return;
+            sdk.captureLicenseCommercializationSnapshot({
                 trigger: 'demo-manual',
                 capturedBy: 'wearable-designer'
             });
@@ -1375,8 +1759,9 @@
         });
 
         exportSnapshotsBtn?.addEventListener('click', () => {
-            if (!adaptiveSDKRef) return;
-            const exportPayload = adaptiveSDKRef.exportLicenseCommercializationSnapshots({
+            const sdk = getAdaptiveSDK();
+            if (!sdk) return;
+            const exportPayload = sdk.exportLicenseCommercializationSnapshots({
                 format: 'json',
                 includeSummary: false
             });
@@ -1442,14 +1827,15 @@
         renderCommercializationSummary(getLicenseCommercializationSummary());
         refreshCommercializationSnapshots();
 
-        const snapshotStore = adaptiveSDKRef.getLicenseCommercializationSnapshotStore?.();
+        const snapshotStore = getAdaptiveSDK()?.getLicenseCommercializationSnapshotStore?.();
         snapshotStore?.whenReady?.().then(() => {
             refreshCommercializationSnapshots();
             renderRemoteStorageStatus();
         });
 
-        if (typeof adaptiveSDKRef?.startLicenseCommercializationSnapshotSchedule === 'function') {
-            stopSnapshotSchedule = adaptiveSDKRef.startLicenseCommercializationSnapshotSchedule(60000, {
+        const snapshotScheduler = getAdaptiveSDK();
+        if (typeof snapshotScheduler?.startLicenseCommercializationSnapshotSchedule === 'function') {
+            stopSnapshotSchedule = snapshotScheduler.startLicenseCommercializationSnapshotSchedule(60000, {
                 trigger: 'demo-schedule',
                 capturedBy: 'wearable-designer'
             }) || null;
@@ -1459,16 +1845,12 @@
             if (typeof stopSnapshotSchedule === 'function') {
                 stopSnapshotSchedule();
             }
+            adaptiveSDKRef = null;
+            adaptiveSDKGlobal = null;
+            if (window.adaptiveSDK) {
+                window.adaptiveSDK = null;
+            }
         });
-
-        const variationSlider = document.getElementById('variationSlider');
-        const randomizeBtn = document.getElementById('randomizeBtn');
-        const variationLabel = document.getElementById('variationLabel');
-        const focusMetric = document.getElementById('focusMetric');
-        const engagementMetric = document.getElementById('engagementMetric');
-        const velocityMetric = document.getElementById('velocityMetric');
-        const stressMetric = document.getElementById('stressMetric');
-        const consentPanelContainer = document.getElementById('telemetryConsentPanel');
 
         consentPanel = createConsentPanel({
             container: consentPanelContainer,
@@ -1532,6 +1914,11 @@
         }
 
         function handleAdaptiveUpdate({ context, layout, design }) {
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
+                return;
+            }
+
             focusMetric.textContent = context.focusVector.x.toFixed(2);
             engagementMetric.textContent = context.engagementLevel.toFixed(2);
             velocityMetric.textContent = layout.motion.velocity.toFixed(2);
@@ -1541,10 +1928,15 @@
             latestBlueprint = buildLayoutBlueprint(layout, design, context);
             renderBlueprintPanel(latestBlueprint);
 
+            if (overlayState.syncEnabled) {
+                const adaptiveOverlay = deriveOverlayFromBlueprint(latestBlueprint);
+                applyBlueprintOverlayIntensity(adaptiveOverlay, { updateSlider: true });
+            }
+
             const projectionContext = buildProjectionContextFromAdaptive(context);
-            const projectionComposition = adaptiveSDK.composeProjectionField(layout, design, projectionContext);
+            const projectionComposition = sdk.composeProjectionField(layout, design, projectionContext);
             if (projectionComposition) {
-                adaptiveSDK.projectionComposer.render(projectionComposition.blueprint, projectionContext);
+                sdk.projectionComposer.render(projectionComposition.blueprint, projectionContext);
                 if (activeProjectionScenario === '__realtime__') {
                     renderProjectionPanel(projectionComposition, { mode: 'realtime' });
                 }


### PR DESCRIPTION
## Summary
- add an adaptive/manual mode toggle and reset button to the wearable designer overlay controls so holographic visuals stay visible while matching blueprint intensity
- persist overlay preferences and automatically sync blueprint opacity with adaptive updates when enabled for a consistent visualization experience

## Testing
- npm test *(fails: vitest binary is unavailable in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68edd6df67e48329827f76c44fd22c17