### PR TITLE
Document Adaptive SDK CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ All four holographic subsystems remain available for creative workflows and cont
 - Automated testing for the adaptive pipeline now uses Vitest + jsdom (`npm test`). Playwright smoke suites (e.g., `npm run test:e2e:smoke`) remain optional and require a one-time `npx playwright install` to pull Chromium locally.
 - Headless CI or server-side integrations can initialize `createAdaptiveSDK({ environment: { mode: 'headless' } })` to bypass canvas/DOM bootstrapping while still exercising sensory, telemetry, licensing, commercialization, and projection APIs.
 
+## 🛠 Adaptive SDK CLI
+
+The repository ships with a lightweight Node.js bootstrap so teams can exercise Adaptive SDK functionality from scripts or CI environments. It dynamically imports the ESM CLI runner and enforces a `main()` contract so the module surface can evolve without breaking the entry point.
+
+Run the status command (optionally in demo mode) with:
+
+```bash
+node bin/adaptive-sdk-cli.js status --demo
+```
+
+Expected output:
+
+```
+Adaptive SDK CLI
+Status: running in demo mode.
+```
+
+If you omit `--demo`, the CLI reports `production` mode instead.
+
 ## 📊 Reality Check
 
 - ⚠️ Prototype status – Suitable for demonstrations, not production deployments.

--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+(async () => {
+  try {
+    const modulePath = path.join(__dirname, '..', 'src', 'cli', 'runAdaptiveSdkCli.js');
+    const moduleUrl = pathToFileURL(modulePath).href;
+    const importedModule = await import(moduleUrl);
+    const main =
+      typeof importedModule.main === 'function'
+        ? importedModule.main
+        : typeof importedModule.default === 'function'
+          ? importedModule.default
+          : typeof importedModule.default?.main === 'function'
+            ? importedModule.default.main
+            : null;
+
+    if (!main) {
+      throw new TypeError('runAdaptiveSdkCli.js must export a callable main() function.');
+    }
+
+    await main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,36 @@
+export async function main(args = process.argv.slice(2)) {
+  const command = args[0];
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  switch (command) {
+    case 'status':
+      handleStatusCommand(args.slice(1));
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      printHelp();
+      process.exitCode = 1;
+  }
+}
+
+function handleStatusCommand(flags) {
+  const isDemo = flags.includes('--demo');
+  const environment = isDemo ? 'demo' : 'production';
+
+  console.log('Adaptive SDK CLI');
+  console.log(`Status: running in ${environment} mode.`);
+}
+
+function printHelp() {
+  console.log('Usage: adaptive-sdk-cli <command> [options]');
+  console.log('');
+  console.log('Commands:');
+  console.log('  status [--demo]     Show the current Adaptive SDK status');
+  console.log('');
+  console.log('Options:');
+  console.log('  -h, --help          Display this help message');
+}


### PR DESCRIPTION
## Summary
- document the Adaptive SDK CLI bootstrap in the README so contributors know how to invoke it
- record the expected status output for demo runs to clarify the new CommonJS entry point

## Testing
- node bin/adaptive-sdk-cli.js status --demo

------
https://chatgpt.com/codex/tasks/task_e_68eefed5f91083299d81bef4f912de10