### PR TITLE
Add shader build suite with WebGL preview

### DIFF
--- a/DOCS/wearable-designer-overview.md
+++ b/DOCS/wearable-designer-overview.md
@@ -1,0 +1,47 @@
+# VIB34D Adaptive Wearable Designer Overview
+
+## Vision
+The wearable designer is a browser-based staging environment for exploring Adaptive SDK-driven Vib3 experiences before shipping them to production devices. It brings together a live holographic visualizer, an adaptive layout blueprint overlay, telemetry controls, and commercialization reporting so design and go-to-market teams can iterate together on a single page. The current build already layers these systems on a shared canvas stack while exposing hooks for importing real grid specs and projecting SDK diagnostics. Future milestones focus on wiring the placeholders to live data feeds (biometrics, licensing, remote storage) and polishing the workflow from experimentation to export.
+
+## Canvas & Visualizer Stack
+* **Multi-layer canvas composition.** The main viewport renders five Vib3 canvases for background, shadow, content, highlight, and accent effects and then places blueprint and grid overlays above them so holographic visuals remain visible under diagnostic UI.【F:wearable-designer.html†L26-L101】【F:wearable-designer.html†L753-L767】
+* **Animated Vib3 renderer.** `createVib3VisualizerStack` manages context setup, responsive sizing, and the animation loop that draws gradients, orbiting particles, highlight sweeps, and accent glows. When a grid is defined it snaps these animations to card anchors; otherwise it falls back to default pulses.【F:wearable-designer.html†L1079-L1520】【F:wearable-designer.html†L1285-L1376】
+* **Lifecycle utilities.** The helper exposes `start`, `stop`, `resize`, `setGridSpec`, `getGridSpec`, and the new `setShaderConfig`/`getShaderConfig` pair, and the page stores the instance on `window.vib3Visualizer` for quick debugging or scripted automation.【F:wearable-designer.html†L1519-L1535】
+
+## Shader Composer & Build Suite
+* **Live shader controls.** The “Shader Composer” panel lets designers adjust background hue, hue swing, arc velocity, highlight intensity, and particle counts with instant feedback in the Vib3 canvases while the JSON editor mirrors the active configuration.【F:wearable-designer.html†L1153-L1213】【F:wearable-designer.html†L1537-L1643】
+* **JSON apply/import/export.** Buttons wire into the visualizer’s `setShaderConfig` API so teams can paste JSON straight into the editor, import files, export presets, or reset to defaults; console helpers under `window.vib3Shader` offer the same hooks for scripted pipelines.【F:wearable-designer.html†L1545-L1643】【F:wearable-designer.html†L1898-L1915】
+* **Production-friendly defaults.** The composer clamps and sanitizes numeric ranges through `sanitizeShaderConfig`, ensuring the exported JSON stays within supported shader bounds for downstream runtime consumption.【F:wearable-designer.html†L1156-L1232】
+* **WebGL validation & packaging.** The “Shader Build Suite” expands the workflow with metadata inputs, a pass list, editable vertex/fragment editors, and a WebGL preview canvas so teams can compile passes and inspect the live output before exporting bundles.【F:wearable-designer.html†L1215-L1283】【F:wearable-designer.html†L1663-L1861】
+* **Preset packages & console APIs.** Designers can load the production baseline (surface, bloom, particle passes), import/export package JSON that bundles shader configs, or script CI flows via `window.vib3ShaderPackage` helpers.【F:wearable-designer.html†L1215-L1283】【F:wearable-designer.html†L1663-L1865】
+
+## Grid Alignment System
+* **Designer controls.** A “Visualizer Alignment” panel lets teams dial in column/row counts, gutters, and card aspect ratios or trigger import/reset actions, with real-time summaries for the current spec.【F:wearable-designer.html†L805-L849】
+* **Stateful generation.** `layoutGridState` tracks the active grid, `generateCardsFromState` produces normalized card rectangles, and `updateGridSummary` writes contextual status text. These helpers ensure the overlay and visualizer stay synchronized as sliders or numeric inputs change.【F:wearable-designer.html†L1533-L1678】【F:wearable-designer.html†L1619-L1661】
+* **Overlay rendering.** `renderGridOverlay` and `resizeGridOverlay` paint labeled card outlines onto a dedicated canvas sized with a `ResizeObserver`, keeping the blueprint overlay aligned with the holographic canvases.【F:wearable-designer.html†L1000-L1059】
+* **Import/export workflow.** Designers can paste JSON exports from tools like Figma via `applyImportedGrid`, which normalizes a variety of schema shapes, snaps values into `[0,1]`, and persists the spec to the visualizer. A sample preset and console helper (`window.vib3Grid`) support quick experimentation or scripted resets.【F:wearable-designer.html†L1782-L1936】
+
+## Blueprint Overlay & Controls
+* **Renderer configuration.** The page instantiates `LayoutBlueprintRenderer` with custom colors, blend modes, and opacity factors so blueprint layers remain translucent above the Vib3 canvases.【F:wearable-designer.html†L2077-L2148】
+* **Adjustable intensity.** The “Overlay intensity” slider drives `setVisualOptions` to tweak background, zone, highlight, and accent opacity in one pass while updating the DOM indicator.【F:wearable-designer.html†L2095-L2148】
+* **Renderer capabilities.** Internally the renderer exposes dynamic opacity factors, blend-mode control, and layered drawing routines for backgrounds, zone arcs, focus highlights, and accent typography, making it straightforward to adapt to future wearable layouts.【F:src/ui/adaptive/renderers/LayoutBlueprintRenderer.js†L95-L443】
+
+## Adaptive SDK Integration
+* **SDK bootstrap.** The module imports `createAdaptiveSDK`, instantiates it with telemetry, commercialization, and marketplace hooks, and caches the instance in safe globals to avoid temporal dead zones.【F:wearable-designer.html†L904-L967】【F:wearable-designer.html†L1937-L2069】【F:wearable-designer.html†L2636-L2757】
+* **Projection composer.** Once the SDK is ready, its projection composer attaches to four stacked canvases inside the “4D Projection Field” panel, enabling real-time scenario previews and manual cycle advances.【F:wearable-designer.html†L850-L868】【F:wearable-designer.html†L2673-L2689】
+* **Telemetry & commercialization.** The build wires compliance telemetry providers, consent UI, commercialization snapshot capture/export, and a stubbed remote storage adapter that currently logs uploads locally but is designed to be swapped for real persistence.【F:wearable-designer.html†L912-L923】【F:wearable-designer.html†L2018-L2073】【F:wearable-designer.html†L2637-L2721】
+
+## Using the Tool Today
+1. Open `wearable-designer.html` in a modern browser; the page boots the Adaptive SDK and starts the Vib3 animation stack automatically.【F:wearable-designer.html†L904-L1532】
+2. Use the alignment panel to tune grid dimensions or import JSON specs; the holographic visualizer and grid overlay will realign immediately while the summary tracks the active configuration.【F:wearable-designer.html†L805-L1936】
+3. Tweak the shader composer sliders or JSON to author gradient, arc, highlight, and particle behaviors, then graduate to the Shader Build Suite to manage multi-pass packages, validate them in WebGL, and export production bundles.【F:wearable-designer.html†L850-L940】【F:wearable-designer.html†L1215-L1283】【F:wearable-designer.html†L1663-L1865】
+4. Adjust the overlay intensity slider to balance blueprint diagnostics against the underlying Vib3 effects; export the current blueprint or commercialization snapshots as needed for downstream documentation.【F:wearable-designer.html†L788-L804】【F:wearable-designer.html†L2095-L2148】【F:wearable-designer.html†L2723-L2734】
+5. Explore projection scenarios, variation sliders, and telemetry panels to understand how SDK updates propagate through the interface and to collect mock commercialization data for review.【F:wearable-designer.html†L850-L2757】
+
+## Roadmap Toward Completion
+* Replace the stubbed remote storage adapter and simulated telemetry with real services so consent, uploads, and KPI deltas reflect production data.【F:wearable-designer.html†L2018-L2073】【F:wearable-designer.html†L2637-L2721】
+* Expose authenticated grid imports from source design systems instead of manual JSON uploads, and add export hooks that push finalized specs back to those tools.【F:wearable-designer.html†L1782-L1899】
+* Connect biometric and projection inputs to live sensors or recorded sessions so blueprint intensity, focus highlights, and projection legends visualize actual wearer conditions instead of demos.【F:wearable-designer.html†L2109-L2184】【F:wearable-designer.html†L2637-L2716】
+* Harden the CLI and SDK shims introduced earlier so the wearable designer can be packaged with the Adaptive SDK CLI for automated validation in CI before shipping updates to partners.【F:bin/adaptive-sdk-cli.js†L1-L29】【F:src/cli/runAdaptiveSdkCli.js†L1-L23】
+
+With these integrations in place, the wearable designer will evolve from a guided mock to an end-to-end control room for authoring, validating, and commercializing adaptive wearable experiences.

--- a/bin/adaptive-sdk-cli.js
+++ b/bin/adaptive-sdk-cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/cli/runAdaptiveSdkCli.js')).href;
+
+(async () => {
+  try {
+    const moduleNamespace = await import(moduleUrl);
+    const main = typeof moduleNamespace.main === 'function'
+      ? moduleNamespace.main
+      : typeof moduleNamespace.default === 'function'
+        ? moduleNamespace.default
+        : null;
+
+    if (!main) {
+      throw new Error('runAdaptiveSdkCli.js must export a main function.');
+    }
+
+    const exitCode = await main();
+    if (typeof exitCode === 'number') {
+      process.exitCode = exitCode;
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/src/cli/loaders/srcModuleLoader.mjs
+++ b/src/cli/loaders/srcModuleLoader.mjs
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+const srcRoot = path.join(projectRoot, 'src');
+
+export async function load(url, context, defaultLoad) {
+  if (url.startsWith('file://')) {
+    const filePath = fileURLToPath(url);
+    if (filePath.startsWith(srcRoot) && filePath.endsWith('.js')) {
+      return defaultLoad(url, { ...context, format: 'module' });
+    }
+  }
+  return defaultLoad(url, context);
+}

--- a/src/cli/runAdaptiveSdkCli.js
+++ b/src/cli/runAdaptiveSdkCli.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+let modulePromise = null;
+
+function loadModule() {
+  if (!modulePromise) {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, './runAdaptiveSdkCli.mjs')).href;
+    modulePromise = import(moduleUrl);
+  }
+  return modulePromise;
+}
+
+async function main(argv = process.argv.slice(2), streams) {
+  const moduleNamespace = await loadModule();
+  if (typeof moduleNamespace.main !== 'function') {
+    throw new Error('runAdaptiveSdkCli.mjs must export a main function.');
+  }
+  return moduleNamespace.main(argv, streams);
+}
+
+module.exports = { main };
+module.exports.default = main;

--- a/src/cli/runAdaptiveSdkCli.mjs
+++ b/src/cli/runAdaptiveSdkCli.mjs
@@ -1,0 +1,645 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageManifest = safeReadPackageManifest();
+
+function createIo(streams = {}) {
+  return {
+    stdout: streams.stdout || process.stdout,
+    stderr: streams.stderr || process.stderr
+  };
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepMerge(base, overrides) {
+  if (!isPlainObject(overrides)) {
+    return overrides === undefined ? base : overrides;
+  }
+
+  const result = { ...(isPlainObject(base) ? base : {}) };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (Array.isArray(value)) {
+      const baseArray = Array.isArray(result[key]) ? result[key] : [];
+      result[key] = [...baseArray, ...value];
+      continue;
+    }
+
+    if (isPlainObject(value) && isPlainObject(result[key])) {
+      result[key] = deepMerge(result[key], value);
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function parseArguments(argv = []) {
+  const result = {
+    command: null,
+    options: {},
+    positionals: [],
+    errors: []
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!result.command && !token.startsWith('-')) {
+      result.command = token;
+      continue;
+    }
+
+    switch (token) {
+      case '--help':
+      case '-h':
+        result.options.help = true;
+        continue;
+      case '--demo':
+        result.options.demo = true;
+        continue;
+      case '--no-demo':
+        result.options.demo = false;
+        continue;
+      case '--env':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --env option.');
+        } else {
+          result.options.environment = argv[index];
+        }
+        continue;
+      case '--format':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --format option.');
+        } else {
+          result.options.format = argv[index];
+        }
+        continue;
+      case '--config':
+        index += 1;
+        if (index >= argv.length) {
+          result.errors.push('Missing value for --config option.');
+        } else {
+          result.options.configPath = argv[index];
+        }
+        continue;
+      case '--verbose':
+      case '-v':
+        result.options.verbose = true;
+        continue;
+      case '--no-validate':
+        result.options.validate = false;
+        continue;
+      case '--validate':
+        result.options.validate = true;
+        continue;
+      case '--strict-license':
+        result.options.strictLicense = true;
+        continue;
+      case '--no-strict-license':
+        result.options.strictLicense = false;
+        continue;
+      default:
+        if (token.startsWith('-')) {
+          result.errors.push(`Unknown option: ${token}`);
+        } else {
+          result.positionals.push(token);
+        }
+    }
+  }
+
+  return result;
+}
+
+async function main(argv = process.argv.slice(2), streams) {
+  const io = createIo(streams);
+  const { command, options, positionals, errors } = parseArguments(argv);
+
+  if (errors.length > 0) {
+    for (const message of errors) {
+      io.stderr.write(`${message}\n`);
+    }
+    printHelp(io.stdout);
+    return 1;
+  }
+
+  if (!command || options.help) {
+    printHelp(io.stdout);
+    return 0;
+  }
+
+  switch (command) {
+    case 'status':
+      return runStatusCommand({ ...options, args: positionals }, io);
+    default:
+      io.stderr.write(`Unknown command: ${command}\n`);
+      printHelp(io.stdout);
+      return 1;
+  }
+}
+
+async function runStatusCommand(options, io) {
+  if (options.args && options.args.length > 0) {
+    io.stderr.write(`Unexpected arguments for status command: ${options.args.join(' ')}\n`);
+    return 1;
+  }
+
+  const format = (options.format || 'text').toLowerCase();
+  if (!['text', 'json'].includes(format)) {
+    io.stderr.write(`Unsupported format: ${options.format}. Use "text" or "json".\n`);
+    return 1;
+  }
+
+  try {
+    const report = await buildStatusReport({
+      environment: options.environment,
+      demo: options.demo,
+      configPath: options.configPath,
+      validate: options.validate,
+      strictLicense: options.strictLicense,
+      verbose: options.verbose
+    });
+
+    if (format === 'json') {
+      io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      formatTextReport(report, options, io.stdout, io.stderr);
+    }
+
+    const licenseState = report.license?.status?.state;
+    const licenseValid = licenseState === 'valid';
+    if (options.strictLicense && !licenseValid) {
+      io.stderr.write('License validation failed while --strict-license is enabled.\n');
+      return 3;
+    }
+
+    return 0;
+  } catch (error) {
+    io.stderr.write(`[adaptive-sdk-cli] ${error.message}\n`);
+    if (options.verbose && error.stack) {
+      io.stderr.write(`${error.stack}\n`);
+    }
+    return 1;
+  }
+}
+
+async function buildStatusReport(options = {}) {
+  const environmentName = String(options.environment || 'production');
+  const payload = {
+    environment: environmentName,
+    demo: Boolean(options.demo),
+    configPath: options.configPath ? path.resolve(options.configPath) : null,
+    validate: options.validate !== false,
+    packageVersion: packageManifest.version || '0.0.0'
+  };
+
+  return runStatusWorker(payload);
+}
+
+async function runStatusWorker(payload) {
+  const loaderPath = path.resolve(moduleDirectory, './loaders/srcModuleLoader.mjs');
+  const workerPath = path.resolve(moduleDirectory, './status/statusWorker.mjs');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--experimental-loader', loaderPath, workerPath],
+      { stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+
+    child.on('close', code => {
+      if (code !== 0) {
+        const error = new Error(stderr.trim() || `Status worker exited with code ${code}`);
+        error.code = code;
+        reject(error);
+        return;
+      }
+
+      try {
+        const result = stdout.trim() ? JSON.parse(stdout) : {};
+        resolve(result);
+      } catch (parseError) {
+        parseError.message = `Failed to parse status worker output: ${parseError.message}`;
+        reject(parseError);
+      }
+    });
+
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
+async function buildAdaptiveSdkConfig(options = {}) {
+  const environmentName = String(options.environment || 'production');
+  const baseConfig = {
+    environment: {
+      mode: 'headless',
+      skipVisualization: true,
+      skipUiBindings: true,
+      skipGallery: true,
+      skipExport: true,
+      skipStatus: true,
+      autoStart: false
+    },
+    sensory: {
+      autoConnectAdapters: false,
+      pollingInterval: 120000,
+      confidenceThreshold: 0.35
+    },
+    telemetry: {
+      enabled: true,
+      auditLogLimit: 400,
+      classificationRules: [
+        { prefix: 'adaptive.', classification: 'interaction' },
+        { prefix: 'design.', classification: 'analytics' },
+        { prefix: 'sensors.', classification: 'system' },
+        { prefix: 'privacy.', classification: 'compliance' }
+      ],
+      defaultConsent: {
+        system: true,
+        compliance: true,
+        interaction: true,
+        analytics: false,
+        biometric: false
+      },
+      commercialization: {
+        captureInitialSnapshot: true,
+        snapshotStore: {
+          maxSnapshots: 24
+        },
+        snapshotIntervalMs: undefined
+      },
+      licenseAttestationProfilePacks: [
+        { id: 'enterprise-saas', options: { applyDefault: false } },
+        { id: 'studio-collab', options: { applyDefault: false } },
+        'indie-lab'
+      ]
+    },
+    sensorAdapters: createDemoSensorAdapters(environmentName),
+    consentOptions: createConsentOptions(environmentName)
+  };
+
+  if (options.demo) {
+    baseConfig.license = createDemoLicenseConfig(environmentName);
+    baseConfig.telemetry.defaultConsent.analytics = true;
+    baseConfig.telemetry.defaultConsent.biometric = true;
+    baseConfig.telemetry.defaultConsent.interaction = true;
+  }
+
+  if (options.configPath) {
+    const overrides = await readConfigOverrides(options.configPath);
+    if (overrides) {
+      return deepMerge(baseConfig, overrides);
+    }
+  }
+
+  return baseConfig;
+}
+
+function createConsentOptions(environmentName) {
+  const tier = environmentName.toLowerCase();
+  return [
+    {
+      id: 'analytics',
+      label: 'Share anonymized adaptive analytics',
+      defaultState: tier === 'production'
+    },
+    {
+      id: 'biometric',
+      label: 'Allow biometric-derived insights for personalization',
+      defaultState: tier !== 'production'
+    },
+    {
+      id: 'interaction',
+      label: 'Record adaptive interaction gestures',
+      defaultState: true
+    }
+  ];
+}
+
+function createDemoLicenseConfig(environmentName) {
+  const now = new Date();
+  const expiry = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+  const normalizedEnv = environmentName.toLowerCase();
+  const seats = normalizedEnv === 'production' ? 500 : 75;
+
+  return {
+    key: `DEMO-${normalizedEnv.toUpperCase()}-ADAPTIVE-${now.getUTCFullYear()}`,
+    tenantId: normalizedEnv === 'production' ? 'wearable-enterprise' : `demo-${normalizedEnv}`,
+    features: [
+      'adaptive-layout',
+      'projection-scenarios',
+      'telemetry-hardened',
+      'commercialization-reports'
+    ],
+    issuedAt: now.toISOString(),
+    expiresAt: expiry.toISOString(),
+    managerOptions: {
+      logger: console
+    },
+    validators: [async license => {
+      const valid = typeof license.key === 'string' && license.key.startsWith('DEMO-');
+      if (!valid) {
+        return { valid: false, reason: 'DEMO_KEY_REQUIRED' };
+      }
+      return {
+        valid: true,
+        metadata: {
+          tier: normalizedEnv === 'production' ? 'enterprise-evaluation' : 'sandbox',
+          seats,
+          entitlements: ['adaptive-layout', 'telemetry-hardened', 'commercialization-reports'],
+          lastValidatedBy: 'adaptive-sdk-cli'
+        }
+      };
+    }],
+    attestor: createDemoLicenseAttestor(environmentName),
+    autoValidate: true
+  };
+}
+
+function createDemoLicenseAttestor(environmentName) {
+  const normalizedEnv = environmentName.toLowerCase();
+  return {
+    id: `demo-attestor-${normalizedEnv}`,
+    createValidator() {
+      return async (license, context = {}) => {
+        const valid = typeof license.key === 'string' && license.key.startsWith('DEMO-');
+        if (!valid) {
+          return { valid: false, reason: 'ATTESTATION_KEY_MISMATCH' };
+        }
+        return {
+          valid: true,
+          metadata: {
+            remote: {
+              attestedAt: new Date().toISOString(),
+              region: normalizedEnv,
+              entitlements: ['adaptive-layout', 'projection-scenarios'],
+              context
+            }
+          }
+        };
+      };
+    },
+    bindToLicenseManager(manager) {
+      const validator = this.createValidator();
+      const detach = manager.registerValidator(async (license, context) => validator(license, context));
+      return () => {
+        if (typeof detach === 'function') {
+          detach();
+        }
+      };
+    }
+  };
+}
+
+function createDemoSensorAdapters(environmentName) {
+  const adapters = [
+    {
+      type: 'eye-tracking',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.92,
+        payload: { x: 0.48, y: 0.52, depth: 0.31 }
+      }))
+    },
+    {
+      type: 'neural-intent',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.88,
+        payload: { x: 0.04, y: -0.03, z: 0.02, w: 0.15, engagement: 0.62 }
+      }))
+    },
+    {
+      type: 'biometric',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.9,
+        payload: { stress: 0.22, heartRate: 72, temperature: 36.6 }
+      }))
+    },
+    {
+      type: 'ambient',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.86,
+        payload: { luminance: 0.58, noiseLevel: 0.18, motion: 0.14 }
+      }))
+    },
+    {
+      type: 'gesture',
+      instance: createStaticSensorAdapter(() => ({
+        confidence: 0.83,
+        payload: { intent: 'focus-hold', vector: { x: 0.42, y: 0.38, z: 0.21 } }
+      }))
+    }
+  ];
+
+  return adapters.map(entry => ({
+    type: entry.type,
+    instance: entry.instance,
+    autoConnect: false
+  }));
+}
+
+function createStaticSensorAdapter(sampleFactory) {
+  let connected = false;
+  return {
+    async connect() {
+      connected = true;
+    },
+    async disconnect() {
+      connected = false;
+    },
+    async read() {
+      if (!connected) {
+        return { confidence: 0, payload: {} };
+      }
+      const sample = sampleFactory();
+      return {
+        confidence: sample.confidence ?? 1,
+        payload: sample.payload || {}
+      };
+    },
+    async test() {
+      return { ok: true, latencyMs: 8 };
+    }
+  };
+}
+
+async function readConfigOverrides(configPath) {
+  try {
+    const absolutePath = path.resolve(configPath);
+    const content = await fs.readFile(absolutePath, 'utf8');
+    const parsed = JSON.parse(content);
+    if (!isPlainObject(parsed)) {
+      throw new Error('Configuration override must be a JSON object.');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to load configuration from ${configPath}: ${error.message}`);
+  }
+}
+
+function formatTextReport(report, options, stdout, stderr) {
+  const header = `Adaptive SDK CLI ${report.metadata.version} — Status (${report.metadata.environment})`;
+  stdout.write(`${header}\n`);
+  stdout.write(`${'-'.repeat(header.length)}\n`);
+  stdout.write(`Generated: ${report.metadata.generatedAt}\n`);
+  stdout.write(`Demo mode: ${report.metadata.demo ? 'enabled' : 'disabled'}\n`);
+  stdout.write(`Configuration: ${report.metadata.configSource}\n`);
+  stdout.write(`Strict license check: ${options.strictLicense ? 'enabled' : 'disabled'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Environment\n');
+  stdout.write(`  Mode: ${report.environment.mode}\n`);
+  stdout.write(`  Visualization skipped: ${report.environment.skipVisualization ? 'yes' : 'no'}\n`);
+  stdout.write(`  UI bindings skipped: ${report.environment.skipUiBindings ? 'yes' : 'no'}\n`);
+  stdout.write(`  Gallery disabled: ${report.environment.skipGallery ? 'yes' : 'no'}\n`);
+  stdout.write(`  Export disabled: ${report.environment.skipExport ? 'yes' : 'no'}\n`);
+  stdout.write('\n');
+
+  stdout.write('License\n');
+  const licenseStatus = report.license.status || {};
+  stdout.write(`  State: ${licenseStatus.state || 'unknown'}\n`);
+  stdout.write(`  Reason: ${licenseStatus.reason || 'n/a'}\n`);
+  if (licenseStatus.validatedAt) {
+    stdout.write(`  Validated at: ${licenseStatus.validatedAt}\n`);
+  }
+  const licenseDetails = report.license.details || {};
+  if (licenseDetails.key) {
+    stdout.write(`  License key: ${licenseDetails.key}\n`);
+  }
+  if (Array.isArray(licenseDetails.features)) {
+    stdout.write(`  Features: ${licenseDetails.features.join(', ')}\n`);
+  }
+  if (licenseDetails.expiresAt) {
+    stdout.write(`  Expires at: ${licenseDetails.expiresAt}\n`);
+  }
+  if (licenseStatus.metadata) {
+    stdout.write(`  Metadata: ${JSON.stringify(licenseStatus.metadata)}\n`);
+  }
+  stdout.write('\n');
+
+  stdout.write('Telemetry\n');
+  stdout.write(`  Enabled: ${report.telemetry.enabled ? 'yes' : 'no'}\n`);
+  stdout.write(`  Providers: ${report.telemetry.providers.map(provider => provider.id).join(', ') || 'none'}\n`);
+  stdout.write(`  Consent: ${formatConsent(report.telemetry.consent)}\n`);
+  stdout.write(`  Audit entries: ${report.telemetry.auditTrail.totalEntries}\n`);
+  stdout.write(`  Buffer size: ${report.telemetry.bufferSize}\n`);
+  stdout.write(`  Attestation profiles: ${report.telemetry.licenseAttestation.profiles.length}\n`);
+  if (report.telemetry.licenseAttestation.defaultProfileId) {
+    stdout.write(`  Default profile: ${report.telemetry.licenseAttestation.defaultProfileId}\n`);
+  }
+  const commercialization = report.telemetry.commercialization;
+  stdout.write(`  Commercialization packs: ${commercialization.summary.packs?.length || 0}\n`);
+  stdout.write(`  Commercialization snapshots: ${commercialization.snapshotCount}\n`);
+  stdout.write('\n');
+
+  stdout.write('Sensors\n');
+  stdout.write(`  Auto-connect adapters: ${report.sensors.autoConnect ? 'yes' : 'no'}\n`);
+  stdout.write(`  Polling interval: ${report.sensors.pollingIntervalMs} ms\n`);
+  stdout.write(`  Registered schemas: ${report.sensors.registeredSchemas.join(', ') || 'none'}\n`);
+  stdout.write(`  Registered adapters: ${report.sensors.adapters.map(adapter => adapter.type).join(', ') || 'none'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Layout & Design\n');
+  stdout.write(`  Layout strategies (${report.layout.strategyCount}): ${report.layout.strategies.join(', ') || 'none'}\n`);
+  stdout.write(`  Layout annotations: ${report.layout.annotations.join(', ') || 'none'}\n`);
+  stdout.write(`  Active design language: ${report.design.activeLanguage ? report.design.activeLanguage.name : 'none'}\n`);
+  stdout.write(`  Available design languages: ${report.design.languages.map(language => language.name).join(', ') || 'none'}\n`);
+  stdout.write('\n');
+
+  stdout.write('Projection\n');
+  stdout.write(`  Registered scenarios: ${report.projection.scenarioCount}\n`);
+  if (report.projection.scenarioCount > 0) {
+    stdout.write(`  Scenario ids: ${report.projection.scenarios.map(scenario => scenario.id).join(', ')}\n`);
+  }
+
+  if (options.verbose && report.telemetry.auditTrail.recent.length > 0) {
+    stdout.write('\nRecent audit trail entries:\n');
+    for (const entry of report.telemetry.auditTrail.recent) {
+      stdout.write(`  • ${entry.event || entry.type || 'event'} at ${entry.timestamp}\n`);
+    }
+  }
+
+  if (options.strictLicense && licenseStatus.state !== 'valid') {
+    stderr.write('\nLicense is not valid. Enable a valid key or disable --strict-license to continue.\n');
+  }
+}
+
+function formatConsent(consentMap) {
+  const entries = Object.entries(consentMap);
+  if (entries.length === 0) {
+    return 'none';
+  }
+  return entries.map(([key, value]) => `${key}=${value ? 'granted' : 'revoked'}`).join(', ');
+}
+
+function printHelp(stdout = process.stdout) {
+  const lines = [
+    'Adaptive SDK CLI',
+    '',
+    'Usage:',
+    '  adaptive-sdk-cli <command> [options]',
+    '',
+    'Commands:',
+    '  status             Display a synthesized Adaptive SDK runtime report.',
+    '',
+    'Status options:',
+    '  --demo                 Bootstrap using demo instrumentation and license.',
+    '  --env <name>           Label the target environment (default: production).',
+    '  --format <text|json>   Output the report as formatted text or JSON.',
+    '  --config <path>        Merge additional SDK configuration overrides (JSON).',
+    '  --strict-license       Exit with a non-zero code when the license is not valid.',
+    '  --no-validate          Skip license validation before reporting.',
+    '  --verbose              Include expanded diagnostics on failure.',
+    '',
+    'Global options:',
+    '  -h, --help             Show this help message.'
+  ];
+
+  for (const line of lines) {
+    stdout.write(`${line}\n`);
+  }
+}
+
+function safeReadPackageManifest() {
+  try {
+    const require = createRequire(import.meta.url);
+    // eslint-disable-next-line import/no-dynamic-require
+    return require('../../package.json');
+  } catch (error) {
+    return { name: 'adaptive-sdk-cli', version: '0.0.0' };
+  }
+}
+
+export {
+  main,
+  parseArguments,
+  buildStatusReport,
+  buildAdaptiveSdkConfig
+};
+
+export default main;

--- a/src/cli/status/statusWorker.mjs
+++ b/src/cli/status/statusWorker.mjs
@@ -1,0 +1,211 @@
+import { stdin, exit } from 'node:process';
+
+async function readPayload() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    stdin.setEncoding('utf8');
+    stdin.on('data', chunk => {
+      data += chunk;
+    });
+    stdin.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    stdin.on('error', reject);
+  });
+}
+
+async function main() {
+  const payload = await readPayload();
+  const { buildAdaptiveSdkConfig } = await import('../runAdaptiveSdkCli.mjs');
+  const { createAdaptiveSDK } = await import('../../core/AdaptiveSDK.js');
+
+  const config = await buildAdaptiveSdkConfig({
+    environment: payload.environment,
+    demo: payload.demo,
+    configPath: payload.configPath
+  });
+
+  const sdk = createAdaptiveSDK(config);
+  const report = {
+    metadata: {
+      environment: payload.environment,
+      demo: Boolean(payload.demo),
+      generatedAt: new Date().toISOString(),
+      configSource: payload.configPath || 'embedded',
+      version: payload.packageVersion || '0.0.0'
+    }
+  };
+
+  try {
+    const licenseManager = sdk.licenseManager || null;
+    let licenseStatus = licenseManager ? licenseManager.getStatus() : { state: 'unconfigured', reason: 'NO_LICENSE' };
+
+    if (licenseManager && payload.validate !== false) {
+      licenseStatus = await licenseManager.validate({
+        source: 'adaptive-sdk-cli',
+        environment: payload.environment,
+        demo: Boolean(payload.demo)
+      });
+    }
+
+    const telemetry = sdk.telemetry;
+    telemetry.track('cli.status.invoked', {
+      environment: payload.environment,
+      demo: Boolean(payload.demo),
+      version: report.metadata.version
+    }, { classification: 'system' });
+    telemetry.identify('adaptive-sdk-cli', {
+      environment: payload.environment,
+      mode: payload.demo ? 'demo' : 'standard'
+    }, { classification: 'system' });
+
+    const consentEntries = telemetry.consent instanceof Map
+      ? Object.fromEntries(telemetry.consent)
+      : {};
+
+    const providers = telemetry.providers instanceof Map
+      ? Array.from(telemetry.providers.values()).map(provider => ({
+          id: provider.id,
+          metadata: provider.metadata || {}
+        }))
+      : [];
+
+    const auditTrail = telemetry.getAuditTrail();
+
+    if (telemetry.getCommercializationSnapshotStore()) {
+      telemetry.captureCommercializationSnapshot({
+        trigger: 'cli-status',
+        environment: payload.environment,
+        demo: Boolean(payload.demo)
+      });
+    }
+
+    const commercializationSummary = telemetry.getCommercializationSummary();
+    const snapshotStore = telemetry.getCommercializationSnapshotStore();
+    const snapshots = snapshotStore ? snapshotStore.getSnapshots({ limit: 3 }) : [];
+    const kpiReport = snapshotStore ? snapshotStore.getKpiReport({ limit: 2 }) : null;
+
+    const attestationProfiles = telemetry.licenseAttestationProfiles?.getProfiles?.() || [];
+    const defaultProfileId = telemetry.licenseAttestationProfiles?.getDefaultProfileId?.() || null;
+
+    const sensoryBridge = sdk.sensoryBridge;
+    const schemaRegistry = sensoryBridge.getSchemaRegistry();
+    const registeredSchemas = schemaRegistry?.schemas instanceof Map
+      ? Array.from(schemaRegistry.schemas.keys())
+      : [];
+    const registeredAdapters = sensoryBridge.adapters instanceof Map
+      ? Array.from(sensoryBridge.adapters.entries()).map(([type, adapter]) => ({
+          type,
+          hasConnect: typeof adapter.connect === 'function',
+          hasDisconnect: typeof adapter.disconnect === 'function',
+          hasTest: typeof adapter.test === 'function'
+        }))
+      : [];
+
+    const layoutStrategies = Array.isArray(sdk.layoutSynthesizer?.strategies)
+      ? sdk.layoutSynthesizer.strategies.map(strategy => strategy.id || 'unknown')
+      : [];
+    const layoutAnnotations = Array.isArray(sdk.layoutSynthesizer?.annotations)
+      ? sdk.layoutSynthesizer.annotations.map(annotation => annotation.id || 'unknown')
+      : [];
+
+    const designLanguages = sdk.designLanguageManager?.languages instanceof Map
+      ? Array.from(sdk.designLanguageManager.languages.entries()).map(([id, descriptor]) => ({
+          id,
+          name: descriptor?.name || id
+        }))
+      : [];
+    const activeDesignLanguage = sdk.designLanguageManager?.getActiveLanguage?.();
+
+    const projectionScenarios = sdk.projectionSimulator?.listScenarios?.() || [];
+
+    const telemetryBufferSize = Array.isArray(telemetry.buffer) ? telemetry.buffer.length : 0;
+
+    report.environment = {
+      mode: sdk.engine?.environment?.mode || 'headless',
+      skipVisualization: Boolean(sdk.engine?.environment?.skipVisualization),
+      skipUiBindings: Boolean(sdk.engine?.environment?.skipUiBindings),
+      skipStatus: Boolean(sdk.engine?.environment?.skipStatus),
+      skipGallery: Boolean(sdk.engine?.environment?.skipGallery),
+      skipExport: Boolean(sdk.engine?.environment?.skipExport),
+      autoStart: Boolean(sdk.engine?.environment?.autoStart)
+    };
+
+    report.license = {
+      status: licenseStatus,
+      details: licenseManager ? licenseManager.getLicense() : null,
+      history: licenseManager ? licenseManager.getValidationHistory() : []
+    };
+
+    report.telemetry = {
+      enabled: telemetry.enabled,
+      consent: consentEntries,
+      providers,
+      bufferSize: telemetryBufferSize,
+      auditTrail: {
+        totalEntries: auditTrail.length,
+        recent: auditTrail.slice(-5)
+      },
+      commercialization: {
+        summary: commercializationSummary,
+        snapshotCount: snapshots.length,
+        snapshots,
+        kpiReport
+      },
+      licenseAttestation: {
+        defaultProfileId,
+        profiles: attestationProfiles
+      }
+    };
+
+    report.sensors = {
+      autoConnect: Boolean(sensoryBridge.autoConnectAdapters),
+      pollingIntervalMs: sensoryBridge.pollingInterval,
+      confidenceThreshold: sensoryBridge.confidenceThreshold,
+      registeredSchemas,
+      adapters: registeredAdapters,
+      snapshot: sensoryBridge.getSnapshot()
+    };
+
+    report.layout = {
+      strategyCount: layoutStrategies.length,
+      strategies: layoutStrategies,
+      annotations: layoutAnnotations
+    };
+
+    report.design = {
+      activeLanguage: activeDesignLanguage ? {
+        id: sdk.designLanguageManager.activeLanguage,
+        name: activeDesignLanguage.name,
+        description: activeDesignLanguage.description
+      } : null,
+      languages: designLanguages
+    };
+
+    report.projection = {
+      scenarioCount: projectionScenarios.length,
+      scenarios: projectionScenarios
+    };
+
+    if (typeof telemetry.flush === 'function') {
+      await telemetry.flush();
+    }
+
+    console.log(JSON.stringify(report));
+  } finally {
+    try {
+      sdk.engine?.dispose?.();
+    } catch (error) {
+      // ignore disposal errors
+    }
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  exit(1);
+});

--- a/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
+++ b/src/ui/adaptive/renderers/LayoutBlueprintRenderer.js
@@ -97,6 +97,19 @@ export class LayoutBlueprintRenderer {
         this.layers = new Map();
         this.zoneColors = { ...DEFAULT_ZONE_COLORS, ...(options.zoneColors || {}) };
         this.background = { ...DEFAULT_BACKGROUND, ...(options.background || {}) };
+        this.backgroundBlendMode = options.backgroundBlendMode || 'source-over';
+        this.backgroundOpacity = typeof options.backgroundOpacity === 'number'
+            ? clamp(options.backgroundOpacity, 0, 1)
+            : 1;
+        this.zoneOpacityFactor = typeof options.zoneOpacityFactor === 'number'
+            ? clamp(options.zoneOpacityFactor, 0, 1)
+            : 1;
+        this.highlightOpacityFactor = typeof options.highlightOpacityFactor === 'number'
+            ? clamp(options.highlightOpacityFactor, 0, 1)
+            : 1;
+        this.accentOpacityFactor = typeof options.accentOpacityFactor === 'number'
+            ? clamp(options.accentOpacityFactor, 0, 1)
+            : 1;
         this.devicePadding = options.devicePadding ?? 0.12;
         this.lastSize = 0;
         this.lastRenderPayload = null;
@@ -180,6 +193,55 @@ export class LayoutBlueprintRenderer {
         }
     }
 
+    setVisualOptions(options = {}) {
+        let shouldRerender = false;
+
+        if (Object.prototype.hasOwnProperty.call(options, 'backgroundOpacity')) {
+            const next = clamp(toNumber(options.backgroundOpacity, this.backgroundOpacity), 0, 1);
+            if (next !== this.backgroundOpacity) {
+                this.backgroundOpacity = next;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'backgroundBlendMode')) {
+            const nextBlend = options.backgroundBlendMode || 'source-over';
+            if (nextBlend !== this.backgroundBlendMode) {
+                this.backgroundBlendMode = nextBlend;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'zoneOpacityFactor')) {
+            const nextZone = clamp(toNumber(options.zoneOpacityFactor, this.zoneOpacityFactor), 0, 1);
+            if (nextZone !== this.zoneOpacityFactor) {
+                this.zoneOpacityFactor = nextZone;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'highlightOpacityFactor')) {
+            const nextHighlight = clamp(toNumber(options.highlightOpacityFactor, this.highlightOpacityFactor), 0, 1);
+            if (nextHighlight !== this.highlightOpacityFactor) {
+                this.highlightOpacityFactor = nextHighlight;
+                shouldRerender = true;
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, 'accentOpacityFactor')) {
+            const nextAccent = clamp(toNumber(options.accentOpacityFactor, this.accentOpacityFactor), 0, 1);
+            if (nextAccent !== this.accentOpacityFactor) {
+                this.accentOpacityFactor = nextAccent;
+                shouldRerender = true;
+            }
+        }
+
+        if (shouldRerender && this.lastRenderPayload) {
+            const { layout, design, context } = this.lastRenderPayload;
+            this.render(layout, design, context);
+        }
+    }
+
     render(layout, design, context) {
         if (!layout) return;
         this.lastRenderPayload = { layout, design, context };
@@ -203,11 +265,17 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        context.save();
+        if (this.backgroundBlendMode && this.backgroundBlendMode !== 'source-over') {
+            context.globalCompositeOperation = this.backgroundBlendMode;
+        }
+        context.globalAlpha = this.backgroundOpacity;
         const gradient = context.createRadialGradient(size / 2, size / 2, size * 0.1, size / 2, size / 2, size * 0.55);
         gradient.addColorStop(0, this.background.inner);
         gradient.addColorStop(1, this.background.outer);
         context.fillStyle = gradient;
         context.fillRect(0, 0, canvas.width, canvas.height);
+        context.restore();
     }
 
     drawShadow(size, center, radius) {
@@ -250,7 +318,13 @@ export class LayoutBlueprintRenderer {
             context.save();
             context.strokeStyle = color;
             context.lineWidth = thickness;
-            context.globalAlpha = 0.65 + (occupancy * 0.25);
+            const zoneAlpha = clamp((0.65 + occupancy * 0.25) * this.zoneOpacityFactor, 0, 1);
+            if (zoneAlpha <= 0) {
+                context.restore();
+                currentRadius -= thickness * 0.8;
+                continue;
+            }
+            context.globalAlpha = zoneAlpha;
             context.lineCap = 'round';
             context.beginPath();
             context.arc(center, center, currentRadius, start, end);
@@ -263,11 +337,14 @@ export class LayoutBlueprintRenderer {
                 const x = center + Math.cos(angle) * pointRadius;
                 const y = center + Math.sin(angle) * pointRadius;
                 context.save();
-                context.fillStyle = color;
-                context.globalAlpha = 0.6;
-                context.beginPath();
-                context.arc(x, y, Math.max(4, thickness * 0.15), 0, Math.PI * 2);
-                context.fill();
+                const markerAlpha = clamp(this.zoneOpacityFactor * 0.8, 0, 1);
+                if (markerAlpha > 0) {
+                    context.fillStyle = color;
+                    context.globalAlpha = markerAlpha;
+                    context.beginPath();
+                    context.arc(x, y, Math.max(4, thickness * 0.15), 0, Math.PI * 2);
+                    context.fill();
+                }
                 context.restore();
             }
 
@@ -280,6 +357,10 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        const highlightAlpha = clamp(this.highlightOpacityFactor, 0, 1);
+        if (highlightAlpha <= 0) {
+            return;
+        }
         const focus = normalizeFocusVector(contextSnapshot?.focusVector);
         const radius = size * 0.12;
         const x = focus.x * size;
@@ -288,10 +369,14 @@ export class LayoutBlueprintRenderer {
         const gradient = context.createRadialGradient(x, y, size * 0.01, x, y, radius);
         gradient.addColorStop(0, 'rgba(76, 159, 255, 0.5)');
         gradient.addColorStop(1, 'rgba(76, 159, 255, 0)');
+        context.save();
+        context.globalAlpha = highlightAlpha;
         context.fillStyle = gradient;
         context.fillRect(0, 0, canvas.width, canvas.height);
+        context.restore();
 
         context.save();
+        context.globalAlpha = clamp(this.highlightOpacityFactor * 1.15, 0, 1);
         context.fillStyle = 'rgba(255, 255, 255, 0.9)';
         context.beginPath();
         context.arc(x, y, size * (0.01 + clamp(toNumber(layout.intensity, 0.5), 0, 1) * 0.015), 0, Math.PI * 2);
@@ -304,6 +389,10 @@ export class LayoutBlueprintRenderer {
         if (!layer) return;
         const { context, canvas } = layer;
         context.clearRect(0, 0, canvas.width, canvas.height);
+        const accentAlpha = clamp(this.accentOpacityFactor, 0, 1);
+        if (accentAlpha <= 0) {
+            return;
+        }
 
         const patternName = design?.pattern?.name || 'Adaptive Pattern';
         const tier = design?.monetization?.tier || 'starter';
@@ -318,6 +407,7 @@ export class LayoutBlueprintRenderer {
         const componentLine = Array.from(components).join('  •  ');
 
         context.save();
+        context.globalAlpha = accentAlpha;
         context.fillStyle = 'rgba(255, 255, 255, 0.82)';
         context.textAlign = 'center';
         context.font = `${Math.round(size * 0.04)}px "Inter", "Segoe UI", sans-serif`;

--- a/wearable-designer.html
+++ b/wearable-designer.html
@@ -30,6 +30,29 @@
             overflow: hidden;
         }
 
+        .canvas-stack::before,
+        .canvas-stack::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 45% 55%, rgba(46, 132, 255, 0.18), transparent 62%),
+                        radial-gradient(circle at 65% 35%, rgba(255, 122, 255, 0.14), transparent 58%),
+                        radial-gradient(circle at 25% 25%, rgba(76, 255, 196, 0.12), transparent 55%);
+            mix-blend-mode: screen;
+            opacity: 0.4;
+            transform: scale(1.1);
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .canvas-stack::before {
+            animation: vib3Pulse 18s ease-in-out infinite;
+        }
+
+        .canvas-stack::after {
+            animation: vib3Drift 24s ease-in-out infinite;
+        }
+
         .canvas-stack canvas {
             position: absolute;
             width: 88vmin;
@@ -38,13 +61,55 @@
             max-height: 880px;
             border-radius: 28px;
             backdrop-filter: blur(20px);
+            z-index: 1;
         }
 
-        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.35; }
-        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.45; }
+        .canvas-stack canvas.vib3-layer {
+            z-index: 2;
+            filter: saturate(1.25) brightness(1.1);
+        }
+
+        .canvas-stack .blueprint-overlay {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            pointer-events: none;
+            z-index: 4;
+        }
+
+        .canvas-stack canvas.blueprint-layer {
+            mix-blend-mode: screen;
+            opacity: 0.6;
+            filter: drop-shadow(0 0 32px rgba(76, 159, 255, 0.35));
+            z-index: 5;
+        }
+
+        .canvas-stack canvas.grid-layer {
+            mix-blend-mode: screen;
+            opacity: 0.55;
+            z-index: 4;
+            pointer-events: none;
+        }
+
+        .canvas-stack canvas:nth-child(1) { mix-blend-mode: screen; opacity: 0.38; }
+        .canvas-stack canvas:nth-child(2) { mix-blend-mode: lighten; opacity: 0.48; }
         .canvas-stack canvas:nth-child(3) { mix-blend-mode: normal; }
-        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.6; }
-        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.8; }
+        .canvas-stack canvas:nth-child(4) { mix-blend-mode: screen; opacity: 0.62; }
+        .canvas-stack canvas:nth-child(5) { mix-blend-mode: screen; opacity: 0.82; }
+
+        @keyframes vib3Pulse {
+            0% { transform: scale(1.08) rotate(0deg); opacity: 0.28; }
+            50% { transform: scale(1.16) rotate(4deg); opacity: 0.44; }
+            100% { transform: scale(1.08) rotate(-2deg); opacity: 0.32; }
+        }
+
+        @keyframes vib3Drift {
+            0% { transform: scale(1.05) translate(0, 0); opacity: 0.22; }
+            40% { transform: scale(1.15) translate(2%, -1%); opacity: 0.36; }
+            70% { transform: scale(1.12) translate(-1%, 2%); opacity: 0.3; }
+            100% { transform: scale(1.05) translate(0, 0); opacity: 0.24; }
+        }
 
         aside {
             padding: 32px;
@@ -62,6 +127,13 @@
             padding: 24px;
             border: 1px solid rgba(255, 255, 255, 0.05);
             box-shadow: 0 20px 40px rgba(10, 20, 40, 0.35);
+        }
+
+        .panel-description {
+            margin: 0 0 16px;
+            font-size: 0.78rem;
+            line-height: 1.5;
+            color: rgba(255, 255, 255, 0.6);
         }
 
         .panel h2 {
@@ -155,6 +227,38 @@
             color: rgba(255, 255, 255, 0.55);
             margin-top: 4px;
             letter-spacing: 0.03em;
+        }
+
+        .overlay-control {
+            margin: 16px 0 18px;
+            display: grid;
+            gap: 8px;
+        }
+
+        .overlay-control label {
+            font-size: 0.72rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .overlay-control__range {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .overlay-control input[type="range"] {
+            flex: 1;
+            accent-color: var(--accent);
+        }
+
+        .overlay-control__value {
+            min-width: 3ch;
+            text-align: right;
+            font-size: 0.72rem;
+            letter-spacing: 0.06em;
+            color: rgba(255, 255, 255, 0.6);
         }
 
         .meta-line {
@@ -472,6 +576,387 @@
             background: rgba(255, 255, 255, 0.1);
         }
 
+        .layout-grid-controls {
+            display: grid;
+            gap: 14px;
+            margin-bottom: 18px;
+        }
+
+        .layout-grid-row {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .grid-control {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            padding: 12px 14px;
+            border-radius: 14px;
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.04);
+        }
+
+        .grid-control span {
+            font-size: 0.72rem;
+            letter-spacing: 0.04em;
+            color: rgba(255, 255, 255, 0.6);
+            text-transform: uppercase;
+        }
+
+        .grid-control input[type='number'] {
+            background: rgba(0, 0, 0, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            padding: 8px 10px;
+            color: #f5f7fb;
+            font-size: 0.95rem;
+        }
+
+        .grid-range {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .grid-range__label {
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.72rem;
+            letter-spacing: 0.04em;
+            color: rgba(255, 255, 255, 0.6);
+            text-transform: uppercase;
+        }
+
+        .grid-range input[type='range'] {
+            width: 100%;
+        }
+
+        .shader-control-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .shader-control {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 14px;
+            padding: 14px 16px;
+        }
+
+        .shader-control label {
+            font-size: 0.74rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .shader-control__input {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .shader-control__input input[type='range'],
+        .shader-control__input input[type='number'] {
+            flex: 1;
+        }
+
+        .shader-control__value {
+            min-width: 52px;
+            text-align: right;
+            font-size: 0.82rem;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .shader-config-editor {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .shader-config-editor textarea {
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 16px;
+            color: #f5f7fb;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.8rem;
+            padding: 14px 16px;
+            min-height: 160px;
+            resize: vertical;
+        }
+
+        .shader-config-editor textarea:focus {
+            outline: none;
+            border-color: rgba(76, 159, 255, 0.5);
+            box-shadow: 0 0 0 1px rgba(76, 159, 255, 0.35);
+        }
+
+        .shader-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .shader-actions .file-input-label {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            color: rgba(255, 255, 255, 0.8);
+            cursor: pointer;
+            font-size: 0.82rem;
+            letter-spacing: 0.02em;
+        }
+
+        .shader-actions .file-input-label:hover {
+            border-color: rgba(76, 159, 255, 0.35);
+            color: #fff;
+        }
+
+        .shader-actions .file-input-label input[type='file'] {
+            display: none;
+        }
+
+        .shader-package-meta {
+            display: grid;
+            gap: 12px;
+            margin-bottom: 18px;
+        }
+
+        .shader-package-meta label {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 0.74rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .shader-package-meta input,
+        .shader-package-meta textarea,
+        .shader-pass-meta input,
+        .shader-pass-meta select {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 12px;
+            color: #f5f7fb;
+            font-size: 0.9rem;
+            padding: 10px 12px;
+            font-family: inherit;
+        }
+
+        .shader-package-meta textarea {
+            resize: vertical;
+            min-height: 72px;
+        }
+
+        .shader-build-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+            gap: 18px;
+            align-items: start;
+            margin-bottom: 18px;
+        }
+
+        .shader-pass-column {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .shader-pass-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.74rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .shader-pass-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            gap: 8px;
+        }
+
+        .shader-pass-list button {
+            width: 100%;
+            text-align: left;
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            background: rgba(255, 255, 255, 0.03);
+            color: rgba(255, 255, 255, 0.82);
+            font-size: 0.85rem;
+            letter-spacing: 0.02em;
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .shader-pass-list button:hover {
+            border-color: rgba(76, 159, 255, 0.35);
+            background: rgba(76, 159, 255, 0.08);
+        }
+
+        .shader-pass-list button.active {
+            border-color: rgba(76, 159, 255, 0.55);
+            background: rgba(76, 159, 255, 0.16);
+            color: #fff;
+        }
+
+        .shader-pass-footer {
+            display: grid;
+            gap: 10px;
+        }
+
+        .shader-pass-footer label {
+            font-size: 0.74rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .shader-pass-footer select {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 12px;
+            padding: 9px 12px;
+            color: #f5f7fb;
+            font-size: 0.9rem;
+        }
+
+        .shader-pass-editor {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .shader-pass-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 12px;
+        }
+
+        .shader-code-editor {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .shader-code-editor label {
+            font-size: 0.74rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .shader-code-editor textarea {
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.78rem;
+            min-height: 140px;
+            background: rgba(12, 18, 32, 0.7);
+            border: 1px solid rgba(76, 159, 255, 0.2);
+            border-radius: 16px;
+            color: #f5f7fb;
+            padding: 14px 16px;
+            resize: vertical;
+        }
+
+        #shaderPreviewCanvas {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            border-radius: 18px;
+            border: 1px solid rgba(76, 159, 255, 0.2);
+            background: rgba(0, 0, 0, 0.4);
+        }
+
+        .shader-build-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-top: 16px;
+            align-items: center;
+        }
+
+        .shader-package-status {
+            margin-top: 8px;
+            font-size: 0.78rem;
+            min-height: 1.2em;
+            color: rgba(255, 255, 255, 0.62);
+        }
+
+        .shader-package-status[data-tone='success'] {
+            color: rgba(148, 255, 208, 0.9);
+        }
+
+        .shader-package-status[data-tone='error'] {
+            color: rgba(255, 138, 138, 0.85);
+        }
+
+        @media (max-width: 1280px) {
+            .shader-build-grid {
+                grid-template-columns: 1fr;
+            }
+
+            #shaderPreviewCanvas {
+                aspect-ratio: 1 / 1;
+            }
+        }
+
+        .shader-status {
+            margin-top: 6px;
+            font-size: 0.78rem;
+            color: rgba(255, 255, 255, 0.65);
+            min-height: 1.2em;
+        }
+
+        .shader-status[data-tone='error'] {
+            color: rgba(255, 138, 138, 0.85);
+        }
+
+        .shader-status[data-tone='success'] {
+            color: rgba(148, 255, 208, 0.9);
+        }
+
+        .grid-import {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin: 12px 0 0;
+        }
+
+        .grid-summary {
+            margin: 16px 0 0;
+            font-size: 0.75rem;
+            letter-spacing: 0.04em;
+            color: rgba(255, 255, 255, 0.62);
+        }
+
+        .grid-status {
+            margin: 6px 0 0;
+            font-size: 0.72rem;
+            color: rgba(255, 255, 255, 0.5);
+            min-height: 1em;
+        }
+
         .projection-stack {
             position: relative;
             width: 100%;
@@ -569,11 +1054,19 @@
 </head>
 <body>
     <div class="canvas-stack" id="canvasStack">
-        <canvas id="background-canvas"></canvas>
-        <canvas id="shadow-canvas"></canvas>
-        <canvas id="content-canvas"></canvas>
-        <canvas id="highlight-canvas"></canvas>
-        <canvas id="accent-canvas"></canvas>
+        <canvas id="background-canvas" class="vib3-layer"></canvas>
+        <canvas id="shadow-canvas" class="vib3-layer"></canvas>
+        <canvas id="content-canvas" class="vib3-layer"></canvas>
+        <canvas id="highlight-canvas" class="vib3-layer"></canvas>
+        <canvas id="accent-canvas" class="vib3-layer"></canvas>
+        <div class="blueprint-overlay" aria-hidden="true">
+            <canvas id="visualizer-grid" class="blueprint-layer grid-layer"></canvas>
+            <canvas id="blueprint-background" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-shadow" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-content" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-highlight" class="blueprint-layer"></canvas>
+            <canvas id="blueprint-accent" class="blueprint-layer"></canvas>
+        </div>
     </div>
     <aside>
         <section class="panel">
@@ -602,8 +1095,191 @@
                 <div class="blueprint-metric"><span>Engagement</span><span id="blueprintEngagement">0.40</span></div>
                 <div class="blueprint-metric"><span>Stress</span><span id="blueprintStress">0.20</span></div>
             </div>
+            <div class="overlay-control">
+                <label for="blueprintOverlayOpacity">Overlay intensity</label>
+                <div class="overlay-control__range">
+                    <input type="range" min="10" max="100" value="70" id="blueprintOverlayOpacity">
+                    <span class="overlay-control__value" id="blueprintOverlayOpacityValue">70%</span>
+                </div>
+            </div>
             <ul class="blueprint-zone-list" id="blueprintZoneList"></ul>
             <button class="secondary" id="downloadBlueprintBtn" type="button">Download Blueprint</button>
+        </section>
+        <section class="panel" id="visualizerGridPanel">
+            <h2>Visualizer Alignment</h2>
+            <p class="panel-description">Tune the Vib3 stack to your layout grid or import card coordinates from design tools.</p>
+            <div class="layout-grid-controls">
+                <div class="layout-grid-row">
+                    <label class="grid-control" for="gridColumnInput">
+                        <span>Columns</span>
+                        <input type="number" min="1" max="8" value="3" id="gridColumnInput">
+                    </label>
+                    <label class="grid-control" for="gridRowInput">
+                        <span>Rows</span>
+                        <input type="number" min="1" max="8" value="2" id="gridRowInput">
+                    </label>
+                </div>
+                <div class="grid-range">
+                    <div class="grid-range__label">
+                        <span>Gutter</span>
+                        <span id="gridGutterValue">8%</span>
+                    </div>
+                    <input type="range" min="2" max="18" value="8" id="gridGutterInput">
+                </div>
+                <div class="grid-range">
+                    <div class="grid-range__label">
+                        <span>Card width</span>
+                        <span id="gridCardWidthValue">88%</span>
+                    </div>
+                    <input type="range" min="50" max="100" value="88" id="gridCardWidthInput">
+                </div>
+                <div class="grid-range">
+                    <div class="grid-range__label">
+                        <span>Card height</span>
+                        <span id="gridCardHeightValue">72%</span>
+                    </div>
+                    <input type="range" min="50" max="120" value="72" id="gridCardHeightInput">
+                </div>
+            </div>
+            <div class="grid-import">
+                <button class="secondary" id="gridImportButton" type="button">Import layout JSON</button>
+                <button class="secondary" id="gridPresetButton" type="button">Load sample</button>
+                <button class="secondary" id="gridClearButton" type="button">Reset grid</button>
+                <input type="file" id="gridImportInput" accept="application/json" hidden>
+            </div>
+            <p class="grid-summary" id="gridSummary">Generated grid · 3 columns · 2 rows · 6 cards</p>
+            <p class="grid-status" id="gridStatus" aria-live="polite"></p>
+        </section>
+        <section class="panel" id="shaderComposerPanel">
+            <h2>Shader Composer</h2>
+            <p class="panel-description">Author the live shader layers that drive the Vib3 visualizer stack and export configurations for production builds.</p>
+            <div class="shader-control-grid">
+                <div class="shader-control">
+                    <label for="shaderBackgroundHue">Background hue</label>
+                    <div class="shader-control__input">
+                        <input type="range" min="0" max="360" value="200" id="shaderBackgroundHue">
+                        <span class="shader-control__value" id="shaderBackgroundHueValue">200°</span>
+                    </div>
+                </div>
+                <div class="shader-control">
+                    <label for="shaderHueSwing">Hue swing</label>
+                    <div class="shader-control__input">
+                        <input type="range" min="0" max="120" value="18" id="shaderHueSwing">
+                        <span class="shader-control__value" id="shaderHueSwingValue">18°</span>
+                    </div>
+                </div>
+                <div class="shader-control">
+                    <label for="shaderArcCount">Arc layers</label>
+                    <div class="shader-control__input">
+                        <input type="number" min="1" max="12" value="6" id="shaderArcCount">
+                        <span class="shader-control__value" id="shaderArcCountValue">6</span>
+                    </div>
+                </div>
+                <div class="shader-control">
+                    <label for="shaderArcSpeed">Arc velocity</label>
+                    <div class="shader-control__input">
+                        <input type="range" min="10" max="160" value="45" id="shaderArcSpeed">
+                        <span class="shader-control__value" id="shaderArcSpeedValue">0.45×</span>
+                    </div>
+                </div>
+                <div class="shader-control">
+                    <label for="shaderHighlightIntensity">Highlight intensity</label>
+                    <div class="shader-control__input">
+                        <input type="range" min="10" max="120" value="90" id="shaderHighlightIntensity">
+                        <span class="shader-control__value" id="shaderHighlightIntensityValue">90%</span>
+                    </div>
+                </div>
+                <div class="shader-control">
+                    <label for="shaderAccentParticles">Accent particles</label>
+                    <div class="shader-control__input">
+                        <input type="range" min="4" max="36" value="18" id="shaderAccentParticles">
+                        <span class="shader-control__value" id="shaderAccentParticlesValue">18</span>
+                    </div>
+                </div>
+            </div>
+            <div class="shader-config-editor">
+                <label for="shaderConfigText">Shader configuration</label>
+                <textarea id="shaderConfigText" spellcheck="false"></textarea>
+            </div>
+            <div class="shader-actions">
+                <button id="shaderApplyBtn" type="button">Apply JSON</button>
+                <button class="secondary" id="shaderExportBtn" type="button">Download JSON</button>
+                <label class="file-input-label" for="shaderImportInput">
+                    <span>Import JSON</span>
+                    <input type="file" id="shaderImportInput" accept="application/json">
+                </label>
+                <button class="secondary" id="shaderResetBtn" type="button">Reset to defaults</button>
+            </div>
+            <p class="shader-status" id="shaderStatus" aria-live="polite"></p>
+        </section>
+        <section class="panel" id="shaderProductionPanel">
+            <h2>Shader Build Suite</h2>
+            <p class="panel-description">Package production-ready Vib3 shader passes, validate them against a live WebGL preview, and export bundles for engineering handoff.</p>
+            <div class="shader-package-meta">
+                <label for="shaderPackageName">
+                    <span>Package name</span>
+                    <input type="text" id="shaderPackageName" value="vib3-production-shader">
+                </label>
+                <label for="shaderPackageVersion">
+                    <span>Version</span>
+                    <input type="text" id="shaderPackageVersion" value="1.0.0">
+                </label>
+                <label for="shaderPackageDescription">
+                    <span>Description</span>
+                    <textarea id="shaderPackageDescription" spellcheck="false">Production Vib3 wearable shader suite with baseline holographic passes.</textarea>
+                </label>
+            </div>
+            <div class="shader-build-grid">
+                <div class="shader-pass-column">
+                    <div class="shader-pass-header">
+                        <span>Shader passes</span>
+                        <button class="secondary" id="shaderAddPassBtn" type="button">Add pass</button>
+                    </div>
+                    <ul class="shader-pass-list" id="shaderPassList"></ul>
+                    <div class="shader-pass-footer">
+                        <label for="shaderEntryPass">
+                            <span>Entry pass</span>
+                            <select id="shaderEntryPass"></select>
+                        </label>
+                        <button class="secondary" id="shaderRemovePassBtn" type="button">Remove pass</button>
+                    </div>
+                </div>
+                <div class="shader-pass-editor">
+                    <div class="shader-pass-meta">
+                        <label for="shaderPassLabel">
+                            <span>Pass label</span>
+                            <input type="text" id="shaderPassLabel" placeholder="e.g. Surface bloom">
+                        </label>
+                        <label for="shaderPassType">
+                            <span>Pass type</span>
+                            <select id="shaderPassType">
+                                <option value="fragment">Fragment</option>
+                                <option value="compute">Compute (simulated)</option>
+                                <option value="post">Post-process</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="shader-code-editor">
+                        <label for="shaderVertexSource">Vertex shader</label>
+                        <textarea id="shaderVertexSource" spellcheck="false"></textarea>
+                    </div>
+                    <div class="shader-code-editor">
+                        <label for="shaderFragmentSource">Fragment shader</label>
+                        <textarea id="shaderFragmentSource" spellcheck="false"></textarea>
+                    </div>
+                </div>
+            </div>
+            <canvas id="shaderPreviewCanvas" width="640" height="360"></canvas>
+            <div class="shader-build-actions">
+                <button id="shaderCompileBtn" type="button">Validate &amp; Preview</button>
+                <button id="shaderPackageExportBtn" type="button">Download Shader Package</button>
+                <label class="file-input-label" for="shaderPackageImportInput">
+                    <span>Import Package</span>
+                    <input type="file" id="shaderPackageImportInput" accept="application/json">
+                </label>
+                <button class="secondary" id="shaderPackagePresetBtn" type="button">Load Production Baseline</button>
+            </div>
+            <p class="shader-package-status" id="shaderPackageStatus" aria-live="polite"></p>
         </section>
         <section class="panel" id="projectionPanel">
             <h2>4D Projection Field</h2>
@@ -687,6 +1363,2167 @@
         const blueprintStress = document.getElementById('blueprintStress');
         const blueprintZoneList = document.getElementById('blueprintZoneList');
         const downloadBlueprintBtn = document.getElementById('downloadBlueprintBtn');
+        const blueprintOverlayElement = document.querySelector('.blueprint-overlay');
+        const blueprintOverlayOpacitySlider = document.getElementById('blueprintOverlayOpacity');
+        const blueprintOverlayOpacityValue = document.getElementById('blueprintOverlayOpacityValue');
+        const visualizerGridCanvas = document.getElementById('visualizer-grid');
+        const gridImportButton = document.getElementById('gridImportButton');
+        const gridImportInput = document.getElementById('gridImportInput');
+        const gridPresetButton = document.getElementById('gridPresetButton');
+        const gridClearButton = document.getElementById('gridClearButton');
+        const gridColumnInput = document.getElementById('gridColumnInput');
+        const gridRowInput = document.getElementById('gridRowInput');
+        const gridGutterInput = document.getElementById('gridGutterInput');
+        const gridCardWidthInput = document.getElementById('gridCardWidthInput');
+        const gridCardHeightInput = document.getElementById('gridCardHeightInput');
+        const gridSummary = document.getElementById('gridSummary');
+        const gridStatus = document.getElementById('gridStatus');
+        const gridGutterValue = document.getElementById('gridGutterValue');
+        const gridCardWidthValue = document.getElementById('gridCardWidthValue');
+        const gridCardHeightValue = document.getElementById('gridCardHeightValue');
+        const shaderBackgroundHueInput = document.getElementById('shaderBackgroundHue');
+        const shaderBackgroundHueValue = document.getElementById('shaderBackgroundHueValue');
+        const shaderHueSwingInput = document.getElementById('shaderHueSwing');
+        const shaderHueSwingValue = document.getElementById('shaderHueSwingValue');
+        const shaderArcCountInput = document.getElementById('shaderArcCount');
+        const shaderArcCountValue = document.getElementById('shaderArcCountValue');
+        const shaderArcSpeedInput = document.getElementById('shaderArcSpeed');
+        const shaderArcSpeedValue = document.getElementById('shaderArcSpeedValue');
+        const shaderHighlightIntensityInput = document.getElementById('shaderHighlightIntensity');
+        const shaderHighlightIntensityValue = document.getElementById('shaderHighlightIntensityValue');
+        const shaderAccentParticlesInput = document.getElementById('shaderAccentParticles');
+        const shaderAccentParticlesValue = document.getElementById('shaderAccentParticlesValue');
+        const shaderConfigText = document.getElementById('shaderConfigText');
+        const shaderApplyBtn = document.getElementById('shaderApplyBtn');
+        const shaderExportBtn = document.getElementById('shaderExportBtn');
+        const shaderImportInput = document.getElementById('shaderImportInput');
+        const shaderResetBtn = document.getElementById('shaderResetBtn');
+        const shaderStatus = document.getElementById('shaderStatus');
+        const shaderPackageNameInput = document.getElementById('shaderPackageName');
+        const shaderPackageVersionInput = document.getElementById('shaderPackageVersion');
+        const shaderPackageDescriptionInput = document.getElementById('shaderPackageDescription');
+        const shaderPassList = document.getElementById('shaderPassList');
+        const shaderAddPassBtn = document.getElementById('shaderAddPassBtn');
+        const shaderRemovePassBtn = document.getElementById('shaderRemovePassBtn');
+        const shaderPassLabelInput = document.getElementById('shaderPassLabel');
+        const shaderPassTypeSelect = document.getElementById('shaderPassType');
+        const shaderEntryPassSelect = document.getElementById('shaderEntryPass');
+        const shaderVertexSourceInput = document.getElementById('shaderVertexSource');
+        const shaderFragmentSourceInput = document.getElementById('shaderFragmentSource');
+        const shaderCompileBtn = document.getElementById('shaderCompileBtn');
+        const shaderPackageExportBtn = document.getElementById('shaderPackageExportBtn');
+        const shaderPackageImportInput = document.getElementById('shaderPackageImportInput');
+        const shaderPackagePresetBtn = document.getElementById('shaderPackagePresetBtn');
+        const shaderPackageStatus = document.getElementById('shaderPackageStatus');
+        const shaderPreviewCanvas = document.getElementById('shaderPreviewCanvas');
+        const canvasStackElement = document.getElementById('canvasStack');
+        const vib3LayerCanvases = {
+            background: document.getElementById('background-canvas'),
+            shadow: document.getElementById('shadow-canvas'),
+            content: document.getElementById('content-canvas'),
+            highlight: document.getElementById('highlight-canvas'),
+            accent: document.getElementById('accent-canvas')
+        };
+
+        const toNumeric = (value, fallback = 0) => {
+            const numeric = Number(value);
+            return Number.isFinite(numeric) ? numeric : fallback;
+        };
+
+        const clampNormalized = (value, min = 0, max = 1) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) {
+                return min;
+            }
+            return Math.min(max, Math.max(min, numeric));
+        };
+
+        const clampRange = (value, min, max, fallback) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) {
+                return fallback;
+            }
+            return Math.min(max, Math.max(min, numeric));
+        };
+
+        const clampCount = (value) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) {
+                return 1;
+            }
+            return Math.min(8, Math.max(1, Math.round(numeric)));
+        };
+
+        function createDefaultShaderConfig() {
+            return {
+                background: {
+                    baseHue: 200,
+                    hueSwing: 18,
+                    hueSpeed: 0.25,
+                    gradientInner: 0.12,
+                    gradientOuter: 0.75,
+                    ringCount: 4,
+                    ringOpacity: 0.28,
+                    ringOpacityFalloff: 0.05,
+                    ringHueStep: 6,
+                    rotationSpeed: 0.05
+                },
+                arcs: {
+                    loopCount: 6,
+                    radiusStart: 0.22,
+                    radiusStep: 0.08,
+                    arcBase: 0.32,
+                    arcSwing: 0.12,
+                    speed: 0.45,
+                    lineWidth: 0.015,
+                    widthFalloff: 0.12,
+                    alphaBase: 0.8,
+                    alphaFalloff: 0.1,
+                    color: [76, 159, 255]
+                },
+                highlight: {
+                    orbitRadius: 0.32,
+                    rotationSpeed: 0.8,
+                    intensity: 0.9,
+                    lightenAlpha: 0.4,
+                    lightenWidthScale: 0.085
+                },
+                accent: {
+                    particleCount: 18,
+                    baseRadius: 0.18,
+                    radiusSwing: 0.28,
+                    particleSize: 0.012,
+                    sizeSwing: 0.3,
+                    orbitSpeed: 0.35,
+                    wobbleSpeed: 0.7
+                },
+                anchored: {
+                    arcSpeedBase: 0.6,
+                    arcSpeedVariance: 0.05,
+                    arcSpanBase: 0.4,
+                    arcSpanSwing: 0.18,
+                    arcWidthScale: 0.24,
+                    highlightGlow: 0.4,
+                    accentParticleCount: 8,
+                    accentOrbitScale: 0.6
+                }
+            };
+        }
+
+        const shaderBounds = {
+            background: {
+                baseHue: [0, 360],
+                hueSwing: [0, 120],
+                hueSpeed: [0.05, 1.5],
+                gradientInner: [0.05, 0.4],
+                gradientOuter: [0.5, 1.2],
+                ringCount: [1, 8],
+                ringOpacity: [0, 1],
+                ringOpacityFalloff: [0, 0.4],
+                ringHueStep: [0, 90],
+                rotationSpeed: [0, 0.3]
+            },
+            arcs: {
+                loopCount: [1, 12],
+                radiusStart: [0.05, 0.5],
+                radiusStep: [0, 0.4],
+                arcBase: [0.1, 1.2],
+                arcSwing: [0, 0.6],
+                speed: [0.1, 2],
+                lineWidth: [0.002, 0.05],
+                widthFalloff: [0, 0.4],
+                alphaBase: [0, 1],
+                alphaFalloff: [0, 0.5]
+            },
+            highlight: {
+                orbitRadius: [0.05, 0.6],
+                rotationSpeed: [0.1, 2],
+                intensity: [0, 1.2],
+                lightenAlpha: [0, 1],
+                lightenWidthScale: [0.02, 0.2]
+            },
+            accent: {
+                particleCount: [1, 64],
+                baseRadius: [0.05, 0.5],
+                radiusSwing: [0, 0.5],
+                particleSize: [0.002, 0.05],
+                sizeSwing: [0, 0.8],
+                orbitSpeed: [0.05, 2],
+                wobbleSpeed: [0.05, 2]
+            },
+            anchored: {
+                arcSpeedBase: [0.1, 2],
+                arcSpeedVariance: [0, 0.5],
+                arcSpanBase: [0.1, 1],
+                arcSpanSwing: [0, 0.6],
+                arcWidthScale: [0.05, 0.6],
+                highlightGlow: [0, 1],
+                accentParticleCount: [1, 24],
+                accentOrbitScale: [0.2, 1.2]
+            }
+        };
+
+        function cloneShaderConfig(config = createDefaultShaderConfig()) {
+            return JSON.parse(JSON.stringify(config));
+        }
+
+        function mergeShaderConfig(base, partial) {
+            const target = cloneShaderConfig(base);
+            if (!partial || typeof partial !== 'object') {
+                return target;
+            }
+            for (const [section, values] of Object.entries(partial)) {
+                if (!(section in target)) continue;
+                if (!values || typeof values !== 'object') continue;
+                for (const [key, value] of Object.entries(values)) {
+                    if (!(key in target[section])) continue;
+                    if (Array.isArray(target[section][key])) {
+                        if (Array.isArray(value)) {
+                            target[section][key] = value.map((entry, index) => {
+                                const numeric = Number(entry);
+                                if (Number.isFinite(numeric)) {
+                                    return numeric;
+                                }
+                                const fallback = target[section][key][index] ?? 0;
+                                return Number(fallback) || 0;
+                            });
+                        }
+                        continue;
+                    }
+                    const numeric = Number(value);
+                    if (Number.isFinite(numeric)) {
+                        target[section][key] = numeric;
+                    }
+                }
+            }
+            return target;
+        }
+
+        function clampShaderValue(section, key, value) {
+            const bounds = shaderBounds[section]?.[key];
+            if (!bounds) {
+                return value;
+            }
+            const [min, max] = bounds;
+            if (!Number.isFinite(value)) {
+                return min;
+            }
+            return Math.min(max, Math.max(min, value));
+        }
+
+        function sanitizeShaderConfig(partial) {
+            const merged = mergeShaderConfig(createDefaultShaderConfig(), partial);
+            for (const [section, values] of Object.entries(merged)) {
+                if (!values || typeof values !== 'object') continue;
+                for (const [key, value] of Object.entries(values)) {
+                    if (Array.isArray(value)) {
+                        merged[section][key] = value.map((entry) => clampShaderValue(section, key, Number(entry)));
+                        continue;
+                    }
+                    merged[section][key] = clampShaderValue(section, key, Number(value));
+                }
+            }
+            merged.background.ringCount = Math.round(merged.background.ringCount);
+            merged.arcs.loopCount = Math.round(merged.arcs.loopCount);
+            merged.accent.particleCount = Math.round(merged.accent.particleCount);
+            merged.anchored.accentParticleCount = Math.round(merged.anchored.accentParticleCount);
+            return merged;
+        }
+
+        const shaderDefaults = createDefaultShaderConfig();
+        let currentShaderConfig = cloneShaderConfig(shaderDefaults);
+
+        function drawRoundedRectPath(context, x, y, width, height, radius) {
+            const safeRadius = Math.max(0, Math.min(radius, Math.min(width, height) / 2));
+            context.moveTo(x + safeRadius, y);
+            context.lineTo(x + width - safeRadius, y);
+            context.quadraticCurveTo(x + width, y, x + width, y + safeRadius);
+            context.lineTo(x + width, y + height - safeRadius);
+            context.quadraticCurveTo(x + width, y + height, x + width - safeRadius, y + height);
+            context.lineTo(x + safeRadius, y + height);
+            context.quadraticCurveTo(x, y + height, x, y + height - safeRadius);
+            context.lineTo(x, y + safeRadius);
+            context.quadraticCurveTo(x, y, x + safeRadius, y);
+        }
+
+        const gridOverlayState = {
+            canvas: visualizerGridCanvas || null,
+            context: visualizerGridCanvas ? visualizerGridCanvas.getContext('2d') : null,
+            size: 0,
+            ratio: window.devicePixelRatio || 1
+        };
+
+        let latestGridSpec = null;
+        let gridOverlayResizeObserver = null;
+
+        function renderGridOverlay(spec = latestGridSpec) {
+            const { context, size } = gridOverlayState;
+            if (!context || !size) {
+                return;
+            }
+
+            context.clearRect(0, 0, size, size);
+            const cards = Array.isArray(spec?.cards) ? spec.cards : [];
+            if (!cards.length) {
+                return;
+            }
+
+            context.save();
+            context.globalAlpha = 0.85;
+            context.lineWidth = Math.max(1.2, size * 0.0025);
+            context.strokeStyle = 'rgba(76, 159, 255, 0.38)';
+            context.fillStyle = 'rgba(76, 159, 255, 0.12)';
+            context.font = `${Math.max(11, size * 0.03)}px 'Inter', system-ui`;
+            context.textAlign = 'left';
+            context.textBaseline = 'top';
+
+            cards.forEach((card, index) => {
+                const x = clampNormalized(card.x, 0, 1) * size;
+                const y = clampNormalized(card.y, 0, 1) * size;
+                const width = clampNormalized(card.width, 0, 1) * size;
+                const height = clampNormalized(card.height, 0, 1) * size;
+                const radius = Math.min(width, height) * 0.18;
+
+                context.beginPath();
+                drawRoundedRectPath(context, x, y, width, height, radius);
+                context.fill();
+                context.stroke();
+
+                const label = `Card ${index + 1}`;
+                context.fillStyle = 'rgba(245, 247, 251, 0.68)';
+                context.fillText(label, x + 10, y + 8);
+                context.fillStyle = 'rgba(76, 159, 255, 0.12)';
+            });
+
+            context.restore();
+        }
+
+        function resizeGridOverlay(force = false) {
+            const { canvas, context } = gridOverlayState;
+            if (!canvas || !context || !blueprintOverlayElement) {
+                return;
+            }
+
+            const rect = blueprintOverlayElement.getBoundingClientRect();
+            const nextSize = Math.floor(Math.min(rect.width || 0, rect.height || 0));
+            if (!nextSize || (!force && nextSize === gridOverlayState.size)) {
+                return;
+            }
+
+            const ratio = window.devicePixelRatio || 1;
+            gridOverlayState.size = nextSize;
+            gridOverlayState.ratio = ratio;
+
+            canvas.width = Math.floor(nextSize * ratio);
+            canvas.height = Math.floor(nextSize * ratio);
+            canvas.style.width = `${nextSize}px`;
+            canvas.style.height = `${nextSize}px`;
+
+            context.setTransform(1, 0, 0, 1, 0, 0);
+            context.scale(ratio, ratio);
+            renderGridOverlay();
+        }
+
+        function createVib3VisualizerStack({ container, canvases = {}, config } = {}) {
+            if (!container) {
+                return {
+                    start() {},
+                    stop() {},
+                    resize() {},
+                    setGridSpec() { return null; },
+                    getGridSpec() { return null; }
+                };
+            }
+
+            const contexts = new Map();
+            for (const [layer, canvas] of Object.entries(canvases)) {
+                if (!canvas) continue;
+                const context = canvas.getContext('2d');
+                if (context) {
+                    contexts.set(layer, { canvas, context });
+                }
+            }
+
+            const state = {
+                frameId: null,
+                size: 0,
+                time: 0,
+                grid: null,
+                gridAnchors: [],
+                gridBuckets: { columns: [], rows: [] },
+                shader: sanitizeShaderConfig(config ?? shaderDefaults)
+            };
+
+            const clamp = (value, min = 0, max = 1) => {
+                const numeric = Number(value);
+                if (!Number.isFinite(numeric)) {
+                    return min;
+                }
+                return Math.min(max, Math.max(min, numeric));
+            };
+
+            const getRatio = () => window.devicePixelRatio || 1;
+
+            function resize() {
+                const rect = container.getBoundingClientRect();
+                const nextSize = Math.floor(Math.min(rect.width || 0, rect.height || 0));
+                if (!nextSize || nextSize === state.size) {
+                    return;
+                }
+                state.size = nextSize;
+                const ratio = getRatio();
+                for (const { canvas, context } of contexts.values()) {
+                    canvas.width = Math.floor(nextSize * ratio);
+                    canvas.height = Math.floor(nextSize * ratio);
+                    context.setTransform(1, 0, 0, 1, 0, 0);
+                    context.scale(ratio, ratio);
+                }
+            }
+
+            function clearContext(context) {
+                if (!context || !state.size) return;
+                context.clearRect(0, 0, state.size, state.size);
+            }
+
+            function drawBackground(context, time) {
+                if (!context || !state.size) return;
+                clearContext(context);
+                const size = state.size;
+                const center = size / 2;
+                const options = state.shader.background;
+                const hue = options.baseHue + Math.sin(time * options.hueSpeed) * options.hueSwing;
+                const gradient = context.createRadialGradient(
+                    center,
+                    center,
+                    size * options.gradientInner,
+                    center,
+                    center,
+                    size * options.gradientOuter
+                );
+                gradient.addColorStop(0, `hsla(${hue}, 95%, 70%, 0.45)`);
+                gradient.addColorStop(0.52, `hsla(${hue - 28}, 75%, 32%, 0.35)`);
+                gradient.addColorStop(1, 'rgba(4, 9, 20, 0.96)');
+                context.fillStyle = gradient;
+                context.fillRect(0, 0, size, size);
+
+                context.save();
+                context.translate(center, center);
+                context.rotate(time * options.rotationSpeed);
+                const ringCount = Math.max(1, Math.round(options.ringCount));
+                for (let ring = 0; ring < ringCount; ring += 1) {
+                    const ringOpacity = Math.max(0, options.ringOpacity - ring * options.ringOpacityFalloff);
+                    context.globalAlpha = ringOpacity;
+                    context.beginPath();
+                    context.ellipse(0, 0, size * (0.22 + ring * 0.12), size * (0.18 + ring * 0.1), 0, 0, Math.PI * 2);
+                    context.strokeStyle = `hsla(${hue + ring * options.ringHueStep}, 88%, ${68 - ring * 8}%, ${ringOpacity})`;
+                    context.lineWidth = size * 0.004 * (1 - ring * 0.12);
+                    context.stroke();
+                    context.rotate(Math.PI / 7);
+                }
+                context.restore();
+            }
+
+            function drawShadow(context) {
+                if (!context || !state.size) return;
+                clearContext(context);
+                const size = state.size;
+                const center = size / 2;
+                context.save();
+                context.fillStyle = 'rgba(2, 6, 12, 0.6)';
+                context.filter = 'blur(32px)';
+                context.beginPath();
+                context.ellipse(center, center * 1.08, size * 0.42, size * 0.22, 0, 0, Math.PI * 2);
+                context.fill();
+                context.restore();
+            }
+
+            function drawDefaultContent(context, time) {
+                const size = state.size;
+                const center = size / 2;
+                const arcs = state.shader.arcs;
+                const loopCount = Math.max(1, Math.round(arcs.loopCount));
+                const [r, g, b] = Array.isArray(arcs.color) && arcs.color.length >= 3
+                    ? arcs.color
+                    : [76, 159, 255];
+                context.save();
+                context.translate(center, center);
+                for (let index = 0; index < loopCount; index += 1) {
+                    const radius = size * Math.max(0.05, arcs.radiusStart + index * arcs.radiusStep);
+                    const arcSpan = Math.PI * Math.max(0.05, arcs.arcBase + arcs.arcSwing * Math.sin(time * 0.5 + index));
+                    const offset = time * (arcs.speed + index * 0.08);
+                    const layerAlpha = Math.max(0, Math.min(1, arcs.alphaBase - index * arcs.alphaFalloff));
+                    const widthFactor = Math.max(0.1, 1 - index * arcs.widthFalloff);
+                    context.beginPath();
+                    context.arc(0, 0, radius, offset, offset + arcSpan);
+                    context.strokeStyle = `rgba(${r}, ${g}, ${b}, ${layerAlpha || 0})`;
+                    context.lineWidth = size * arcs.lineWidth * widthFactor;
+                    context.lineCap = 'round';
+                    context.globalAlpha = Math.min(1, layerAlpha + 0.2);
+                    context.stroke();
+                }
+                context.restore();
+            }
+
+            function drawGridCardGlow(context, anchor, time, index, size) {
+                const width = Math.max(size * 0.05, anchor.width * size);
+                const height = Math.max(size * 0.05, anchor.height * size);
+                const x = anchor.x * size - width / 2;
+                const y = anchor.y * size - height / 2;
+                const radius = Math.min(width, height) * 0.22;
+                const glow = Math.max(0, Math.min(1, state.shader.anchored.highlightGlow));
+
+                context.save();
+                context.globalCompositeOperation = 'lighter';
+                context.lineWidth = Math.max(1.2, Math.min(width, height) * 0.08);
+                const strokeAlpha = glow * (0.4 + 0.2 * Math.sin(time * 0.8 + index));
+                context.strokeStyle = `rgba(118, 202, 255, ${Math.max(0, Math.min(1, strokeAlpha))})`;
+                context.beginPath();
+                drawRoundedRectPath(context, x, y, width, height, radius);
+                context.stroke();
+                context.restore();
+
+                context.save();
+                context.globalAlpha = glow * (0.16 + 0.1 * Math.sin(time * 0.9 + index));
+                context.fillStyle = 'rgba(76, 159, 255, 0.22)';
+                context.beginPath();
+                drawRoundedRectPath(context, x, y, width, height, radius);
+                context.fill();
+                context.restore();
+            }
+
+            function drawContent(context, time) {
+                if (!context || !state.size) return;
+                clearContext(context);
+                const anchors = state.gridAnchors;
+                if (!anchors.length) {
+                    drawDefaultContent(context, time);
+                    return;
+                }
+
+                const size = state.size;
+                const arcs = state.shader.arcs;
+                const anchored = state.shader.anchored;
+                const [r, g, b] = Array.isArray(arcs.color) && arcs.color.length >= 3
+                    ? arcs.color
+                    : [76, 159, 255];
+                context.save();
+                anchors.forEach((anchor, index) => {
+                    const cx = anchor.x * size;
+                    const cy = anchor.y * size;
+                    const baseRadius = Math.min(anchor.width, anchor.height) * size * 0.48;
+                    const offset = time * (anchored.arcSpeedBase + (anchor.column ?? index) * anchored.arcSpeedVariance);
+                    const arcSpan = Math.PI * Math.max(0.05, anchored.arcSpanBase + anchored.arcSpanSwing * Math.sin(time * 0.6 + index));
+                    const strokeAlpha = Math.max(0, Math.min(1, arcs.alphaBase + 0.16 * Math.sin(time * 0.4 + index)));
+                    context.beginPath();
+                    context.arc(cx, cy, Math.max(baseRadius, size * 0.06), offset, offset + arcSpan);
+                    context.strokeStyle = `rgba(${r}, ${g}, ${b}, ${strokeAlpha})`;
+                    context.lineWidth = Math.max(1.4, Math.min(baseRadius, size * 0.18) * anchored.arcWidthScale);
+                    context.lineCap = 'round';
+                    context.globalAlpha = Math.min(1, arcs.alphaBase + 0.3);
+                    context.stroke();
+
+                    drawGridCardGlow(context, anchor, time, index, size);
+                });
+                context.restore();
+            }
+
+            function drawDefaultHighlight(context, time) {
+                const size = state.size;
+                const center = size / 2;
+                const highlight = state.shader.highlight;
+                const orbitRadius = size * highlight.orbitRadius;
+                const angle = time * highlight.rotationSpeed;
+                const x = center + Math.cos(angle) * orbitRadius;
+                const y = center + Math.sin(angle * 0.9) * orbitRadius * 0.7;
+                const gradient = context.createRadialGradient(x, y, size * 0.04, x, y, size * 0.25);
+                gradient.addColorStop(0, 'rgba(120, 212, 255, 0.9)');
+                gradient.addColorStop(0.45, 'rgba(120, 212, 255, 0.35)');
+                gradient.addColorStop(1, 'rgba(120, 212, 255, 0)');
+                context.globalAlpha = Math.min(1, highlight.intensity);
+                context.fillStyle = gradient;
+                context.fillRect(0, 0, size, size);
+
+                context.save();
+                context.globalCompositeOperation = 'lighter';
+                context.globalAlpha = Math.min(1, highlight.lightenAlpha);
+                context.translate(center, center);
+                context.rotate(angle * 0.6);
+                context.beginPath();
+                context.ellipse(0, 0, size * 0.36, size * 0.18, 0, 0, Math.PI * 2);
+                context.strokeStyle = 'rgba(76, 159, 255, 0.45)';
+                context.lineWidth = size * highlight.lightenWidthScale;
+                context.stroke();
+                context.restore();
+            }
+
+            function drawHighlight(context, time) {
+                if (!context || !state.size) return;
+                clearContext(context);
+                const anchors = state.gridAnchors;
+                if (!anchors.length) {
+                    drawDefaultHighlight(context, time);
+                    return;
+                }
+
+                const size = state.size;
+                const highlight = state.shader.highlight;
+                const sequence = time * 0.75;
+                const count = anchors.length;
+                const activeIndex = Math.floor(sequence % count);
+                const blend = count > 1 ? sequence % 1 : 0;
+                const anchor = anchors[activeIndex];
+                const nextAnchor = anchors[(activeIndex + 1) % count];
+                const cx = (anchor.x * (1 - blend) + nextAnchor.x * blend) * size;
+                const cy = (anchor.y * (1 - blend) + nextAnchor.y * blend) * size;
+                const radius = Math.min(anchor.width, anchor.height) * size * 0.85;
+                const gradient = context.createRadialGradient(cx, cy, radius * 0.12, cx, cy, radius);
+                gradient.addColorStop(0, 'rgba(120, 212, 255, 0.95)');
+                gradient.addColorStop(0.45, 'rgba(120, 212, 255, 0.35)');
+                gradient.addColorStop(1, 'rgba(120, 212, 255, 0)');
+                context.globalAlpha = Math.min(1, highlight.intensity);
+                context.fillStyle = gradient;
+                context.fillRect(0, 0, size, size);
+
+                context.save();
+                context.globalCompositeOperation = 'lighter';
+                context.globalAlpha = Math.min(1, highlight.lightenAlpha + 0.05);
+                const width = Math.max(size * 0.12, anchor.width * size * 1.25);
+                const height = Math.max(size * 0.08, anchor.height * size * 1.05);
+                context.beginPath();
+                drawRoundedRectPath(context, cx - width / 2, cy - height / 2, width, height, Math.min(width, height) * 0.32);
+                context.strokeStyle = 'rgba(76, 159, 255, 0.45)';
+                context.lineWidth = Math.max(1.2, Math.min(width, height) * highlight.lightenWidthScale);
+                context.stroke();
+                context.restore();
+            }
+
+            function drawDefaultAccent(context, time) {
+                const size = state.size;
+                const center = size / 2;
+                const accent = state.shader.accent;
+                const particleCount = Math.max(1, Math.round(accent.particleCount));
+                context.save();
+                context.translate(center, center);
+                context.globalCompositeOperation = 'lighter';
+                for (let index = 0; index < particleCount; index += 1) {
+                    const theta = (index / particleCount) * Math.PI * 2 + time * accent.orbitSpeed;
+                    const radius = size * Math.max(0.05, accent.baseRadius + accent.radiusSwing * Math.sin(time * 0.6 + index));
+                    const x = Math.cos(theta) * radius;
+                    const y = Math.sin(theta) * radius * 0.9;
+                    context.beginPath();
+                    context.fillStyle = `rgba(118, 202, 255, ${0.55 - index * 0.01})`;
+                    context.globalAlpha = 0.45 + 0.35 * Math.sin(time * accent.wobbleSpeed + index);
+                    context.arc(
+                        x,
+                        y,
+                        size * accent.particleSize * (1 + accent.sizeSwing * Math.sin(time * accent.wobbleSpeed + index)),
+                        0,
+                        Math.PI * 2
+                    );
+                    context.fill();
+                }
+                context.restore();
+            }
+
+            function drawAccent(context, time) {
+                if (!context || !state.size) return;
+                clearContext(context);
+                const anchors = state.gridAnchors;
+                if (!anchors.length) {
+                    drawDefaultAccent(context, time);
+                    return;
+                }
+
+                const size = state.size;
+                const accent = state.shader.accent;
+                const anchored = state.shader.anchored;
+                context.save();
+                context.globalCompositeOperation = 'lighter';
+                anchors.forEach((anchor, index) => {
+                    const cx = anchor.x * size;
+                    const cy = anchor.y * size;
+                    const orbital = Math.min(anchor.width, anchor.height) * size * anchored.accentOrbitScale;
+                    const particles = Math.max(1, Math.round(anchored.accentParticleCount));
+                    for (let i = 0; i < particles; i += 1) {
+                        const theta = time * accent.orbitSpeed * 2.7 + (index + i) * (Math.PI * 2 / particles);
+                        const radius = orbital * (0.45 + 0.25 * Math.sin(time * accent.wobbleSpeed + i));
+                        const wobble = 0.8 + 0.2 * Math.sin(time * accent.wobbleSpeed + index + i);
+                        const x = cx + Math.cos(theta) * radius;
+                        const y = cy + Math.sin(theta * 0.92) * radius * 0.9;
+                        context.beginPath();
+                        context.fillStyle = `rgba(118, 202, 255, ${0.45 + 0.2 * Math.sin(time * accent.orbitSpeed + index + i)})`;
+                        context.globalAlpha = 0.45 + 0.35 * Math.sin(time * accent.wobbleSpeed + index + i);
+                        const particleRadius = Math.max(1.2, Math.min(anchor.width, anchor.height) * size * accent.particleSize * wobble);
+                        context.arc(x, y, particleRadius, 0, Math.PI * 2);
+                        context.fill();
+                    }
+                });
+                context.restore();
+            }
+
+            function buildBuckets(cards, axis) {
+                if (!Array.isArray(cards) || cards.length === 0) {
+                    return [];
+                }
+                const tolerance = 0.04;
+                const centers = cards
+                    .map(card => {
+                        const dimension = axis === 'x' ? card.width : card.height;
+                        const position = axis === 'x' ? card.x : card.y;
+                        return clamp(position + dimension / 2, 0, 1);
+                    })
+                    .sort((a, b) => a - b);
+                const buckets = [];
+                centers.forEach(center => {
+                    if (!buckets.some(value => Math.abs(value - center) <= tolerance)) {
+                        buckets.push(center);
+                    }
+                });
+                return buckets;
+            }
+
+            function findBucket(value, buckets) {
+                if (!Array.isArray(buckets) || buckets.length === 0) {
+                    return 0;
+                }
+                let closestIndex = 0;
+                let closestDistance = Number.POSITIVE_INFINITY;
+                for (let index = 0; index < buckets.length; index += 1) {
+                    const distance = Math.abs(buckets[index] - value);
+                    if (distance < closestDistance) {
+                        closestDistance = distance;
+                        closestIndex = index;
+                    }
+                }
+                return closestIndex;
+            }
+
+            function setGridSpec(spec = null) {
+                if (!spec) {
+                    state.grid = null;
+                    state.gridAnchors = [];
+                    state.gridBuckets = { columns: [], rows: [] };
+                    return null;
+                }
+
+                const normalizedCards = Array.isArray(spec.cards)
+                    ? spec.cards
+                        .map(card => ({
+                            x: clamp(card.x ?? card.left ?? 0, 0, 1),
+                            y: clamp(card.y ?? card.top ?? 0, 0, 1),
+                            width: clamp(card.width ?? card.w ?? 0, 0, 1),
+                            height: clamp(card.height ?? card.h ?? 0, 0, 1)
+                        }))
+                        .filter(card => card.width > 0 && card.height > 0)
+                    : [];
+
+                const columnBuckets = buildBuckets(normalizedCards, 'x');
+                const rowBuckets = buildBuckets(normalizedCards, 'y');
+                const anchors = normalizedCards.map(card => {
+                    const anchor = {
+                        x: clamp(card.x + card.width / 2, 0, 1),
+                        y: clamp(card.y + card.height / 2, 0, 1),
+                        width: clamp(card.width, 0, 1),
+                        height: clamp(card.height, 0, 1)
+                    };
+                    anchor.column = findBucket(anchor.x, columnBuckets);
+                    anchor.row = findBucket(anchor.y, rowBuckets);
+                    return anchor;
+                });
+
+                const columnValue = Number(spec.columns);
+                const rowValue = Number(spec.rows);
+                const resolvedColumns = Number.isFinite(columnValue) && columnValue > 0
+                    ? Math.min(12, Math.floor(columnValue))
+                    : columnBuckets.length;
+                const resolvedRows = Number.isFinite(rowValue) && rowValue > 0
+                    ? Math.min(12, Math.floor(rowValue))
+                    : rowBuckets.length;
+
+                state.grid = {
+                    mode: spec.mode || 'generated',
+                    label: spec.label || null,
+                    columns: resolvedColumns,
+                    rows: resolvedRows,
+                    cards: normalizedCards
+                };
+                state.gridAnchors = anchors;
+                state.gridBuckets = { columns: columnBuckets, rows: rowBuckets };
+                return getGridSpec();
+            }
+
+            function getGridSpec() {
+                if (!state.grid) {
+                    return null;
+                }
+                return {
+                    mode: state.grid.mode,
+                    label: state.grid.label,
+                    columns: state.grid.columns,
+                    rows: state.grid.rows,
+                    cards: state.grid.cards.map(card => ({ ...card }))
+                };
+            }
+
+            function getShaderConfig() {
+                return cloneShaderConfig(state.shader);
+            }
+
+            function setShaderConfig(nextConfig, options = {}) {
+                if (options.merge) {
+                    state.shader = sanitizeShaderConfig(mergeShaderConfig(state.shader, nextConfig));
+                } else {
+                    state.shader = sanitizeShaderConfig(nextConfig ?? state.shader);
+                }
+                return getShaderConfig();
+            }
+
+            function renderFrame(timestamp) {
+                state.frameId = window.requestAnimationFrame(renderFrame);
+                resize();
+                if (!state.size) {
+                    return;
+                }
+                state.time = timestamp / 1000;
+                const time = state.time;
+                const background = contexts.get('background')?.context;
+                const shadow = contexts.get('shadow')?.context;
+                const content = contexts.get('content')?.context;
+                const highlight = contexts.get('highlight')?.context;
+                const accent = contexts.get('accent')?.context;
+
+                drawBackground(background, time);
+                drawShadow(shadow);
+                drawContent(content, time);
+                drawHighlight(highlight, time);
+                drawAccent(accent, time);
+            }
+
+            function start() {
+                if (state.frameId !== null) {
+                    return;
+                }
+                resize();
+                state.frameId = window.requestAnimationFrame(renderFrame);
+            }
+
+            function stop() {
+                if (state.frameId !== null) {
+                    window.cancelAnimationFrame(state.frameId);
+                    state.frameId = null;
+                }
+            }
+
+            return { start, stop, resize, setGridSpec, getGridSpec, setShaderConfig, getShaderConfig };
+        }
+
+        const vib3Visualizer = createVib3VisualizerStack({
+            container: canvasStackElement,
+            canvases: vib3LayerCanvases,
+            config: currentShaderConfig
+        });
+        vib3Visualizer.start();
+        window.addEventListener('resize', () => {
+            vib3Visualizer.resize();
+            resizeGridOverlay(true);
+        });
+        window.vib3Visualizer = vib3Visualizer;
+        if (typeof vib3Visualizer.getShaderConfig === 'function') {
+            currentShaderConfig = vib3Visualizer.getShaderConfig();
+        }
+
+        let shaderFormSyncing = false;
+
+        function updateShaderStatus(message, tone = 'info') {
+            if (!shaderStatus) return;
+            shaderStatus.textContent = message || '';
+            shaderStatus.dataset.tone = tone;
+        }
+
+        function refreshShaderConfigUI({ preserveText = false } = {}) {
+            if (shaderFormSyncing) {
+                return;
+            }
+            shaderFormSyncing = true;
+            const shader = currentShaderConfig;
+            if (shaderBackgroundHueInput) {
+                shaderBackgroundHueInput.value = Math.round(shader.background.baseHue);
+                if (shaderBackgroundHueValue) {
+                    shaderBackgroundHueValue.textContent = `${Math.round(shader.background.baseHue)}°`;
+                }
+            }
+            if (shaderHueSwingInput) {
+                shaderHueSwingInput.value = Math.round(shader.background.hueSwing);
+                if (shaderHueSwingValue) {
+                    shaderHueSwingValue.textContent = `${Math.round(shader.background.hueSwing)}°`;
+                }
+            }
+            if (shaderArcCountInput) {
+                shaderArcCountInput.value = Math.max(1, Math.round(shader.arcs.loopCount));
+                if (shaderArcCountValue) {
+                    shaderArcCountValue.textContent = `${Math.max(1, Math.round(shader.arcs.loopCount))}`;
+                }
+            }
+            if (shaderArcSpeedInput) {
+                shaderArcSpeedInput.value = Math.round(shader.arcs.speed * 100);
+                if (shaderArcSpeedValue) {
+                    shaderArcSpeedValue.textContent = `${shader.arcs.speed.toFixed(2)}×`;
+                }
+            }
+            if (shaderHighlightIntensityInput) {
+                shaderHighlightIntensityInput.value = Math.round(shader.highlight.intensity * 100);
+                if (shaderHighlightIntensityValue) {
+                    shaderHighlightIntensityValue.textContent = `${Math.round(shader.highlight.intensity * 100)}%`;
+                }
+            }
+            if (shaderAccentParticlesInput) {
+                shaderAccentParticlesInput.value = Math.max(1, Math.round(shader.accent.particleCount));
+                if (shaderAccentParticlesValue) {
+                    shaderAccentParticlesValue.textContent = `${Math.max(1, Math.round(shader.accent.particleCount))}`;
+                }
+            }
+            if (shaderConfigText && !preserveText) {
+                shaderConfigText.value = JSON.stringify(shader, null, 2);
+            }
+            shaderFormSyncing = false;
+        }
+
+        const defaultVertexSource = `
+attribute vec2 position;
+varying vec2 vUv;
+
+void main() {
+    vUv = position * 0.5 + 0.5;
+    gl_Position = vec4(position, 0.0, 1.0);
+}`.trim();
+
+        const defaultFragmentSource = `
+precision highp float;
+uniform float uTime;
+uniform vec2 uResolution;
+varying vec2 vUv;
+
+float circle(vec2 uv, vec2 center, float radius) {
+    return length(uv - center) - radius;
+}
+
+void main() {
+    vec2 uv = vUv;
+    vec2 center = vec2(0.5);
+    float dist = circle(uv, center, 0.34 + 0.04 * sin(uTime * 0.6));
+    float glow = smoothstep(0.32, 0.12, dist);
+    float rim = smoothstep(0.02, 0.0, abs(dist - 0.14));
+    float wave = 0.5 + 0.5 * sin(uTime * 1.4 + uv.x * 8.0);
+    vec3 base = mix(vec3(0.05, 0.12, 0.25), vec3(0.1, 0.35, 0.75), glow);
+    vec3 accent = vec3(0.6, 0.9, 1.0) * rim * wave;
+    gl_FragColor = vec4(base + accent, max(glow, rim));
+}`.trim();
+
+        const presetBloomFragment = `
+precision highp float;
+uniform float uTime;
+uniform vec2 uResolution;
+varying vec2 vUv;
+
+void main() {
+    vec2 uv = vUv - 0.5;
+    float radius = length(uv);
+    float theta = atan(uv.y, uv.x);
+    float pulse = 0.65 + 0.35 * sin(uTime * 1.8 + theta * 6.0);
+    float bloom = smoothstep(0.4, 0.12, radius) * pulse;
+    float rim = smoothstep(0.02, 0.0, abs(radius - 0.28));
+    float streak = smoothstep(0.96, 1.0, sin((uv.x + uv.y + uTime * 0.8) * 22.0));
+    vec3 color = vec3(0.08, 0.26, 0.72) * bloom + vec3(0.52, 0.86, 1.0) * rim + vec3(0.95, 0.65, 1.0) * streak * 0.35;
+    float alpha = max(max(bloom, rim), streak * 0.45);
+    gl_FragColor = vec4(color, alpha);
+}`.trim();
+
+        const presetParticleFragment = `
+precision mediump float;
+uniform float uTime;
+uniform vec2 uResolution;
+varying vec2 vUv;
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+void main() {
+    vec2 grid = floor(vUv * 64.0);
+    float sparkle = step(0.94, hash(grid + floor(uTime * 5.0)));
+    float pulse = 0.45 + 0.55 * sin(uTime * 2.6 + (grid.x + grid.y));
+    float alpha = sparkle * pulse;
+    vec3 base = vec3(0.07, 0.18, 0.36);
+    vec3 glow = vec3(0.52, 0.86, 1.0) * alpha;
+    gl_FragColor = vec4(base + glow, alpha * 0.65);
+}`.trim();
+
+        function generatePassId() {
+            return `pass-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`;
+        }
+
+        function sanitizeUniformList(uniforms) {
+            if (!Array.isArray(uniforms)) {
+                return [];
+            }
+            return uniforms
+                .map(uniform => ({
+                    name: typeof uniform?.name === 'string' ? uniform.name.trim() : '',
+                    type: typeof uniform?.type === 'string' ? uniform.type.trim() : 'float'
+                }))
+                .filter(uniform => uniform.name.length > 0);
+        }
+
+        function sanitizeShaderPass(pass, fallbackLabel = 'Shader Pass') {
+            const sanitized = {
+                id: typeof pass?.id === 'string' && pass.id.trim() ? pass.id.trim() : generatePassId(),
+                label: typeof pass?.label === 'string' && pass.label.trim() ? pass.label.trim() : fallbackLabel,
+                type: ['fragment', 'compute', 'post'].includes(pass?.type) ? pass.type : 'fragment',
+                vertexSource: typeof pass?.vertexSource === 'string' && pass.vertexSource.trim()
+                    ? pass.vertexSource
+                    : defaultVertexSource,
+                fragmentSource: typeof pass?.fragmentSource === 'string' && pass.fragmentSource.trim()
+                    ? pass.fragmentSource
+                    : defaultFragmentSource,
+                uniforms: sanitizeUniformList(pass?.uniforms)
+            };
+            return sanitized;
+        }
+
+        function cloneShaderPass(pass) {
+            const sanitized = sanitizeShaderPass(pass);
+            return {
+                ...sanitized,
+                uniforms: sanitized.uniforms.map(uniform => ({ ...uniform }))
+            };
+        }
+
+        function createBaselineShaderPass(label = 'Primary Vib3 Surface') {
+            return sanitizeShaderPass({
+                id: generatePassId(),
+                label,
+                type: 'fragment',
+                vertexSource: defaultVertexSource,
+                fragmentSource: defaultFragmentSource,
+                uniforms: [
+                    { name: 'uTime', type: 'float' },
+                    { name: 'uResolution', type: 'vec2' }
+                ]
+            });
+        }
+
+        function createProductionPresetPackage() {
+            const surface = createBaselineShaderPass('Primary Vib3 Surface');
+            const bloom = sanitizeShaderPass({
+                id: generatePassId(),
+                label: 'Accent Bloom',
+                type: 'fragment',
+                vertexSource: defaultVertexSource,
+                fragmentSource: presetBloomFragment,
+                uniforms: [
+                    { name: 'uTime', type: 'float' },
+                    { name: 'uResolution', type: 'vec2' }
+                ]
+            }, 'Accent Bloom');
+            const particles = sanitizeShaderPass({
+                id: generatePassId(),
+                label: 'Particle Overlay',
+                type: 'post',
+                vertexSource: defaultVertexSource,
+                fragmentSource: presetParticleFragment,
+                uniforms: [
+                    { name: 'uTime', type: 'float' },
+                    { name: 'uResolution', type: 'vec2' }
+                ]
+            }, 'Particle Overlay');
+            return {
+                name: 'vib3-production-shader',
+                version: '1.0.0',
+                description: 'Production Vib3 wearable shader suite with baseline holographic passes.',
+                entryPassId: surface.id,
+                activePassId: surface.id,
+                passes: [surface, bloom, particles]
+            };
+        }
+
+        function cloneShaderPackage(state) {
+            return {
+                name: state?.name ?? 'vib3-production-shader',
+                version: state?.version ?? '1.0.0',
+                description: state?.description ?? '',
+                entryPassId: state?.entryPassId,
+                activePassId: state?.activePassId,
+                passes: Array.isArray(state?.passes)
+                    ? state.passes.map(pass => cloneShaderPass(pass))
+                    : [cloneShaderPass(createBaselineShaderPass())]
+            };
+        }
+
+        function sanitizeShaderPackage(raw) {
+            const base = typeof raw === 'object' && raw ? raw : {};
+            const passes = Array.isArray(base.passes) && base.passes.length
+                ? base.passes.map((pass, index) => sanitizeShaderPass(pass, `Pass ${index + 1}`))
+                : [createBaselineShaderPass()];
+            const deduped = [];
+            const seen = new Set();
+            passes.forEach(pass => {
+                let id = pass.id;
+                while (seen.has(id)) {
+                    id = generatePassId();
+                }
+                seen.add(id);
+                deduped.push({ ...pass, id });
+            });
+            const entry = typeof base.entryPassId === 'string' && deduped.some(pass => pass.id === base.entryPassId)
+                ? base.entryPassId
+                : deduped[0].id;
+            return {
+                name: typeof base.name === 'string' && base.name.trim() ? base.name.trim() : 'vib3-production-shader',
+                version: typeof base.version === 'string' && base.version.trim() ? base.version.trim() : '1.0.0',
+                description: typeof base.description === 'string' ? base.description.trim() : '',
+                entryPassId: entry,
+                activePassId: deduped.some(pass => pass.id === base.activePassId) ? base.activePassId : entry,
+                passes: deduped
+            };
+        }
+
+        let shaderPackageState = sanitizeShaderPackage(createProductionPresetPackage());
+        let isSyncingShaderPackage = false;
+
+        const shaderPreviewState = {
+            gl: null,
+            buffer: null,
+            program: null,
+            vertexShader: null,
+            fragmentShader: null,
+            positionLocation: -1,
+            uniformLocations: {},
+            frameId: null,
+            startTime: 0
+        };
+
+        function setShaderPackageStatus(message, tone = 'info') {
+            if (!shaderPackageStatus) {
+                return;
+            }
+            shaderPackageStatus.textContent = message || '';
+            shaderPackageStatus.dataset.tone = tone;
+        }
+
+        function getActiveShaderPass() {
+            const id = shaderPackageState?.activePassId;
+            return shaderPackageState?.passes?.find(pass => pass.id === id) ?? null;
+        }
+
+        function renderShaderPassList() {
+            if (!shaderPassList) {
+                return;
+            }
+            shaderPassList.innerHTML = '';
+            shaderPackageState.passes.forEach(pass => {
+                const listItem = document.createElement('li');
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.dataset.passId = pass.id;
+                button.textContent = pass.label || 'Untitled pass';
+                if (pass.id === shaderPackageState.activePassId) {
+                    button.classList.add('active');
+                }
+                listItem.appendChild(button);
+                shaderPassList.appendChild(listItem);
+            });
+        }
+
+        function updateEntryPassOptions() {
+            if (!shaderEntryPassSelect) {
+                return;
+            }
+            shaderEntryPassSelect.innerHTML = '';
+            shaderPackageState.passes.forEach(pass => {
+                const option = document.createElement('option');
+                option.value = pass.id;
+                option.textContent = pass.label || pass.id;
+                shaderEntryPassSelect.appendChild(option);
+            });
+            shaderEntryPassSelect.value = shaderPackageState.entryPassId;
+        }
+
+        function updateRemoveButtonState() {
+            if (!shaderRemovePassBtn) return;
+            shaderRemovePassBtn.disabled = shaderPackageState.passes.length <= 1;
+        }
+
+        function hydrateShaderMetadata() {
+            isSyncingShaderPackage = true;
+            if (shaderPackageNameInput) {
+                shaderPackageNameInput.value = shaderPackageState.name;
+            }
+            if (shaderPackageVersionInput) {
+                shaderPackageVersionInput.value = shaderPackageState.version;
+            }
+            if (shaderPackageDescriptionInput) {
+                shaderPackageDescriptionInput.value = shaderPackageState.description;
+            }
+            isSyncingShaderPackage = false;
+        }
+
+        function hydrateShaderPassEditor(pass) {
+            isSyncingShaderPackage = true;
+            if (shaderPassLabelInput) {
+                shaderPassLabelInput.value = pass?.label ?? '';
+            }
+            if (shaderPassTypeSelect) {
+                shaderPassTypeSelect.value = pass?.type ?? 'fragment';
+            }
+            if (shaderVertexSourceInput) {
+                shaderVertexSourceInput.value = pass?.vertexSource ?? defaultVertexSource;
+            }
+            if (shaderFragmentSourceInput) {
+                shaderFragmentSourceInput.value = pass?.fragmentSource ?? defaultFragmentSource;
+            }
+            isSyncingShaderPackage = false;
+        }
+
+        function refreshShaderPackageUI() {
+            hydrateShaderMetadata();
+            renderShaderPassList();
+            updateEntryPassOptions();
+            updateRemoveButtonState();
+            hydrateShaderPassEditor(getActiveShaderPass());
+        }
+
+        function persistActiveShaderPass() {
+            if (isSyncingShaderPackage) {
+                return;
+            }
+            const pass = getActiveShaderPass();
+            if (!pass) {
+                return;
+            }
+            if (shaderPassLabelInput) {
+                const next = shaderPassLabelInput.value.trim();
+                pass.label = next || pass.label;
+            }
+            if (shaderPassTypeSelect) {
+                pass.type = ['fragment', 'compute', 'post'].includes(shaderPassTypeSelect.value)
+                    ? shaderPassTypeSelect.value
+                    : pass.type;
+            }
+            if (shaderVertexSourceInput) {
+                pass.vertexSource = shaderVertexSourceInput.value || defaultVertexSource;
+            }
+            if (shaderFragmentSourceInput) {
+                pass.fragmentSource = shaderFragmentSourceInput.value || defaultFragmentSource;
+            }
+            renderShaderPassList();
+            updateEntryPassOptions();
+        }
+
+        function selectShaderPass(passId) {
+            persistActiveShaderPass();
+            const next = shaderPackageState.passes.find(pass => pass.id === passId);
+            shaderPackageState.activePassId = next ? next.id : shaderPackageState.passes[0].id;
+            hydrateShaderPassEditor(getActiveShaderPass());
+            renderShaderPassList();
+            updateEntryPassOptions();
+        }
+
+        function ensurePreviewContext() {
+            if (!shaderPreviewCanvas) {
+                return null;
+            }
+            if (shaderPreviewState.gl) {
+                return shaderPreviewState;
+            }
+            const gl = shaderPreviewCanvas.getContext('webgl', { preserveDrawingBuffer: true, antialias: true });
+            if (!gl) {
+                setShaderPackageStatus('WebGL preview is not supported in this browser.', 'error');
+                return null;
+            }
+            const buffer = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+            gl.bufferData(
+                gl.ARRAY_BUFFER,
+                new Float32Array([
+                    -1, -1,
+                    1, -1,
+                    -1, 1,
+                    -1, 1,
+                    1, -1,
+                    1, 1
+                ]),
+                gl.STATIC_DRAW
+            );
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            shaderPreviewState.gl = gl;
+            shaderPreviewState.buffer = buffer;
+            return shaderPreviewState;
+        }
+
+        function resizeShaderPreview() {
+            if (!shaderPreviewCanvas || !shaderPreviewState.gl) {
+                return;
+            }
+            const dpr = window.devicePixelRatio || 1;
+            const width = Math.max(1, Math.floor(shaderPreviewCanvas.clientWidth * dpr));
+            const height = Math.max(1, Math.floor(shaderPreviewCanvas.clientHeight * dpr));
+            if (shaderPreviewCanvas.width !== width || shaderPreviewCanvas.height !== height) {
+                shaderPreviewCanvas.width = width;
+                shaderPreviewCanvas.height = height;
+                shaderPreviewState.gl.viewport(0, 0, width, height);
+            }
+        }
+
+        function disposePreviewProgram() {
+            const { gl, program, vertexShader, fragmentShader } = shaderPreviewState;
+            if (!gl) {
+                return;
+            }
+            if (program) {
+                gl.useProgram(null);
+                gl.deleteProgram(program);
+            }
+            if (vertexShader) {
+                gl.deleteShader(vertexShader);
+            }
+            if (fragmentShader) {
+                gl.deleteShader(fragmentShader);
+            }
+            shaderPreviewState.program = null;
+            shaderPreviewState.vertexShader = null;
+            shaderPreviewState.fragmentShader = null;
+            shaderPreviewState.positionLocation = -1;
+            shaderPreviewState.uniformLocations = {};
+        }
+
+        function cancelShaderPreviewLoop() {
+            if (shaderPreviewState.frameId !== null) {
+                window.cancelAnimationFrame(shaderPreviewState.frameId);
+                shaderPreviewState.frameId = null;
+            }
+        }
+
+        function compileShader(gl, type, source) {
+            const shader = gl.createShader(type);
+            gl.shaderSource(shader, source);
+            gl.compileShader(shader);
+            if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+                const info = gl.getShaderInfoLog(shader) || 'Unknown error';
+                gl.deleteShader(shader);
+                throw new Error(info.trim());
+            }
+            return shader;
+        }
+
+        function linkProgram(gl, vertexShader, fragmentShader) {
+            const program = gl.createProgram();
+            gl.attachShader(program, vertexShader);
+            gl.attachShader(program, fragmentShader);
+            gl.linkProgram(program);
+            if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+                const info = gl.getProgramInfoLog(program) || 'Unknown error';
+                gl.deleteProgram(program);
+                throw new Error(info.trim());
+            }
+            return program;
+        }
+
+        function startShaderPreviewLoop() {
+            cancelShaderPreviewLoop();
+            shaderPreviewState.startTime = performance.now();
+            shaderPreviewState.frameId = window.requestAnimationFrame(renderShaderPreview);
+        }
+
+        function renderShaderPreview(timestamp) {
+            shaderPreviewState.frameId = window.requestAnimationFrame(renderShaderPreview);
+            const { gl, program, buffer, positionLocation, uniformLocations } = shaderPreviewState;
+            if (!gl || !program || !buffer) {
+                return;
+            }
+            resizeShaderPreview();
+            gl.clearColor(0, 0, 0, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+            gl.useProgram(program);
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+            if (positionLocation >= 0) {
+                gl.enableVertexAttribArray(positionLocation);
+                gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+            }
+            const elapsed = (timestamp - (shaderPreviewState.startTime || timestamp)) / 1000;
+            if (uniformLocations.uTime) {
+                gl.uniform1f(uniformLocations.uTime, elapsed);
+            }
+            if (uniformLocations.uResolution) {
+                gl.uniform2f(uniformLocations.uResolution, shaderPreviewCanvas.width, shaderPreviewCanvas.height);
+            }
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+        }
+
+        function applyShaderPreview(pass) {
+            const state = ensurePreviewContext();
+            if (!state?.gl) {
+                throw new Error('WebGL preview unavailable.');
+            }
+            const { gl } = state;
+            disposePreviewProgram();
+            const vertexShader = compileShader(gl, gl.VERTEX_SHADER, pass.vertexSource);
+            const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, pass.fragmentSource);
+            const program = linkProgram(gl, vertexShader, fragmentShader);
+            state.program = program;
+            state.vertexShader = vertexShader;
+            state.fragmentShader = fragmentShader;
+            state.positionLocation = gl.getAttribLocation(program, 'position');
+            const uniforms = Array.isArray(pass.uniforms) ? pass.uniforms : [];
+            const tracked = new Set(uniforms.map(uniform => uniform.name).filter(Boolean));
+            tracked.add('uTime');
+            tracked.add('uResolution');
+            state.uniformLocations = {};
+            tracked.forEach(name => {
+                const location = gl.getUniformLocation(program, name);
+                if (location !== null) {
+                    state.uniformLocations[name] = location;
+                }
+            });
+            startShaderPreviewLoop();
+        }
+
+        function compileActiveShaderPass() {
+            persistActiveShaderPass();
+            const pass = getActiveShaderPass();
+            if (!pass) {
+                setShaderPackageStatus('No shader pass selected.', 'error');
+                return { success: false };
+            }
+            if (pass.type === 'compute') {
+                cancelShaderPreviewLoop();
+                disposePreviewProgram();
+                setShaderPackageStatus('Compute passes cannot be previewed in WebGL but will be included in the export.', 'info');
+                return { success: true, skipped: true };
+            }
+            try {
+                applyShaderPreview(pass);
+                setShaderPackageStatus(`Shader pass “${pass.label}” compiled successfully.`, 'success');
+                return { success: true };
+            } catch (error) {
+                cancelShaderPreviewLoop();
+                disposePreviewProgram();
+                setShaderPackageStatus(`Shader validation failed: ${error.message}`, 'error');
+                return { success: false, error };
+            }
+        }
+
+        function exportShaderPackage() {
+            persistActiveShaderPass();
+            const payload = {
+                package: cloneShaderPackage(shaderPackageState),
+                shaderConfig: cloneShaderConfig(currentShaderConfig),
+                generatedAt: new Date().toISOString()
+            };
+            const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            const fileName = `${shaderPackageState.name || 'vib3-shader'}-${Date.now()}.json`;
+            link.download = fileName.replace(/\s+/g, '-');
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            setShaderPackageStatus(`Exported shader package to ${link.download}.`, 'success');
+        }
+
+        function applyShaderPackage(nextPackage) {
+            shaderPackageState = sanitizeShaderPackage(nextPackage);
+            refreshShaderPackageUI();
+        }
+
+        function loadProductionPreset() {
+            applyShaderPackage(createProductionPresetPackage());
+            setShaderPackageStatus('Loaded production shader baseline.', 'success');
+        }
+
+        refreshShaderPackageUI();
+
+        shaderPassList?.addEventListener('click', event => {
+            const target = event.target.closest('button[data-pass-id]');
+            if (!target) {
+                return;
+            }
+            selectShaderPass(target.dataset.passId);
+        });
+
+        shaderAddPassBtn?.addEventListener('click', () => {
+            persistActiveShaderPass();
+            const newPass = createBaselineShaderPass(`Pass ${shaderPackageState.passes.length + 1}`);
+            shaderPackageState.passes.push(newPass);
+            shaderPackageState.activePassId = newPass.id;
+            if (!shaderPackageState.entryPassId) {
+                shaderPackageState.entryPassId = newPass.id;
+            }
+            refreshShaderPackageUI();
+            setShaderPackageStatus(`Added shader pass “${newPass.label}”.`, 'success');
+        });
+
+        shaderRemovePassBtn?.addEventListener('click', () => {
+            if (shaderPackageState.passes.length <= 1) {
+                setShaderPackageStatus('At least one shader pass is required.', 'error');
+                return;
+            }
+            const active = getActiveShaderPass();
+            shaderPackageState.passes = shaderPackageState.passes.filter(pass => pass.id !== active.id);
+            if (shaderPackageState.entryPassId === active.id) {
+                shaderPackageState.entryPassId = shaderPackageState.passes[0].id;
+            }
+            shaderPackageState.activePassId = shaderPackageState.passes[0].id;
+            refreshShaderPackageUI();
+            setShaderPackageStatus(`Removed shader pass “${active.label}”.`, 'info');
+        });
+
+        shaderEntryPassSelect?.addEventListener('change', event => {
+            const selected = event.target.value;
+            if (shaderPackageState.passes.some(pass => pass.id === selected)) {
+                shaderPackageState.entryPassId = selected;
+                setShaderPackageStatus(`Entry pass set to “${event.target.options[event.target.selectedIndex].textContent}”.`, 'success');
+            }
+        });
+
+        shaderPassLabelInput?.addEventListener('input', () => {
+            persistActiveShaderPass();
+        });
+
+        shaderPassTypeSelect?.addEventListener('change', () => {
+            persistActiveShaderPass();
+        });
+
+        shaderVertexSourceInput?.addEventListener('input', () => {
+            persistActiveShaderPass();
+        });
+
+        shaderFragmentSourceInput?.addEventListener('input', () => {
+            persistActiveShaderPass();
+        });
+
+        shaderPackageNameInput?.addEventListener('input', event => {
+            if (isSyncingShaderPackage) return;
+            shaderPackageState.name = event.target.value.trim() || 'vib3-production-shader';
+        });
+
+        shaderPackageVersionInput?.addEventListener('input', event => {
+            if (isSyncingShaderPackage) return;
+            shaderPackageState.version = event.target.value.trim() || '1.0.0';
+        });
+
+        shaderPackageDescriptionInput?.addEventListener('input', event => {
+            if (isSyncingShaderPackage) return;
+            shaderPackageState.description = event.target.value;
+        });
+
+        shaderCompileBtn?.addEventListener('click', () => {
+            compileActiveShaderPass();
+        });
+
+        shaderPackageExportBtn?.addEventListener('click', () => {
+            exportShaderPackage();
+        });
+
+        shaderPackageImportInput?.addEventListener('change', event => {
+            const file = event.target.files?.[0];
+            if (!file) {
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    const parsed = JSON.parse(reader.result);
+                    const nextPackage = parsed?.package ?? parsed;
+                    applyShaderPackage(nextPackage);
+                    if (parsed?.shaderConfig) {
+                        applyShaderConfig(parsed.shaderConfig, { message: `Imported shader configuration from ${file.name}.` });
+                    }
+                    setShaderPackageStatus(`Imported shader package from ${file.name}.`, 'success');
+                } catch (error) {
+                    setShaderPackageStatus(`Failed to import package: ${error.message}`, 'error');
+                }
+            };
+            reader.readAsText(file);
+            event.target.value = '';
+        });
+
+        shaderPackagePresetBtn?.addEventListener('click', () => {
+            loadProductionPreset();
+        });
+
+        if (shaderPreviewCanvas) {
+            resizeShaderPreview();
+            window.addEventListener('resize', resizeShaderPreview);
+        }
+
+        window.vib3ShaderPackage = {
+            getPackage: () => cloneShaderPackage(shaderPackageState),
+            setPackage: (next) => applyShaderPackage(next),
+            compileActivePass: () => compileActiveShaderPass(),
+            exportPackage: () => exportShaderPackage()
+        };
+
+        function applyShaderConfig(config, { merge = false, message } = {}) {
+            if (!vib3Visualizer?.setShaderConfig) {
+                return;
+            }
+            if (merge) {
+                currentShaderConfig = vib3Visualizer.setShaderConfig(config, { merge: true });
+            } else {
+                currentShaderConfig = vib3Visualizer.setShaderConfig(config);
+            }
+            refreshShaderConfigUI();
+            if (message) {
+                updateShaderStatus(message, 'success');
+            }
+        }
+
+        function handleShaderRangeUpdate(input, formatter, update) {
+            if (!input) return;
+            input.addEventListener('input', () => {
+                const nextValue = update();
+                applyShaderConfig(currentShaderConfig, { message: 'Live shader preview updated.' });
+                if (typeof formatter === 'function') {
+                    formatter(nextValue);
+                }
+            });
+        }
+
+        handleShaderRangeUpdate(shaderBackgroundHueInput, (value) => {
+            if (shaderBackgroundHueValue) {
+                shaderBackgroundHueValue.textContent = `${Math.round(value)}°`;
+            }
+        }, () => {
+            currentShaderConfig.background.baseHue = shaderBackgroundHueInput.valueAsNumber;
+            return currentShaderConfig.background.baseHue;
+        });
+
+        handleShaderRangeUpdate(shaderHueSwingInput, (value) => {
+            if (shaderHueSwingValue) {
+                shaderHueSwingValue.textContent = `${Math.round(value)}°`;
+            }
+        }, () => {
+            currentShaderConfig.background.hueSwing = shaderHueSwingInput.valueAsNumber;
+            return currentShaderConfig.background.hueSwing;
+        });
+
+        if (shaderArcCountInput) {
+            shaderArcCountInput.addEventListener('change', () => {
+                const numeric = Number(shaderArcCountInput.value);
+                const next = Number.isFinite(numeric) ? Math.min(12, Math.max(1, Math.round(numeric))) : 6;
+                currentShaderConfig.arcs.loopCount = next;
+                applyShaderConfig(currentShaderConfig, { message: 'Arc layers updated.' });
+            });
+        }
+
+        handleShaderRangeUpdate(shaderArcSpeedInput, (value) => {
+            if (shaderArcSpeedValue) {
+                shaderArcSpeedValue.textContent = `${(value / 100).toFixed(2)}×`;
+            }
+        }, () => {
+            currentShaderConfig.arcs.speed = shaderArcSpeedInput.valueAsNumber / 100;
+            return currentShaderConfig.arcs.speed;
+        });
+
+        handleShaderRangeUpdate(shaderHighlightIntensityInput, (value) => {
+            if (shaderHighlightIntensityValue) {
+                shaderHighlightIntensityValue.textContent = `${Math.round(value)}%`;
+            }
+        }, () => {
+            currentShaderConfig.highlight.intensity = shaderHighlightIntensityInput.valueAsNumber / 100;
+            return currentShaderConfig.highlight.intensity;
+        });
+
+        handleShaderRangeUpdate(shaderAccentParticlesInput, (value) => {
+            if (shaderAccentParticlesValue) {
+                shaderAccentParticlesValue.textContent = `${Math.round(value)}`;
+            }
+        }, () => {
+            currentShaderConfig.accent.particleCount = shaderAccentParticlesInput.valueAsNumber;
+            currentShaderConfig.anchored.accentParticleCount = Math.max(
+                currentShaderConfig.anchored.accentParticleCount,
+                shaderAccentParticlesInput.valueAsNumber / 2
+            );
+            return currentShaderConfig.accent.particleCount;
+        });
+
+        shaderApplyBtn?.addEventListener('click', () => {
+            if (!shaderConfigText) {
+                return;
+            }
+            try {
+                const parsed = JSON.parse(shaderConfigText.value);
+                applyShaderConfig(parsed, { message: 'Shader configuration applied.' });
+            } catch (error) {
+                updateShaderStatus(`Invalid shader JSON: ${error.message}`, 'error');
+            }
+        });
+
+        shaderExportBtn?.addEventListener('click', () => {
+            const blob = new Blob([JSON.stringify(currentShaderConfig, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `vib3-shader-config-${Date.now()}.json`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            updateShaderStatus('Shader configuration downloaded.', 'success');
+        });
+
+        shaderImportInput?.addEventListener('change', (event) => {
+            const file = event.target.files?.[0];
+            if (!file) {
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    const parsed = JSON.parse(reader.result);
+                    applyShaderConfig(parsed, { message: `Loaded shader from ${file.name}.` });
+                } catch (error) {
+                    updateShaderStatus(`Failed to import shader: ${error.message}`, 'error');
+                }
+            };
+            reader.readAsText(file);
+            event.target.value = '';
+        });
+
+        shaderResetBtn?.addEventListener('click', () => {
+            currentShaderConfig = cloneShaderConfig(shaderDefaults);
+            applyShaderConfig(currentShaderConfig, { message: 'Shader configuration reset to defaults.' });
+        });
+
+        refreshShaderConfigUI();
+
+        const layoutGridState = {
+            mode: 'generated',
+            columns: clampCount(gridColumnInput?.value ?? 3),
+            rows: clampCount(gridRowInput?.value ?? 2),
+            gutter: clampRange(Number(gridGutterInput?.value ?? 8) / 100, 0.02, 0.18, 0.08),
+            cardWidthRatio: clampRange(Number(gridCardWidthInput?.value ?? 88) / 100, 0.4, 1, 0.88),
+            cardHeightRatio: clampRange(Number(gridCardHeightInput?.value ?? 72) / 100, 0.4, 1.2, 0.72),
+            cards: []
+        };
+
+        function resolveSpacing(count, requested) {
+            if (count <= 0) {
+                return { spacing: 0, available: 1 };
+            }
+            const absoluteMax = 0.35 / Math.max(count, 1);
+            let spacing = Math.min(Math.max(requested, 0), absoluteMax);
+            let available = 1 - spacing * (count + 1);
+            if (available <= 0.05) {
+                spacing = Math.max(0.005, (1 - 0.05) / (count + 1));
+                available = Math.max(0.05, 1 - spacing * (count + 1));
+            }
+            return { spacing, available };
+        }
+
+        function generateCardsFromState(state = layoutGridState) {
+            const columns = clampCount(state.columns);
+            const rows = clampCount(state.rows);
+            const horizontal = resolveSpacing(columns, state.gutter);
+            const vertical = resolveSpacing(rows, state.gutter);
+            const widthRatio = clampRange(state.cardWidthRatio, 0.4, 1, 0.88);
+            const heightRatio = clampRange(state.cardHeightRatio, 0.4, 1.2, 0.72);
+            const cellWidth = columns > 0 ? horizontal.available / columns : 1;
+            const cellHeight = rows > 0 ? vertical.available / rows : 1;
+            const cardWidth = cellWidth * widthRatio;
+            const cardHeight = cellHeight * heightRatio;
+            const offsetX = (cellWidth - cardWidth) / 2;
+            const offsetY = (cellHeight - cardHeight) / 2;
+            const cards = [];
+            for (let row = 0; row < rows; row += 1) {
+                for (let column = 0; column < columns; column += 1) {
+                    const x = horizontal.spacing + column * (cellWidth + horizontal.spacing) + offsetX;
+                    const y = vertical.spacing + row * (cellHeight + vertical.spacing) + offsetY;
+                    cards.push({
+                        x: clampNormalized(x, 0, 1),
+                        y: clampNormalized(y, 0, 1),
+                        width: clampNormalized(cardWidth, 0, 1),
+                        height: clampNormalized(cardHeight, 0, 1)
+                    });
+                }
+            }
+            return cards;
+        }
+
+        function updateGridRangeLabels() {
+            if (gridGutterValue) {
+                gridGutterValue.textContent = `${Math.round(layoutGridState.gutter * 100)}%`;
+            }
+            if (gridCardWidthValue) {
+                gridCardWidthValue.textContent = `${Math.round(layoutGridState.cardWidthRatio * 100)}%`;
+            }
+            if (gridCardHeightValue) {
+                gridCardHeightValue.textContent = `${Math.round(layoutGridState.cardHeightRatio * 100)}%`;
+            }
+        }
+
+        function inferDimensionFromCards(cards, axis) {
+            if (!Array.isArray(cards) || cards.length === 0) {
+                return 0;
+            }
+            const tolerance = 0.05;
+            const centers = cards
+                .map(card => {
+                    const dimension = axis === 'x' ? card.width : card.height;
+                    const position = axis === 'x' ? card.x : card.y;
+                    return clampNormalized(position + dimension / 2, 0, 1);
+                })
+                .sort((a, b) => a - b);
+            const buckets = [];
+            centers.forEach(center => {
+                if (!buckets.some(value => Math.abs(value - center) <= tolerance)) {
+                    buckets.push(center);
+                }
+            });
+            return buckets.length || cards.length;
+        }
+
+        function updateGridSummary(spec, { mode, message } = {}) {
+            if (!gridSummary) {
+                if (gridStatus && message) {
+                    gridStatus.textContent = message;
+                }
+                return;
+            }
+
+            if (!spec || !Array.isArray(spec.cards) || spec.cards.length === 0) {
+                gridSummary.textContent = 'No alignment grid active';
+                if (gridStatus && message) {
+                    gridStatus.textContent = message;
+                }
+                return;
+            }
+
+            const origin = mode === 'custom' || spec.mode === 'custom' ? 'Imported grid' : 'Generated grid';
+            const parts = [];
+            if (Number.isFinite(spec.columns) && spec.columns > 0) {
+                parts.push(`${spec.columns} column${spec.columns === 1 ? '' : 's'}`);
+            }
+            if (Number.isFinite(spec.rows) && spec.rows > 0) {
+                parts.push(`${spec.rows} row${spec.rows === 1 ? '' : 's'}`);
+            }
+            parts.push(`${spec.cards.length} card${spec.cards.length === 1 ? '' : 's'}`);
+            gridSummary.textContent = `${origin} · ${parts.join(' · ')}`;
+            if (gridStatus && message) {
+                gridStatus.textContent = message;
+            }
+        }
+
+        function applyGridSpec(spec, options = {}) {
+            if (!vib3Visualizer?.setGridSpec) {
+                latestGridSpec = spec;
+                renderGridOverlay(spec);
+                updateGridSummary(spec, options);
+                return spec;
+            }
+            latestGridSpec = vib3Visualizer.setGridSpec(spec) || spec;
+            renderGridOverlay(latestGridSpec);
+            updateGridSummary(latestGridSpec, options);
+            return latestGridSpec;
+        }
+
+        function rebuildGeneratedGrid(message) {
+            layoutGridState.mode = 'generated';
+            layoutGridState.columns = clampCount(layoutGridState.columns);
+            layoutGridState.rows = clampCount(layoutGridState.rows);
+            layoutGridState.cards = generateCardsFromState(layoutGridState);
+            const spec = {
+                mode: 'generated',
+                label: 'Generated grid',
+                columns: layoutGridState.columns,
+                rows: layoutGridState.rows,
+                cards: layoutGridState.cards
+            };
+            applyGridSpec(spec, {
+                mode: 'generated',
+                message: message || `Generated ${layoutGridState.columns}×${layoutGridState.rows} grid (${spec.cards.length} cards)`
+            });
+        }
+
+        function normalizeImportedSpec(raw) {
+            let source;
+            try {
+                source = typeof raw === 'string' ? JSON.parse(raw) : raw;
+            } catch (error) {
+                throw new Error('Invalid grid JSON.');
+            }
+
+            if (!source || typeof source !== 'object') {
+                throw new Error('Grid specification is empty.');
+            }
+
+            const cardSource = Array.isArray(source.cards)
+                ? source.cards
+                : Array.isArray(source.grid?.cards)
+                    ? source.grid.cards
+                    : Array.isArray(source.items)
+                        ? source.items
+                        : Array.isArray(source.frames)
+                            ? source.frames
+                            : [];
+
+            if (!cardSource.length) {
+                throw new Error('No cards found in grid file.');
+            }
+
+            const processed = cardSource
+                .map((card) => {
+                    const x = toNumeric(card.x ?? card.left ?? card.frame?.x ?? card.origin?.x, 0);
+                    const y = toNumeric(card.y ?? card.top ?? card.frame?.y ?? card.origin?.y, 0);
+                    let width = toNumeric(card.width ?? card.frame?.width ?? card.size?.width ?? card.w, 0);
+                    let height = toNumeric(card.height ?? card.frame?.height ?? card.size?.height ?? card.h, 0);
+                    if (!width && Number.isFinite(card.right)) {
+                        width = toNumeric(card.right, 0) - x;
+                    }
+                    if (!height && Number.isFinite(card.bottom)) {
+                        height = toNumeric(card.bottom, 0) - y;
+                    }
+                    return { x, y, width, height };
+                })
+                .filter(card => card.width > 0 && card.height > 0);
+
+            if (!processed.length) {
+                throw new Error('All cards in the grid file have zero size.');
+            }
+
+            let scaleX = toNumeric(source.viewportWidth ?? source.viewport?.width ?? source.frame?.width ?? source.size?.width ?? source.width, 0);
+            let scaleY = toNumeric(source.viewportHeight ?? source.viewport?.height ?? source.frame?.height ?? source.size?.height ?? source.height, 0);
+            const maxRight = Math.max(...processed.map(card => card.x + card.width));
+            const maxBottom = Math.max(...processed.map(card => card.y + card.height));
+
+            if (!scaleX) {
+                scaleX = maxRight || 1;
+            }
+            if (!scaleY) {
+                scaleY = maxBottom || 1;
+            }
+
+            if (maxRight <= 1.01 && maxBottom <= 1.01) {
+                scaleX = 1;
+                scaleY = 1;
+            } else if (maxRight <= 100.01 && maxBottom <= 100.01 && scaleX > 1 && scaleY > 1) {
+                scaleX = 100;
+                scaleY = 100;
+            }
+
+            const normalizedCards = processed
+                .map(card => ({
+                    x: clampNormalized(scaleX ? card.x / scaleX : 0, 0, 1),
+                    y: clampNormalized(scaleY ? card.y / scaleY : 0, 0, 1),
+                    width: clampNormalized(scaleX ? card.width / scaleX : 0, 0, 1),
+                    height: clampNormalized(scaleY ? card.height / scaleY : 0, 0, 1)
+                }))
+                .filter(card => card.width > 0 && card.height > 0);
+
+            if (!normalizedCards.length) {
+                throw new Error('Grid could not be normalized.');
+            }
+
+            const columns = toNumeric(source.columns ?? source.columnCount, 0) || inferDimensionFromCards(normalizedCards, 'x');
+            const rows = toNumeric(source.rows ?? source.rowCount, 0) || inferDimensionFromCards(normalizedCards, 'y');
+            const gutterValue = source.gutter ?? source.spacing ?? null;
+            let normalizedGutter;
+            if (typeof gutterValue === 'number') {
+                normalizedGutter = gutterValue > 1
+                    ? clampNormalized(gutterValue / (scaleX || 1000), 0, 0.35)
+                    : clampNormalized(gutterValue, 0, 0.35);
+            }
+
+            const label = source.name || source.title || source.label || 'Imported grid';
+
+            return {
+                mode: 'custom',
+                label,
+                columns: columns ? Math.min(12, Math.max(1, Math.round(columns))) : undefined,
+                rows: rows ? Math.min(12, Math.max(1, Math.round(rows))) : undefined,
+                gutter: typeof normalizedGutter === 'number' ? normalizedGutter : undefined,
+                cards: normalizedCards
+            };
+        }
+
+        function applyImportedGrid(raw, { source } = {}) {
+            try {
+                const normalized = normalizeImportedSpec(raw);
+                layoutGridState.mode = 'custom';
+                layoutGridState.cards = normalized.cards;
+
+                if (Number.isFinite(normalized.columns)) {
+                    layoutGridState.columns = clampCount(normalized.columns);
+                    if (gridColumnInput) {
+                        gridColumnInput.value = layoutGridState.columns;
+                    }
+                }
+
+                if (Number.isFinite(normalized.rows)) {
+                    layoutGridState.rows = clampCount(normalized.rows);
+                    if (gridRowInput) {
+                        gridRowInput.value = layoutGridState.rows;
+                    }
+                }
+
+                if (typeof normalized.gutter === 'number') {
+                    layoutGridState.gutter = clampRange(normalized.gutter, 0.02, 0.18, layoutGridState.gutter);
+                    if (gridGutterInput) {
+                        gridGutterInput.value = Math.round(layoutGridState.gutter * 100);
+                    }
+                }
+
+                const spec = {
+                    mode: 'custom',
+                    label: normalized.label,
+                    columns: normalized.columns ?? layoutGridState.columns,
+                    rows: normalized.rows ?? layoutGridState.rows,
+                    cards: normalized.cards
+                };
+
+                applyGridSpec(spec, {
+                    mode: 'custom',
+                    message: source ? `Loaded ${source} (${normalized.cards.length} cards)` : `${normalized.label} ready (${normalized.cards.length} cards)`
+                });
+
+                updateGridRangeLabels();
+            } catch (error) {
+                if (gridStatus) {
+                    gridStatus.textContent = error?.message || 'Unable to import grid.';
+                }
+            }
+        }
+
+        const sampleGridSpec = {
+            mode: 'custom',
+            label: 'Wearable story grid',
+            columns: 3,
+            rows: 2,
+            cards: [
+                { x: 0.08, y: 0.08, width: 0.24, height: 0.2 },
+                { x: 0.38, y: 0.08, width: 0.24, height: 0.2 },
+                { x: 0.68, y: 0.08, width: 0.24, height: 0.2 },
+                { x: 0.08, y: 0.44, width: 0.24, height: 0.2 },
+                { x: 0.38, y: 0.44, width: 0.24, height: 0.2 },
+                { x: 0.68, y: 0.44, width: 0.24, height: 0.2 }
+            ]
+        };
+
+        gridColumnInput?.addEventListener('input', event => {
+            layoutGridState.columns = clampCount(event.target.value);
+            event.target.value = layoutGridState.columns;
+            layoutGridState.mode = 'generated';
+            rebuildGeneratedGrid();
+        });
+
+        gridRowInput?.addEventListener('input', event => {
+            layoutGridState.rows = clampCount(event.target.value);
+            event.target.value = layoutGridState.rows;
+            layoutGridState.mode = 'generated';
+            rebuildGeneratedGrid();
+        });
+
+        gridGutterInput?.addEventListener('input', event => {
+            layoutGridState.gutter = clampRange(Number(event.target.value) / 100, 0.02, 0.18, layoutGridState.gutter);
+            layoutGridState.mode = 'generated';
+            updateGridRangeLabels();
+            rebuildGeneratedGrid();
+        });
+
+        gridCardWidthInput?.addEventListener('input', event => {
+            layoutGridState.cardWidthRatio = clampRange(Number(event.target.value) / 100, 0.4, 1, layoutGridState.cardWidthRatio);
+            layoutGridState.mode = 'generated';
+            updateGridRangeLabels();
+            rebuildGeneratedGrid();
+        });
+
+        gridCardHeightInput?.addEventListener('input', event => {
+            layoutGridState.cardHeightRatio = clampRange(Number(event.target.value) / 100, 0.4, 1.2, layoutGridState.cardHeightRatio);
+            layoutGridState.mode = 'generated';
+            updateGridRangeLabels();
+            rebuildGeneratedGrid();
+        });
+
+        gridImportButton?.addEventListener('click', () => {
+            gridImportInput?.click();
+        });
+
+        gridImportInput?.addEventListener('change', event => {
+            const files = Array.from(event.target.files || []);
+            const [file] = files;
+            if (!file) {
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = () => {
+                applyImportedGrid(reader.result, { source: file.name });
+            };
+            reader.onerror = () => {
+                if (gridStatus) {
+                    gridStatus.textContent = 'Failed to read grid file.';
+                }
+            };
+            reader.readAsText(file);
+            event.target.value = '';
+        });
+
+        gridClearButton?.addEventListener('click', () => {
+            layoutGridState.mode = 'generated';
+            if (gridStatus) {
+                gridStatus.textContent = 'Grid reset to generated layout.';
+            }
+            rebuildGeneratedGrid('Grid reset to generated layout.');
+        });
+
+        gridPresetButton?.addEventListener('click', () => {
+            applyImportedGrid(sampleGridSpec, { source: 'Sample grid' });
+        });
+
+        updateGridRangeLabels();
+        rebuildGeneratedGrid('Generated starter grid');
+        resizeGridOverlay(true);
+        if (typeof ResizeObserver !== 'undefined' && blueprintOverlayElement) {
+            gridOverlayResizeObserver = new ResizeObserver(() => resizeGridOverlay(true));
+            gridOverlayResizeObserver.observe(blueprintOverlayElement);
+        }
+
+        window.vib3Grid = {
+            get active() {
+                return latestGridSpec;
+            },
+            set(spec) {
+                applyImportedGrid(spec, { source: 'Console' });
+            },
+            reset() {
+                layoutGridState.mode = 'generated';
+                rebuildGeneratedGrid('Grid reset to generated layout.');
+            },
+            regenerate: rebuildGeneratedGrid,
+            state: layoutGridState
+        };
+
+        window.vib3Shader = {
+            get config() {
+                return cloneShaderConfig(currentShaderConfig);
+            },
+            set config(spec) {
+                applyShaderConfig(spec, { message: 'Shader configuration applied via console.' });
+                return cloneShaderConfig(currentShaderConfig);
+            },
+            merge(partial) {
+                applyShaderConfig(partial, { merge: true, message: 'Shader parameters merged via console.' });
+                return cloneShaderConfig(currentShaderConfig);
+            },
+            reset() {
+                currentShaderConfig = cloneShaderConfig(shaderDefaults);
+                applyShaderConfig(currentShaderConfig, { message: 'Shader configuration reset to defaults.' });
+            },
+            export() {
+                return cloneShaderConfig(currentShaderConfig);
+            }
+        };
         const projectionHaloRadius = document.getElementById('projectionHaloRadius');
         const projectionDepthBias = document.getElementById('projectionDepthBias');
         const projectionContourCount = document.getElementById('projectionContourCount');
@@ -694,14 +3531,29 @@
         const projectionScenarioSelect = document.getElementById('projectionScenarioSelect');
         const projectionSimulateBtn = document.getElementById('projectionSimulateBtn');
         const projectionLegend = document.getElementById('projectionLegend');
+        const variationSlider = document.getElementById('variationSlider');
+        const randomizeBtn = document.getElementById('randomizeBtn');
+        const variationLabel = document.getElementById('variationLabel');
+        const focusMetric = document.getElementById('focusMetric');
+        const engagementMetric = document.getElementById('engagementMetric');
+        const velocityMetric = document.getElementById('velocityMetric');
+        const stressMetric = document.getElementById('stressMetric');
+        const consentPanelContainer = document.getElementById('telemetryConsentPanel');
 
-        let adaptiveSDKRef;
+        let adaptiveSDKRef = null;
+        // Maintain a backward-compatible alias for legacy inline handlers or
+        // diagnostics snippets that still expect a global `adaptiveSDK`
+        // reference. Initializing it up front avoids temporal dead zone
+        // lookups before the SDK instance is created.
+        let adaptiveSDKGlobal = null;
         let stopSnapshotSchedule = null;
 
         const remoteUploadLog = [];
         let latestBlueprint = null;
         let latestProjectionComposition = null;
         let activeProjectionScenario = '__realtime__';
+
+        const getAdaptiveSDK = () => adaptiveSDKRef || adaptiveSDKGlobal || window.adaptiveSDK || null;
 
         const formatTime = (value) => {
             if (!value) return 'unknown';
@@ -814,35 +3666,30 @@
 
         const blueprintRenderer = createLayoutBlueprintRenderer({
             layers: {
-                background: document.getElementById('background-canvas'),
-                shadow: document.getElementById('shadow-canvas'),
-                content: document.getElementById('content-canvas'),
-                highlight: document.getElementById('highlight-canvas'),
-                accent: document.getElementById('accent-canvas')
-            }
+                background: document.getElementById('blueprint-background'),
+                shadow: document.getElementById('blueprint-shadow'),
+                content: document.getElementById('blueprint-content'),
+                highlight: document.getElementById('blueprint-highlight'),
+                accent: document.getElementById('blueprint-accent')
+            },
+            background: {
+                inner: 'rgba(64, 148, 255, 0.24)',
+                outer: 'rgba(10, 24, 48, 0.48)'
+            },
+            zoneColors: {
+                primary: 'rgba(76, 159, 255, 0.85)',
+                peripheral: 'rgba(178, 107, 255, 0.8)',
+                ambient: 'rgba(255, 196, 122, 0.75)'
+            },
+            backgroundBlendMode: 'screen',
+            backgroundOpacity: 0.72,
+            devicePadding: 0.1
         });
 
         blueprintRenderer.resize();
         window.addEventListener('resize', () => blueprintRenderer.resize());
 
         renderBlueprintPanel(null);
-
-        const projectionComposer = adaptiveSDKRef?.projectionComposer || adaptiveSDK.projectionComposer;
-        const projectionBaseCanvas = document.getElementById('projection-base');
-        const projectionBandCanvas = document.getElementById('projection-bands');
-        const projectionHaloCanvas = document.getElementById('projection-halo');
-        const projectionContourCanvas = document.getElementById('projection-contours');
-
-        projectionComposer.attachLayer('base', projectionBaseCanvas);
-        projectionComposer.attachLayer('bands', projectionBandCanvas);
-        projectionComposer.attachLayer('halo', projectionHaloCanvas);
-        projectionComposer.attachLayer('contours', projectionContourCanvas);
-        projectionComposer.observeResize?.();
-        projectionComposer.resize();
-        window.addEventListener('resize', () => projectionComposer.resize());
-
-        renderProjectionPanel(null);
-        initializeProjectionScenarios();
 
         const formatLabel = (value) => {
             if (!value) return 'Unspecified';
@@ -856,6 +3703,42 @@
         };
 
         const formatPercent = (value) => `${Math.round(clamp(value, 0, 1) * 100)}%`;
+
+        const applyBlueprintOverlayIntensity = (rawValue) => {
+            if (!blueprintRenderer) {
+                return;
+            }
+            const numeric = clamp(Number(rawValue), 0.1, 1);
+            const overlayOpacity = 0.25 + numeric * 0.75;
+            if (blueprintOverlayElement) {
+                blueprintOverlayElement.style.opacity = overlayOpacity.toFixed(2);
+            }
+
+            const layerOpacity = 0.35 + numeric * 0.6;
+            blueprintRenderer.setVisualOptions({
+                backgroundOpacity: overlayOpacity,
+                zoneOpacityFactor: layerOpacity,
+                highlightOpacityFactor: layerOpacity,
+                accentOpacityFactor: layerOpacity
+            });
+
+            if (blueprintOverlayOpacityValue) {
+                blueprintOverlayOpacityValue.textContent = `${Math.round(numeric * 100)}%`;
+            }
+        };
+
+        if (blueprintOverlayOpacitySlider) {
+            const initial = Number(blueprintOverlayOpacitySlider.value);
+            const normalized = Number.isFinite(initial) ? initial / 100 : 0.7;
+            applyBlueprintOverlayIntensity(normalized);
+            blueprintOverlayOpacitySlider.addEventListener('input', event => {
+                const raw = Number(event.target.value);
+                const next = Number.isFinite(raw) ? raw / 100 : 0.7;
+                applyBlueprintOverlayIntensity(next);
+            });
+        } else {
+            applyBlueprintOverlayIntensity(0.7);
+        }
 
         function renderBlueprintPanel(blueprint) {
             if (!blueprint) {
@@ -1063,8 +3946,13 @@
             realtimeOption.textContent = 'Realtime Field';
             projectionScenarioSelect.appendChild(realtimeOption);
 
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
+                return;
+            }
+
             for (const scenario of scenarios) {
-                adaptiveSDK.registerProjectionScenario(scenario);
+                sdk.registerProjectionScenario(scenario);
                 const option = document.createElement('option');
                 option.value = scenario.id;
                 option.textContent = scenario.name;
@@ -1078,23 +3966,27 @@
                 if (activeProjectionScenario === '__realtime__') {
                     return;
                 }
-                adaptiveSDK.setActiveProjectionScenario(activeProjectionScenario);
+                sdk.setActiveProjectionScenario(activeProjectionScenario);
             });
 
             projectionSimulateBtn?.addEventListener('click', () => {
+                const activeSdk = getAdaptiveSDK();
+                if (!activeSdk) {
+                    return;
+                }
                 if (!latestBlueprint) {
                     return;
                 }
                 if (activeProjectionScenario === '__realtime__') {
-                    const projectionContext = buildProjectionContextFromAdaptive(adaptiveSDK.engine?.sensoryBridge?.getSnapshot?.());
-                    const composition = adaptiveSDK.composeProjectionField(latestBlueprint, null, projectionContext);
-                    adaptiveSDK.projectionComposer.render(latestBlueprint, projectionContext);
+                    const projectionContext = buildProjectionContextFromAdaptive(activeSdk.engine?.sensoryBridge?.getSnapshot?.());
+                    const composition = activeSdk.composeProjectionField(latestBlueprint, null, projectionContext);
+                    activeSdk.projectionComposer.render(latestBlueprint, projectionContext);
                     renderProjectionPanel(composition, { mode: 'realtime' });
                     return;
                 }
-                const frame = adaptiveSDK.stepProjectionSimulation({});
+                const frame = activeSdk.stepProjectionSimulation({});
                 if (frame?.composition) {
-                    adaptiveSDK.projectionComposer.render(frame.blueprint, frame.context);
+                    activeSdk.projectionComposer.render(frame.blueprint, frame.context);
                     renderProjectionPanel(frame.composition, {
                         mode: 'scenario',
                         scenario: frame.name,
@@ -1154,7 +4046,7 @@
                 commercializationKpiSummary.innerHTML = '';
                 snapshotList.innerHTML = '';
                 commercializationUpdated.textContent = 'No commercialization activity yet';
-                if (adaptiveSDKRef) {
+                if (getAdaptiveSDK()) {
                     refreshCommercializationSnapshots();
                 }
                 return;
@@ -1224,7 +4116,7 @@
                 commercializationUpdated.textContent = 'No commercialization activity yet';
             }
 
-            if (adaptiveSDKRef) {
+            if (getAdaptiveSDK()) {
                 refreshCommercializationSnapshots();
             }
         }
@@ -1319,18 +4211,19 @@
         }
 
         function refreshCommercializationSnapshots() {
-            if (!adaptiveSDKRef) {
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
                 commercializationKpiSummary.innerHTML = '';
                 snapshotList.innerHTML = '';
                 return;
             }
-            const snapshots = adaptiveSDKRef.getLicenseCommercializationSnapshots({ limit: 5, withSummary: false });
+            const snapshots = sdk.getLicenseCommercializationSnapshots({ limit: 5, withSummary: false });
             renderSnapshotHistory(snapshots);
-            const kpiReport = adaptiveSDKRef.getLicenseCommercializationKpiReport();
+            const kpiReport = sdk.getLicenseCommercializationKpiReport();
             renderKpiSummary(kpiReport);
         }
 
-        const adaptiveSDK = (adaptiveSDKRef = createAdaptiveSDK({
+        const adaptiveSDKInstance = createAdaptiveSDK({
             telemetry: {
                 enabled: true,
                 defaultConsent: { analytics: false, biometric: false },
@@ -1351,7 +4244,11 @@
                 onPatternChange: updatePatternPanel,
                 onAdaptiveUpdate: handleAdaptiveUpdate
             }
-        }));
+        });
+
+        adaptiveSDKRef = adaptiveSDKInstance;
+        adaptiveSDKGlobal = adaptiveSDKInstance;
+        window.adaptiveSDK = adaptiveSDKInstance;
 
         const {
             engine,
@@ -1360,14 +4257,34 @@
             getTelemetryConsent,
             getTelemetryAuditTrail,
             getLicenseCommercializationSummary,
-            setLicenseAttestorFromProfile,
             registerLicenseAttestationProfilePack
-        } = adaptiveSDK;
+        } = adaptiveSDKInstance;
 
-        const telemetryHarness = adaptiveSDK.telemetry;
+        const setLicenseAttestorFromProfile = (...args) => adaptiveSDKInstance.setLicenseAttestorFromProfile(...args);
+
+        const projectionComposer = adaptiveSDKInstance.projectionComposer;
+        const projectionBaseCanvas = document.getElementById('projection-base');
+        const projectionBandCanvas = document.getElementById('projection-bands');
+        const projectionHaloCanvas = document.getElementById('projection-halo');
+        const projectionContourCanvas = document.getElementById('projection-contours');
+
+        projectionComposer.attachLayer('base', projectionBaseCanvas);
+        projectionComposer.attachLayer('bands', projectionBandCanvas);
+        projectionComposer.attachLayer('halo', projectionHaloCanvas);
+        projectionComposer.attachLayer('contours', projectionContourCanvas);
+        projectionComposer.observeResize?.();
+        projectionComposer.resize();
+        window.addEventListener('resize', () => projectionComposer.resize());
+
+        renderProjectionPanel(null);
+        initializeProjectionScenarios();
+
+        const telemetryHarness = adaptiveSDKInstance.telemetry;
 
         captureSnapshotBtn?.addEventListener('click', () => {
-            adaptiveSDKRef?.captureLicenseCommercializationSnapshot({
+            const sdk = getAdaptiveSDK();
+            if (!sdk) return;
+            sdk.captureLicenseCommercializationSnapshot({
                 trigger: 'demo-manual',
                 capturedBy: 'wearable-designer'
             });
@@ -1375,8 +4292,9 @@
         });
 
         exportSnapshotsBtn?.addEventListener('click', () => {
-            if (!adaptiveSDKRef) return;
-            const exportPayload = adaptiveSDKRef.exportLicenseCommercializationSnapshots({
+            const sdk = getAdaptiveSDK();
+            if (!sdk) return;
+            const exportPayload = sdk.exportLicenseCommercializationSnapshots({
                 format: 'json',
                 includeSummary: false
             });
@@ -1442,14 +4360,15 @@
         renderCommercializationSummary(getLicenseCommercializationSummary());
         refreshCommercializationSnapshots();
 
-        const snapshotStore = adaptiveSDKRef.getLicenseCommercializationSnapshotStore?.();
+        const snapshotStore = getAdaptiveSDK()?.getLicenseCommercializationSnapshotStore?.();
         snapshotStore?.whenReady?.().then(() => {
             refreshCommercializationSnapshots();
             renderRemoteStorageStatus();
         });
 
-        if (typeof adaptiveSDKRef?.startLicenseCommercializationSnapshotSchedule === 'function') {
-            stopSnapshotSchedule = adaptiveSDKRef.startLicenseCommercializationSnapshotSchedule(60000, {
+        const snapshotScheduler = getAdaptiveSDK();
+        if (typeof snapshotScheduler?.startLicenseCommercializationSnapshotSchedule === 'function') {
+            stopSnapshotSchedule = snapshotScheduler.startLicenseCommercializationSnapshotSchedule(60000, {
                 trigger: 'demo-schedule',
                 capturedBy: 'wearable-designer'
             }) || null;
@@ -1459,16 +4378,14 @@
             if (typeof stopSnapshotSchedule === 'function') {
                 stopSnapshotSchedule();
             }
+            adaptiveSDKRef = null;
+            adaptiveSDKGlobal = null;
+            if (window.adaptiveSDK) {
+                window.adaptiveSDK = null;
+            }
+            vib3Visualizer.stop?.();
+            gridOverlayResizeObserver?.disconnect?.();
         });
-
-        const variationSlider = document.getElementById('variationSlider');
-        const randomizeBtn = document.getElementById('randomizeBtn');
-        const variationLabel = document.getElementById('variationLabel');
-        const focusMetric = document.getElementById('focusMetric');
-        const engagementMetric = document.getElementById('engagementMetric');
-        const velocityMetric = document.getElementById('velocityMetric');
-        const stressMetric = document.getElementById('stressMetric');
-        const consentPanelContainer = document.getElementById('telemetryConsentPanel');
 
         consentPanel = createConsentPanel({
             container: consentPanelContainer,
@@ -1532,6 +4449,11 @@
         }
 
         function handleAdaptiveUpdate({ context, layout, design }) {
+            const sdk = getAdaptiveSDK();
+            if (!sdk) {
+                return;
+            }
+
             focusMetric.textContent = context.focusVector.x.toFixed(2);
             engagementMetric.textContent = context.engagementLevel.toFixed(2);
             velocityMetric.textContent = layout.motion.velocity.toFixed(2);
@@ -1542,9 +4464,9 @@
             renderBlueprintPanel(latestBlueprint);
 
             const projectionContext = buildProjectionContextFromAdaptive(context);
-            const projectionComposition = adaptiveSDK.composeProjectionField(layout, design, projectionContext);
+            const projectionComposition = sdk.composeProjectionField(layout, design, projectionContext);
             if (projectionComposition) {
-                adaptiveSDK.projectionComposer.render(projectionComposition.blueprint, projectionContext);
+                sdk.projectionComposer.render(projectionComposition.blueprint, projectionContext);
                 if (activeProjectionScenario === '__realtime__') {
                     renderProjectionPanel(projectionComposition, { mode: 'realtime' });
                 }


### PR DESCRIPTION
## Summary
- add a Shader Build Suite panel with metadata inputs, pass management, editable shader code, and a WebGL preview canvas for production-ready authoring
- implement shader package state management, WebGL compilation/preview helpers, export/import flows, and console APIs for scripted pipelines
- update the wearable designer overview to document the expanded build workflow and new tooling expectations

## Testing
- not run (browser-based manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68edd6df67e48329827f76c44fd22c17