### PR TITLE
Add CommonJS bootstrap for Adaptive SDK CLI

### DIFF
--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+(async () => {
+  try {
+    const modulePath = path.join(__dirname, '..', 'src', 'cli', 'runAdaptiveSdkCli.js');
+    const moduleUrl = pathToFileURL(modulePath).href;
+    const importedModule = await import(moduleUrl);
+    const main =
+      typeof importedModule.main === 'function'
+        ? importedModule.main
+        : typeof importedModule.default === 'function'
+          ? importedModule.default
+          : typeof importedModule.default?.main === 'function'
+            ? importedModule.default.main
+            : null;
+
+    if (!main) {
+      throw new TypeError('runAdaptiveSdkCli.js must export a callable main() function.');
+    }
+
+    await main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,36 @@
+export async function main(args = process.argv.slice(2)) {
+  const command = args[0];
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  switch (command) {
+    case 'status':
+      handleStatusCommand(args.slice(1));
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      printHelp();
+      process.exitCode = 1;
+  }
+}
+
+function handleStatusCommand(flags) {
+  const isDemo = flags.includes('--demo');
+  const environment = isDemo ? 'demo' : 'production';
+
+  console.log('Adaptive SDK CLI');
+  console.log(`Status: running in ${environment} mode.`);
+}
+
+function printHelp() {
+  console.log('Usage: adaptive-sdk-cli <command> [options]');
+  console.log('');
+  console.log('Commands:');
+  console.log('  status [--demo]     Show the current Adaptive SDK status');
+  console.log('');
+  console.log('Options:');
+  console.log('  -h, --help          Display this help message');
+}


### PR DESCRIPTION
## Summary
- add a CommonJS bootstrap script that dynamically imports the Adaptive SDK CLI runner and defends against missing exports
- add an Adaptive SDK CLI runner module with a simple status command and help output
- mark the CLI directory as ESM so the runner can use modern syntax under the current package configuration

## Testing
- node bin/adaptive-sdk-cli.js status --demo

------
https://chatgpt.com/codex/tasks/task_e_68eefed5f91083299d81bef4f912de10